### PR TITLE
Markdown にアラート記法を追加する

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -13,6 +13,7 @@ import rehypeSlug from "rehype-slug";
 import rehypeBudoux from "./src/lib/rehype-budoux";
 import rehypePagefind from "./src/lib/rehype-pagefind";
 import rehypeSlugWithCustomId from "./src/lib/rehype-slug-with-custom-id";
+import remarkBlockQuoteAlert from "./src/lib/remark-blockquote-alert";
 import remarkFootnoteTitle from "./src/lib/remark-footnote-title";
 import remarkLinkCard from "./src/lib/remark-link-card";
 
@@ -81,7 +82,7 @@ export default defineConfig({
   markdown: {
     syntaxHighlight: false,
     smartypants: false,
-    remarkPlugins: [remarkLinkCard, remarkFootnoteTitle],
+    remarkPlugins: [remarkLinkCard, remarkFootnoteTitle, remarkBlockQuoteAlert],
     remarkRehype: {
       footnoteLabel: " ",
       footnoteBackLabel: "戻る",

--- a/src/features/blog/components/content-wrapper.astro
+++ b/src/features/blog/components/content-wrapper.astro
@@ -6,6 +6,7 @@ import CheckBox from "#/features/blog/components/ui/blocks/checkbox.astro";
 import Heading2 from "#/features/blog/components/ui/blocks/heading-2.astro";
 import Heading3 from "#/features/blog/components/ui/blocks/heading-3.astro";
 import MermaidBlock from "#/features/blog/components/ui/blocks/mermaid-block.astro";
+import DivHandler from "#/features/blog/components/ui/div-handler.astro";
 
 interface Props {
   content: AstroComponentFactory;
@@ -21,5 +22,6 @@ const { content: Content } = Astro.props;
     h2: Heading2,
     h3: Heading3,
     input: CheckBox,
-    picture: MermaidBlock }}
+    picture: MermaidBlock,
+    div: DivHandler }}
 />

--- a/src/features/blog/components/ui/blocks/alert-block.astro
+++ b/src/features/blog/components/ui/blocks/alert-block.astro
@@ -39,9 +39,9 @@ const IconComponent = alertIcons[alertType];
 const styleClasses = alertStyles[alertType];
 ---
 
-<div class={cn("flex flex-col md:flex-row gap-1.5 items-start md:items-center rounded-md border px-4 py-4 md:py-3 [&>p]:m-0 [&>p]:text-sm [&>p]:leading-6", styleClasses)} {...rest}>
+<div class={cn("flex flex-col md:flex-row gap-3 items-start md:items-center rounded-md border px-4 py-4 md:py-3 [&>p]:m-0 [&>p]:text-sm [&>p]:leading-6 [&>p>a]:underline [&>p>a]:text-current [&>p>a]:leading-6", styleClasses)} {...rest}>
     <IconComponent
-            class="size-4 opacity-70"
+            class="size-4 opacity-70 shrink-0"
             aria-hidden="true"
     />
     <slot />

--- a/src/features/blog/components/ui/blocks/alert-block.astro
+++ b/src/features/blog/components/ui/blocks/alert-block.astro
@@ -1,0 +1,48 @@
+---
+import InfoIcon from "@lucide/astro/icons/info";
+import LightbulbIcon from "@lucide/astro/icons/lightbulb";
+import MessageSquareWarningIcon from "@lucide/astro/icons/message-square-warning";
+import OctagonAlertIcon from "@lucide/astro/icons/octagon-alert";
+import TriangleAlertIcon from "@lucide/astro/icons/triangle-alert";
+import type { AstroComponentFactory } from "astro/runtime/server/index.js";
+import type { HTMLAttributes } from "astro/types";
+import { cn } from "#/lib/ui";
+
+export type AlertType = "note" | "tip" | "important" | "warning" | "caution";
+
+interface Props extends HTMLAttributes<"div"> {
+  "data-alert-type": AlertType;
+}
+
+const { "data-alert-type": alertType, ...rest } = Astro.props;
+
+const alertIcons: Record<AlertType, AstroComponentFactory> = {
+  note: InfoIcon,
+  tip: LightbulbIcon,
+  important: MessageSquareWarningIcon,
+  warning: TriangleAlertIcon,
+  caution: OctagonAlertIcon,
+};
+
+const alertStyles: Record<AlertType, string> = {
+  note: "border-blue-500/50 text-blue-600 dark:border-blue-400/50 dark:text-blue-400",
+  tip: "border-emerald-500/50 text-emerald-600 dark:border-emerald-400/50 dark:text-emerald-500",
+  important:
+    "border-purple-500/50 text-purple-600 dark:border-purple-400/50 dark:text-purple-400",
+  warning:
+    "border-amber-500/50 text-amber-600 dark:border-amber-400/50 dark:text-amber-500",
+  caution:
+    "border-red-500/50 text-red-600 dark:border-red-400/50 dark:text-red-400",
+};
+
+const IconComponent = alertIcons[alertType];
+const styleClasses = alertStyles[alertType];
+---
+
+<div class={cn("flex flex-col md:flex-row gap-1.5 items-start md:items-center rounded-md border px-4 py-4 md:py-3 [&>p]:m-0! [&>p]:text-sm [&>p]:leading-6", styleClasses)} {...rest}>
+    <IconComponent
+            class="size-4 opacity-70"
+            aria-hidden="true"
+    />
+    <slot />
+</div>

--- a/src/features/blog/components/ui/blocks/alert-block.astro
+++ b/src/features/blog/components/ui/blocks/alert-block.astro
@@ -39,7 +39,7 @@ const IconComponent = alertIcons[alertType];
 const styleClasses = alertStyles[alertType];
 ---
 
-<div class={cn("flex flex-col md:flex-row gap-1.5 items-start md:items-center rounded-md border px-4 py-4 md:py-3 [&>p]:m-0! [&>p]:text-sm [&>p]:leading-6", styleClasses)} {...rest}>
+<div class={cn("flex flex-col md:flex-row gap-1.5 items-start md:items-center rounded-md border px-4 py-4 md:py-3 [&>p]:m-0 [&>p]:text-sm [&>p]:leading-6", styleClasses)} {...rest}>
     <IconComponent
             class="size-4 opacity-70"
             aria-hidden="true"

--- a/src/features/blog/components/ui/div-handler.astro
+++ b/src/features/blog/components/ui/div-handler.astro
@@ -1,0 +1,25 @@
+
+---
+import type { HTMLAttributes } from "astro/types";
+import type { AlertType } from "#/features/blog/components/ui/blocks/alert-block.astro";
+import AlertBlock from "#/features/blog/components/ui/blocks/alert-block.astro";
+
+interface Props extends HTMLAttributes<"div"> {
+  "data-alert-type"?: AlertType;
+}
+
+const props = Astro.props;
+const { "data-alert-type": alertType, ...rest } = props;
+---
+
+{
+    alertType ? (
+        <AlertBlock data-alert-type={alertType} {...rest} >
+            <slot />
+        </AlertBlock>
+    ) : (
+        <div {...props}>
+            <slot />
+        </div>
+    )
+}

--- a/src/features/blog/components/ui/div-handler.astro
+++ b/src/features/blog/components/ui/div-handler.astro
@@ -8,8 +8,7 @@ interface Props extends HTMLAttributes<"div"> {
   "data-alert-type"?: AlertType;
 }
 
-const props = Astro.props;
-const { "data-alert-type": alertType, ...rest } = props;
+const { "data-alert-type": alertType, ...rest } = Astro.props;
 ---
 
 {
@@ -18,7 +17,7 @@ const { "data-alert-type": alertType, ...rest } = props;
             <slot />
         </AlertBlock>
     ) : (
-        <div {...props}>
+        <div {...rest}>
             <slot />
         </div>
     )

--- a/src/lib/remark-blockquote-alert.ts
+++ b/src/lib/remark-blockquote-alert.ts
@@ -1,0 +1,57 @@
+import type { Paragraph, PhrasingContent, Root, Text } from "mdast";
+import { visit } from "unist-util-visit";
+
+const alertRegex = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)]/i;
+
+const processAlertParagraph = (
+  item: Paragraph,
+  text: string,
+): PhrasingContent[] => {
+  if (text.includes("\n")) {
+    item.children[0] = {
+      type: "text",
+      value: text.replace(alertRegex, "").replace(/^\n+/, ""),
+    } as Text;
+    return item.children;
+  }
+
+  return item.children
+    .slice(1)
+    .filter((child, idx) => !(idx === 0 && child.type === "break"));
+};
+
+const remarkBlockQuoteAlert = () => (tree: Root) => {
+  visit(tree, "blockquote", (node) => {
+    let alertType = "";
+    let processed = false;
+
+    node.children = node.children.map((item) => {
+      if (processed || item.type !== "paragraph") return item;
+
+      const paragraph = item as Paragraph;
+      const firstNode = paragraph.children[0];
+      if (!firstNode || firstNode.type !== "text") return item;
+
+      const textNode = firstNode as Text;
+      const match = textNode.value.match(alertRegex);
+      if (!match?.[1]) return item;
+
+      processed = true;
+      alertType = match[1].toLowerCase();
+      paragraph.children = processAlertParagraph(paragraph, textNode.value);
+
+      return paragraph;
+    });
+
+    if (alertType) {
+      node.data = {
+        hName: "div",
+        hProperties: {
+          dataAlertType: alertType,
+        },
+      };
+    }
+  });
+};
+
+export default remarkBlockQuoteAlert;


