### PR TITLE
RSS ボタンに識別可能な名前を指定する

### DIFF
--- a/src/features/blog/components/ui/category-navigation.astro
+++ b/src/features/blog/components/ui/category-navigation.astro
@@ -41,6 +41,7 @@ const linkClass =
     </div>
     <SpCategoryNavigation pathname={pathname} className="sm:hidden" client:media="(max-width: 40rem)" transition:persist="sp-category-navigation" />
     <a class={cn('rounded-full!', buttonVariants({ variant: "outline", size: "icon" }))} href="/rss.xml">
-        <RssIcon class="size-4" />
+        <RssIcon class="size-4" aria-hidden="true" />
+        <span class="sr-only">RSS フィード</span>
     </a>
 </nav>


### PR DESCRIPTION
This pull request includes a small accessibility improvement to the `category-navigation.astro` file. The change adds an `aria-hidden` attribute to the `RssIcon` and a visually hidden `<span>` element with descriptive text for screen readers.