### PR TITLE
記事作成スクリプトを追加する

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "check": "astro check && tsc --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "playwright-install": "pnpx playwright-core install chromium"
+    "playwright-install": "pnpx playwright-core install chromium",
+    "release": "bun run scripts/release.ts",
+    "create:entry": "bun run scripts/create-entry.ts"
   },
   "dependencies": {
     "@astrojs/check": "0.9.4",

--- a/scripts/create-entry.ts
+++ b/scripts/create-entry.ts
@@ -1,0 +1,169 @@
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type CategoryTitle,
+  categories,
+} from "#/features/blog/config/category";
+import { generateBech32m } from "#/lib/hash";
+
+interface Frontmatter {
+  title: string;
+  description: string;
+  emoji: string;
+  category: CategoryTitle;
+  tags: string;
+  status: "draft" | "published";
+  publishedAt: string;
+  slug: string;
+}
+
+const getTodayDate = () => {
+  const today = new Date();
+  const datePart = today.toISOString().split("T")[0];
+  if (!datePart) {
+    throw new Error("Failed to extract date part from ISO string");
+  }
+  return datePart;
+};
+
+const validateDateFormat = (dateString: string) => {
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+  if (!dateRegex.test(dateString)) {
+    return false;
+  }
+
+  const date = new Date(dateString);
+  return date.toISOString().split("T")[0] === dateString;
+};
+
+const prompt = (question: string): Promise<string> =>
+  new Promise((resolve) => {
+    process.stdout.write(question);
+    process.stdin.once("data", (data) => resolve(data.toString().trim()));
+  });
+
+const selectCategory = async (): Promise<CategoryTitle> => {
+  console.log("\nカテゴリーを選択してください:");
+
+  categories.forEach((category, index) => {
+    console.log(
+      `${index + 1}. ${category.emoji} ${category.title} (${category.label})`,
+    );
+  });
+
+  const choice = await prompt(`選択してください (1-${categories.length}): `);
+  const choiceIndex = Number.parseInt(choice, 10) - 1;
+
+  if (choiceIndex >= 0 && choiceIndex < categories.length) {
+    const selectedCategory = categories[choiceIndex];
+    if (selectedCategory) {
+      return selectedCategory.title;
+    }
+  }
+
+  console.log("無効な選択です。最初のカテゴリーを選択します。");
+  return categories[0]?.title || "Tech";
+};
+
+const inputPublishedDate = async () => {
+  const defaultDate = getTodayDate();
+  const input = await prompt(
+    "公開日を入力してください (yyyy-mm-dd形式、空白で今日の日付): ",
+  );
+
+  if (input === "") {
+    console.log(`今日の日付を使用します: ${defaultDate}`);
+    return defaultDate;
+  }
+
+  if (!validateDateFormat(input)) {
+    console.log("無効な日付形式です。今日の日付を使用します。");
+    return defaultDate;
+  }
+
+  return input;
+};
+
+const checkFileExists = (filePath: string) => {
+  if (existsSync(filePath)) {
+    throw new Error(`ファイルが既に存在します: ${filePath}`);
+  }
+};
+
+const generateMDXContent = (frontmatter: Frontmatter) => {
+  if (!validateDateFormat(frontmatter.publishedAt)) {
+    throw new Error(
+      `Invalid date format: ${frontmatter.publishedAt}. Expected format: yyyy-mm-dd`,
+    );
+  }
+
+  return `---
+title: ${frontmatter.title}
+description: ${frontmatter.description}
+emoji: ${frontmatter.emoji}
+category: ${frontmatter.category}
+tags: ${frontmatter.tags}
+status: ${frontmatter.status}
+publishedAt: ${frontmatter.publishedAt}
+slug: ${frontmatter.slug}
+---
+
+`;
+};
+
+const main = async () => {
+  console.log("📝 新しいブログ記事を作成します\n");
+
+  try {
+    const title = await prompt("タイトルを入力してください: ");
+    const description =
+      (await prompt('説明を入力してください (空白で"xxx"): ')) || "xxx";
+    const emoji = await prompt("絵文字を入力してください: ");
+    const category = await selectCategory();
+    const publishedAt = await inputPublishedDate();
+
+    const slug = generateBech32m(publishedAt, "b");
+
+    const frontmatter: Frontmatter = {
+      title,
+      description,
+      emoji,
+      category,
+      tags: "[]",
+      status: "draft",
+      publishedAt,
+      slug,
+    };
+
+    const dirPath = join("content", "blog", publishedAt);
+    const filePath = join(dirPath, "index.mdx");
+
+    checkFileExists(filePath);
+
+    if (!existsSync(dirPath)) {
+      mkdirSync(dirPath, { recursive: true });
+      console.log(`\n📁 ディレクトリを作成しました: ${dirPath}`);
+    }
+
+    const content = generateMDXContent(frontmatter);
+    writeFileSync(filePath, content, "utf8");
+
+    console.log("\n✅ ブログ記事を作成しました!");
+    console.log(`📄 ファイル: ${filePath}`);
+    console.log(`🏷️  スラッグ: ${frontmatter.slug}`);
+    console.log(`📅 日付: ${frontmatter.publishedAt}`);
+    console.log(`📝 説明: ${frontmatter.description}`);
+  } catch (error) {
+    console.error("エラーが発生しました:", error);
+    process.exit(1);
+  }
+
+  process.exit(0);
+};
+
+process.stdin.setEncoding("utf8");
+
+main().catch((error) => {
+  console.error("予期しないエラーが発生しました:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
This pull request introduces two new scripts to streamline development workflows and adds the implementation for creating blog entry files. The most significant change is the addition of the `create-entry.ts` script, which automates the creation of blog posts with predefined metadata.

### New Scripts for Development Workflow

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R16): Added two new scripts, `release` and `create:entry`, to simplify the release process and automate blog entry creation. (`[package.jsonL14-R16](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R16)`)

### Blog Entry Automation

* [`scripts/create-entry.ts`](diffhunk://#diff-96bfa4e0e40ef9978689b8b0d825267af4629d7f26cdc145f7a60ba1d33ede60R1-R169): Implemented a script to create new blog entries with metadata such as title, description, emoji, category, tags, status, publication date, and slug. It includes validation for date formats, interactive prompts for user input, and automatic generation of MDX content. (`[scripts/create-entry.tsR1-R169](diffhunk://#diff-96bfa4e0e40ef9978689b8b0d825267af4629d7f26cdc145f7a60ba1d33ede60R1-R169)`)