### PR TITLE
Astro 5.10 で導入された Responsive images 機能を適用させる

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -183,6 +183,7 @@ export default defineConfig({
         ? { entrypoint: "astro/assets/services/noop" }
         : { entrypoint: "astro/assets/services/sharp" },
     responsiveStyles: true,
+    layout: "constrained",
   },
   vite: {
     plugins: [tailwindcss()],

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -182,6 +182,7 @@ export default defineConfig({
       process.env.GITHUB_ACTIONS === "true"
         ? { entrypoint: "astro/assets/services/noop" }
         : { entrypoint: "astro/assets/services/sharp" },
+    responsiveStyles: true,
   },
   vite: {
     plugins: [tailwindcss()],

--- a/src/components/ui/image/image.astro
+++ b/src/components/ui/image/image.astro
@@ -23,9 +23,7 @@ const divClass = cn(
 const pictureProps = {
   class: cn("rounded-2xl", className),
   formats: ["avif"],
-  widths: [330, 640, 670, 1200],
-  sizes:
-    "(max-width: 360px) 330px, (max-width: 720px) 640px, (max-width: 1600px) 670px, 1200px",
+  layout: "constrained",
   ...rest,
 } as Parameters<typeof Picture>[0];
 ---

--- a/src/components/ui/image/image.astro
+++ b/src/components/ui/image/image.astro
@@ -23,7 +23,6 @@ const divClass = cn(
 const pictureProps = {
   class: cn("rounded-2xl", className),
   formats: ["avif"],
-  layout: "constrained",
   ...rest,
 } as Parameters<typeof Picture>[0];
 ---

--- a/src/features/home/components/ui/bento/bento-item-about-me.astro
+++ b/src/features/home/components/ui/bento/bento-item-about-me.astro
@@ -19,7 +19,6 @@ import { cn } from "#/lib/ui";
             src={profileImage}
             alt="Keisuke Hayashi"
             formats={['avif']}
-            layout="constrained"
             priority={true}
     />
     <ProgressiveBlur

--- a/src/features/home/components/ui/bento/bento-item-about-me.astro
+++ b/src/features/home/components/ui/bento/bento-item-about-me.astro
@@ -19,10 +19,8 @@ import { cn } from "#/lib/ui";
             src={profileImage}
             alt="Keisuke Hayashi"
             formats={['avif']}
-            widths={[330, 640, 670, 1000]}
-            sizes="(max-width: 360px) 330px, (max-width: 720px) 640px, (max-width: 1600px) 220px, 1000px"
-            width={1000}
-            height={1000}
+            layout="constrained"
+            priority={true}
     />
     <ProgressiveBlur
             class='pointer-events-none absolute bottom-0 left-0 h-[40%] w-full'

--- a/src/features/home/components/ui/bento/bento-item-map.astro
+++ b/src/features/home/components/ui/bento/bento-item-map.astro
@@ -22,7 +22,6 @@ import { cn } from "#/lib/ui";
             alt="マップ"
             class="size-full dark:hidden"
             formats={['avif']}
-            layout="constrained"
             priority={true}
     />
     <Picture
@@ -30,7 +29,6 @@ import { cn } from "#/lib/ui";
             alt="マップ"
             class="size-full hidden dark:block"
             formats={['avif']}
-            layout="constrained"
             priority={true}
     />
     <div class="absolute top-0 left-0 translate-x-[83px] translate-y-[48px]">

--- a/src/features/home/components/ui/bento/bento-item-map.astro
+++ b/src/features/home/components/ui/bento/bento-item-map.astro
@@ -22,20 +22,16 @@ import { cn } from "#/lib/ui";
             alt="マップ"
             class="size-full dark:hidden"
             formats={['avif']}
-            widths={[330, 640, 670, 850]}
-            sizes="(max-width: 360px) 330px, (max-width: 720px) 640px, (max-width: 1600px) 220px, 850px"
-            width={850}
-            height={850}
+            layout="constrained"
+            priority={true}
     />
     <Picture
             src={mapDarkImage}
             alt="マップ"
             class="size-full hidden dark:block"
             formats={['avif']}
-            widths={[330, 640, 670, 850]}
-            sizes="(max-width: 360px) 330px, (max-width: 720px) 640px, (max-width: 1600px) 220px, 850px"
-            width={850}
-            height={850}
+            layout="constrained"
+            priority={true}
     />
     <div class="absolute top-0 left-0 translate-x-[83px] translate-y-[48px]">
            <span class="relative grid place-content-center size-12">

--- a/src/features/home/components/ui/bento/featured-entry.astro
+++ b/src/features/home/components/ui/bento/featured-entry.astro
@@ -38,11 +38,8 @@ const { class: className } = Astro.props;
                 src={featuredBlog01}
                 alt="「デスク構成スナップショット 2024」の画像"
                 formats={['avif']}
-                widths={[330, 640, 670, 1200]}
-                sizes="(max-width: 360px) 330px, (max-width: 720px) 640px, (max-width: 1600px) 640px, 1200px"
-                width={1200}
-                height={1200}
-                class="rounded-lg object-cover aspect-[3/2] shadow-sm"
+                layout="constrained"
+                class="rounded-lg object-cover! aspect-[3/2]! shadow-sm"
         />
         <div class="absolute inset-0 bg-foreground/2 opacity-0 hover:opacity-100 transition-opacity z-10 active:bg-foreground/6" />
     </a>
@@ -57,11 +54,8 @@ const { class: className } = Astro.props;
                 src={featuredBlog02}
                 alt="「Mac mini という選択」の画像"
                 formats={['avif']}
-                widths={[330, 640, 670, 1200]}
-                sizes="(max-width: 360px) 330px, (max-width: 720px) 640px, (max-width: 1600px) 640px, 1200px"
-                width={1200}
-                height={1200}
-                class="rounded-lg object-cover aspect-square shadow-sm"
+                layout="constrained"
+                class="rounded-lg object-cover! aspect-square! shadow-sm"
         />
         <ProgressiveBlur
                 class='pointer-events-none absolute -bottom-1 left-0 h-[50%] w-full'
@@ -86,11 +80,8 @@ const { class: className } = Astro.props;
                 src={featuredBlog03}
                 alt="「さよなら、My 自作 PC」の画像"
                 formats={['avif']}
-                widths={[330, 640, 670, 1200]}
-                sizes="(max-width: 360px) 330px, (max-width: 720px) 640px, (max-width: 1600px) 640px, 1200px"
-                width={1200}
-                height={1200}
-                class="rounded-lg object-cover object-right aspect-square shadow-sm"
+                layout="constrained"
+                class="rounded-lg object-cover! object-right! aspect-square! shadow-sm"
         />
         <ProgressiveBlur
                 class='pointer-events-none absolute -bottom-1 left-0 h-[50%] w-full'
@@ -115,11 +106,8 @@ const { class: className } = Astro.props;
                 src={featuredBlog04}
                 alt="「景色と料理を楽しむ、鹿児島 3 泊 4 日の旅」の画像"
                 formats={['avif']}
-                widths={[330, 640, 670, 1200]}
-                sizes="(max-width: 360px) 330px, (max-width: 720px) 640px, (max-width: 1600px) 640px, 1200px"
-                width={1200}
-                height={1200}
-                class="rounded-lg object-cover object-left aspect-square shadow-sm"
+                layout="constrained"
+                class="rounded-lg object-cover! object-left! aspect-square! shadow-sm"
         />
         <ProgressiveBlur
                 class='pointer-events-none absolute -bottom-1 left-0 h-[50%] w-full'
@@ -146,11 +134,8 @@ const { class: className } = Astro.props;
                 src={featuredBlog05}
                 alt="「バリ島旅行記」の画像"
                 formats={['avif']}
-                widths={[330, 640, 670, 1200]}
-                sizes="(max-width: 360px) 330px, (max-width: 720px) 640px, (max-width: 1600px) 640px, 1200px"
-                width={1200}
-                height={1200}
-                class="rounded-lg object-cover object-bottom aspect-square md:aspect-[2/1] shadow-sm"
+                layout="constrained"
+                class="rounded-lg object-cover! object-bottom! aspect-square! md:aspect-[2/1]! shadow-sm"
         />
         <ProgressiveBlur
                 class='pointer-events-none absolute -bottom-1 left-0 h-[40%] w-full'

--- a/src/features/home/components/ui/bento/featured-entry.astro
+++ b/src/features/home/components/ui/bento/featured-entry.astro
@@ -38,7 +38,6 @@ const { class: className } = Astro.props;
                 src={featuredBlog01}
                 alt="「デスク構成スナップショット 2024」の画像"
                 formats={['avif']}
-                layout="constrained"
                 class="rounded-lg object-cover! aspect-[3/2]! shadow-sm"
         />
         <div class="absolute inset-0 bg-foreground/2 opacity-0 hover:opacity-100 transition-opacity z-10 active:bg-foreground/6" />
@@ -54,7 +53,6 @@ const { class: className } = Astro.props;
                 src={featuredBlog02}
                 alt="「Mac mini という選択」の画像"
                 formats={['avif']}
-                layout="constrained"
                 class="rounded-lg object-cover! aspect-square! shadow-sm"
         />
         <ProgressiveBlur
@@ -80,7 +78,6 @@ const { class: className } = Astro.props;
                 src={featuredBlog03}
                 alt="「さよなら、My 自作 PC」の画像"
                 formats={['avif']}
-                layout="constrained"
                 class="rounded-lg object-cover! object-right! aspect-square! shadow-sm"
         />
         <ProgressiveBlur
@@ -106,7 +103,6 @@ const { class: className } = Astro.props;
                 src={featuredBlog04}
                 alt="「景色と料理を楽しむ、鹿児島 3 泊 4 日の旅」の画像"
                 formats={['avif']}
-                layout="constrained"
                 class="rounded-lg object-cover! object-left! aspect-square! shadow-sm"
         />
         <ProgressiveBlur
@@ -134,7 +130,6 @@ const { class: className } = Astro.props;
                 src={featuredBlog05}
                 alt="「バリ島旅行記」の画像"
                 formats={['avif']}
-                layout="constrained"
                 class="rounded-lg object-cover! object-bottom! aspect-square! md:aspect-[2/1]! shadow-sm"
         />
         <ProgressiveBlur


### PR DESCRIPTION
This pull request introduces changes to improve image rendering and styling across multiple components by adopting a `layout="constrained"` approach and enhancing class definitions for better responsiveness and visual consistency. Additionally, a new configuration option, `responsiveStyles`, is added to the Astro configuration.

### Configuration Updates:
* [`astro.config.ts`](diffhunk://#diff-baf06eda15601b59413c77e1f18884403033204061e6c9408cd9a3bb5bc6e586R185): Added `responsiveStyles: true` to the configuration, enabling responsive styling features.

### Image Rendering Improvements:
* [`src/components/ui/image/image.astro`](diffhunk://#diff-1e4581e3586288a79f40483b4b6340faea0a2074e5017ef3cea8259993c96471L26-R26): Replaced `widths` and `sizes` properties with `layout="constrained"` for simplified and responsive image rendering.
* [`src/features/home/components/ui/bento/bento-item-about-me.astro`](diffhunk://#diff-7371f00904ddc1518f9704ec1cf79e1477be1c19eb12c65ab9e034797a6e5a8dL22-R23): Updated image rendering to use `layout="constrained"` and added `priority={true}` for optimized loading.
* [`src/features/home/components/ui/bento/bento-item-map.astro`](diffhunk://#diff-e4c845af5156b440c5f35e2ceb7372efe0aaf8530f99503590c0e0818dc8f840L25-R34): Applied `layout="constrained"` and `priority={true}` to improve image handling for both light and dark mode images.

### Styling Enhancements:
* [`src/features/home/components/ui/bento/featured-entry.astro`](diffhunk://#diff-98f20e35a086b5ebcab5b7d9e958d177b70d22921c2a2dbe3878afee68b59ee8L41-R42): Updated multiple featured blog entries to use `layout="constrained"` and enhanced class definitions with `!` for improved styling precision. Changes applied to entries such as `featuredBlog01`, `featuredBlog02`, `featuredBlog03`, `featuredBlog04`, and `featuredBlog05`. [[1]](diffhunk://#diff-98f20e35a086b5ebcab5b7d9e958d177b70d22921c2a2dbe3878afee68b59ee8L41-R42) [[2]](diffhunk://#diff-98f20e35a086b5ebcab5b7d9e958d177b70d22921c2a2dbe3878afee68b59ee8L60-R58) [[3]](diffhunk://#diff-98f20e35a086b5ebcab5b7d9e958d177b70d22921c2a2dbe3878afee68b59ee8L89-R84) [[4]](diffhunk://#diff-98f20e35a086b5ebcab5b7d9e958d177b70d22921c2a2dbe3878afee68b59ee8L118-R110) [[5]](diffhunk://#diff-98f20e35a086b5ebcab5b7d9e958d177b70d22921c2a2dbe3878afee68b59ee8L149-R138)