### PR TITLE
GitHub Actions の実行をラベルでキャンセルできる機能を追加する

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,3 +2,8 @@
 - name: 'type: bump-version'
   description: ''
   color: '#f2edfc'
+
+# CI Control
+- name: 'skip-ci'
+  description: 'Skip CI workflow execution'
+  color: '#ff6b6b'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   checks:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This pull request introduces a new label to control CI workflow execution and updates the CI workflow configuration to respect this label. The changes aim to provide flexibility by allowing developers to skip CI runs when appropriate.

### CI Control Enhancements:

* [`.github/labels.yml`](diffhunk://#diff-080b7ef0dc11b28f262ea02985043c6229e353ecfdd5920b4d3b19f369f85dc6R5-R9): Added a new label named `skip-ci` with a description "Skip CI workflow execution" and a red color (`#ff6b6b`). This label will be used to indicate pull requests where CI workflows should be skipped.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR17): Updated the `checks` job to conditionally run based on the presence of the `skip-ci` label. If the label is present in the pull request, the CI workflow will be skipped.