### PR DESCRIPTION
This pull request introduces functionality for handling alert blocks in markdown and Astro components. The changes include adding a new remark plugin for processing blockquote alerts, implementing corresponding Astro components, and integrating the new functionality into the configuration and codebase.

### Markdown Alert Handling

* [`src/lib/remark-blockquote-alert.ts`](diffhunk://#diff-689bbcc8f6c094efe9ef309bc00d791282ba53f50be84bdd80bdfa60fde2628aR1-R57): Added a new remark plugin `remarkBlockQuoteAlert` that processes blockquote elements in markdown to identify alert types (e.g., "note", "tip", "important") and transform them into custom HTML elements with appropriate attributes.
* [`astro.config.ts`](diffhunk://#diff-baf06eda15601b59413c77e1f18884403033204061e6c9408cd9a3bb5bc6e586L84-R85): Integrated the `remarkBlockQuoteAlert` plugin into the `remarkPlugins` array in the markdown configuration.

### Astro Component Enhancements

* [`src/features/blog/components/ui/blocks/alert-block.astro`](diffhunk://#diff-adbe24f116cebd1760756c4128c6ceff6ef88b7210626521e660f9220a4e7452R1-R48): Implemented the `AlertBlock` component, which dynamically renders alert blocks with icons and styles based on the alert type.
* [`src/features/blog/components/ui/div-handler.astro`](diffhunk://#diff-e408ca13b3baa2f9eadb1618fb4016d10a1c91bc7ab33b777c56c6fbd2f77373R1-R24): Added the `DivHandler` component, which conditionally renders `AlertBlock` components or standard `div` elements based on the presence of the `data-alert-type` attribute.

### Codebase Integration

* [`src/features/blog/components/content-wrapper.astro`](diffhunk://#diff-d82d2d84ec5584621cfe02b5f1b2058ecfeb2c88252966c168f12fce311ea4b9L24-R26): Updated the `content-wrapper` component to support rendering `DivHandler` for `div` elements.