### PR TITLE
umami でイベントを追跡する

### DIFF
--- a/src/features/blog/components/ui/menu/config-menu.tsx
+++ b/src/features/blog/components/ui/menu/config-menu.tsx
@@ -30,20 +30,40 @@ export const ConfigMenu = ({
       <DropdownMenuLabel>開発者向け</DropdownMenuLabel>
       <DropdownMenuGroup>
         {editUrl && (
-          <NavLink href={editUrl} isExternal>
+          <NavLink
+            href={editUrl}
+            isExternal
+            umamiEvent="github-edit-click"
+            umamiLocation="blog-developer-menu"
+          >
             GitHub で編集する
           </NavLink>
         )}
-        <NavLink href={`${siteConfig.github.content}/issues/new`} isExternal>
+        <NavLink
+          href={`${siteConfig.github.content}/issues/new`}
+          isExternal
+          umamiEvent="github-issue-click"
+          umamiLocation="blog-developer-menu"
+        >
           記事の問題を報告する
         </NavLink>
         {sourceUrl && (
-          <NavLink href={sourceUrl} isExternal>
+          <NavLink
+            href={sourceUrl}
+            isExternal
+            umamiEvent="github-source-click"
+            umamiLocation="blog-developer-menu"
+          >
             ソースコードを表示する
           </NavLink>
         )}
         {revisionHistoryUrl && (
-          <NavLink href={revisionHistoryUrl} isExternal>
+          <NavLink
+            href={revisionHistoryUrl}
+            isExternal
+            umamiEvent="github-history-click"
+            umamiLocation="blog-developer-menu"
+          >
             変更履歴を表示する
           </NavLink>
         )}

--- a/src/features/blog/components/ui/menu/nav-link.tsx
+++ b/src/features/blog/components/ui/menu/nav-link.tsx
@@ -6,10 +6,14 @@ export const NavLink = ({
   href,
   children,
   isExternal = false,
+  umamiEvent,
+  umamiLocation,
 }: {
   href: string;
   children: ReactNode;
   isExternal?: boolean;
+  umamiEvent?: string;
+  umamiLocation?: string;
 }) => (
   <DropdownMenuItem asChild>
     <a
@@ -17,6 +21,8 @@ export const NavLink = ({
       className="cursor-pointer"
       target={isExternal ? "_blank" : undefined}
       rel={isExternal ? "noreferrer" : undefined}
+      data-umami-event={umamiEvent}
+      data-umami-event-location={umamiLocation}
     >
       {children}
       {isExternal && <MoveUpRightIcon className="size-3 stroke-foreground" />}

--- a/src/features/blog/components/ui/menu/shared-menu.tsx
+++ b/src/features/blog/components/ui/menu/shared-menu.tsx
@@ -40,19 +40,36 @@ export const SharedMenu = ({ title, url }: { title: string; url: string }) => (
           type="button"
           className="w-full cursor-pointer"
           onClick={() => handleCopyLink(url)}
+          data-umami-event="copy-url-click"
+          data-umami-event-location="blog-share-menu"
         >
           URL をコピー
         </button>
       </DropdownMenuItem>
       <DropdownMenuSeparator />
       <DropdownMenuGroup>
-        <NavLink href={generateXShareLink(url, title)} isExternal>
+        <NavLink
+          href={generateXShareLink(url, title)}
+          isExternal
+          umamiEvent="x-share-click"
+          umamiLocation="blog-share-menu"
+        >
           X で共有
         </NavLink>
-        <NavLink href={generateFacebookShareLink(url)} isExternal>
+        <NavLink
+          href={generateFacebookShareLink(url)}
+          isExternal
+          umamiEvent="facebook-share-click"
+          umamiLocation="blog-share-menu"
+        >
           Facebook で共有
         </NavLink>
-        <NavLink href={generateHatebuSaveLink(url, title)} isExternal>
+        <NavLink
+          href={generateHatebuSaveLink(url, title)}
+          isExternal
+          umamiEvent="hatebu-share-click"
+          umamiLocation="blog-share-menu"
+        >
           はてなブックマークに保存
         </NavLink>
       </DropdownMenuGroup>

--- a/src/features/home/components/ui/bento/bento-item-map.astro
+++ b/src/features/home/components/ui/bento/bento-item-map.astro
@@ -16,6 +16,8 @@ import { cn } from "#/lib/ui";
             "col-span-1 row-span-1 md:col-span-2 aspect-square"
         )}
         transition:animate={getCustomTransition(0.45)}
+        data-umami-event="map-click"
+        data-umami-event-location="home-bento"
 >
     <Picture
             src={mapLightImage}

--- a/src/features/home/components/ui/bento/bento-item-mastodon.astro
+++ b/src/features/home/components/ui/bento/bento-item-mastodon.astro
@@ -15,6 +15,8 @@ import { cn } from "#/lib/ui";
             "col-span-1 row-span-1 md:col-span-2 aspect-square"
         )}
         transition:animate={getCustomTransition(0.35)}
+        data-umami-event="mastodon-click"
+        data-umami-event-location="home-bento"
 >
     <div class="grid place-content-center size-10 shadow-sm rounded-[8px] bg-gradient-to-b from-[#6364ff] to-[#563acc] border border-[#5348cc]">
         <Mastodon class="size-5 fill-white" />

--- a/src/features/home/components/ui/bento/bento-item-support.astro
+++ b/src/features/home/components/ui/bento/bento-item-support.astro
@@ -15,6 +15,8 @@ import { cn } from "#/lib/ui";
             "col-span-1 row-span-1 md:col-span-2 aspect-square"
         )}
         transition:animate={getCustomTransition(0.40)}
+        data-umami-event="buy-me-coffee-click"
+        data-umami-event-location="home-bento"
 >
     <div class="grid place-content-center size-10 shadow-sm rounded-[8px] bg-[#ffdd00] border border-[#e2c400]">
         <BuyMeACoffee class="size-6" />

--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -144,6 +144,8 @@ const relatedPosts = await getRelatedPosts({ id, category });
                                             target="_blank"
                                             rel="noreferrer"
                                             class={cn(buttonVariants())}
+                                            data-umami-event="buy-me-coffee-click"
+                                            data-umami-event-location="blog-cta"
                                     >
                                         サポートする
                                         <MoveUpRightIcon class="size-3.5" />


### PR DESCRIPTION
主要リンクとアクションボタンにUmamiイベント追跡を追加し、
ユーザーの行動データを詳細に取得できるようにしました。

## 追加されたイベント追跡

### ホームページ (Bentoグリッド)
- Buy me a coffee: `buy-me-coffee-click`
- Mastodon: `mastodon-click`
- Map: `map-click`

### ブログ記事
- サポートボタン: `buy-me-coffee-click` (blog-cta)
- 開発者メニュー: GitHub編集、Issue報告、ソース表示、履歴表示
- シェアメニュー: URL コピー、X、Facebook、はてブ共有

各イベントには適切な location 属性も設定し、
どのコンテキストでクリックされたかを識別可能にしました。

🤖 Generated with [Claude Code](https://claude.ai/code)