### PR TITLE
implement YouTube embed

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -18,6 +18,7 @@ import remarkFootnoteTitle from "./src/lib/remark-footnote-title";
 import remarkLinkCard from "./src/lib/remark-link-card";
 import remarkTweetBlock from "./src/lib/remark-tweet-block";
 import remarkVideoBlock from "./src/lib/remark-video-block";
+import remarkYoutubeBlock from "./src/lib/remark-youtube-block";
 
 let adapter = vercel();
 
@@ -87,6 +88,7 @@ export default defineConfig({
     remarkPlugins: [
       remarkTweetBlock,
       remarkVideoBlock,
+      remarkYoutubeBlock,
       remarkLinkCard,
       remarkFootnoteTitle,
       remarkBlockQuoteAlert,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@astrojs/sitemap": "3.6.0",
     "@astrojs/vercel": "8.2.9",
     "@hono/zod-validator": "0.7.4",
+    "@justinribeiro/lite-youtube": "1.8.2",
     "@lucide/astro": "0.545.0",
     "@radix-ui/react-dropdown-menu": "2.1.16",
     "@tailwindcss/vite": "4.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@hono/zod-validator':
         specifier: 0.7.4
         version: 0.7.4(hono@4.9.11)(zod@3.25.76)
+      '@justinribeiro/lite-youtube':
+        specifier: 1.8.2
+        version: 1.8.2
       '@lucide/astro':
         specifier: 0.545.0
         version: 0.545.0(astro@5.14.4(@types/node@24.0.0)(@upstash/redis@1.35.5)(@vercel/functions@2.2.13)(jiti@2.6.1)(lightningcss@1.30.1)(rollup@4.42.0)(terser@5.42.0)(typescript@5.9.3)(yaml@2.8.0))
@@ -952,6 +955,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+
+  '@justinribeiro/lite-youtube@1.8.2':
+    resolution: {integrity: sha512-wayU5sYA/e5J/1j7zFk8Hoi72Hk67Axy7Za2OFRzsytd9gvtv7ZeWhmdi2lOGbnXwMZHkeMsqxRGFxH60lo5bg==}
 
   '@lucide/astro@0.545.0':
     resolution: {integrity: sha512-uhBiJCVXH+YmZdiTncV3I8e2gA4iqA/YLCKyMfxl1pWLleyrJWrQY5Avmt1qKjtYEMah0uJiQzaYtaeekaCdCw==}
@@ -5242,6 +5248,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@justinribeiro/lite-youtube@1.8.2': {}
 
   '@lucide/astro@0.545.0(astro@5.14.4(@types/node@24.0.0)(@upstash/redis@1.35.5)(@vercel/functions@2.2.13)(jiti@2.6.1)(lightningcss@1.30.1)(rollup@4.42.0)(terser@5.42.0)(typescript@5.9.3)(yaml@2.8.0))':
     dependencies:

--- a/src/features/blog/components/content-wrapper.astro
+++ b/src/features/blog/components/content-wrapper.astro
@@ -8,6 +8,7 @@ import Heading3 from "#/features/blog/components/ui/blocks/heading-3.astro";
 import MermaidBlock from "#/features/blog/components/ui/blocks/mermaid-block.astro";
 import TweetBlock from "#/features/blog/components/ui/blocks/tweet-block.astro";
 import VideoBlock from "#/features/blog/components/ui/blocks/video-block.astro";
+import YoutubeBlock from "#/features/blog/components/ui/blocks/youtube-block.astro";
 import DivHandler from "#/features/blog/components/ui/div-handler.astro";
 
 interface Props {
@@ -26,5 +27,6 @@ const { content: Content } = Astro.props;
   picture: MermaidBlock,
   div: DivHandler,
   'tweet-block': TweetBlock,
-  'video-block': VideoBlock }}
+  'video-block': VideoBlock,
+  'youtube-block': YoutubeBlock }}
 />

--- a/src/features/blog/components/ui/blocks/youtube-block.astro
+++ b/src/features/blog/components/ui/blocks/youtube-block.astro
@@ -1,0 +1,123 @@
+---
+import type { HTMLAttributes } from "astro/types";
+
+interface Props extends HTMLAttributes<"div"> {
+  /**
+   * YouTube video ID (e.g., "kpz_U8wHpa8")
+   */
+  videoId: string;
+  /**
+   * Optional playlist ID
+   */
+  playlistId?: string;
+  /**
+   * Optional video title (improves accessibility)
+   */
+  title?: string;
+  /**
+   * Optional YouTube player parameters (e.g., "controls=0&start=10")
+   * @see https://developers.google.com/youtube/player_parameters
+   */
+  params?: string;
+}
+
+const {
+  videoId,
+  playlistId,
+  title,
+  params,
+  class: className,
+  ...rest
+} = Astro.props;
+---
+
+<lite-youtube
+  videoid={videoId}
+  playlistid={playlistId}
+  videotitle={title}
+  params={params}
+  class:list={["block max-w-full rounded-2xl border-[#474747] dark:border bg-black relative cursor-pointer overflow-hidden", className]}
+  {...rest}
+></lite-youtube>
+
+<style>
+  lite-youtube {
+    contain: content;
+    background-position: center center;
+    background-size: cover;
+  }
+
+  lite-youtube::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAADGCAYAAAAT+OqFAAAAdklEQVQoz42QQQ7AIAgEF/T/D+kbq/RWAlnQyyazA4aoAB4FsBSA/bFjuF1EOL7VbrIrBuusmrt4ZZORfb6ehbWdnRHEIiITaEUKa5EJqUakRSaEYBJSCY2dEstQY7AuxahwXFrvZmWl2rh4JZ07z9dLtesfNj5q0FU3A5ObbwAAAABJRU5ErkJggg==);
+    background-position: top;
+    background-repeat: repeat-x;
+    height: 60px;
+    padding-bottom: 50px;
+    width: 100%;
+    transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
+  }
+
+  lite-youtube::after {
+    content: "";
+    display: block;
+    padding-bottom: calc(100% / (16 / 9));
+  }
+
+  lite-youtube > iframe {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    border: 0;
+  }
+
+  lite-youtube > .lty-playbtn {
+    width: 68px;
+    height: 48px;
+    position: absolute;
+    cursor: pointer;
+    transform: translate3d(-50%, -50%, 0);
+    top: 50%;
+    left: 50%;
+    z-index: 1;
+    background-color: transparent;
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="%23f00"/><path d="M45 24 27 14v20" fill="%23fff"/></svg>');
+    filter: grayscale(100%);
+    transition: filter 0.1s cubic-bezier(0, 0, 0.2, 1);
+    border: none;
+  }
+
+  lite-youtube:hover > .lty-playbtn,
+  lite-youtube .lty-playbtn:focus {
+    filter: none;
+  }
+
+  lite-youtube.lyt-activated {
+    cursor: unset;
+  }
+
+  lite-youtube.lyt-activated::before,
+  lite-youtube.lyt-activated > .lty-playbtn {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .lyt-visually-hidden {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+</style>
+
+<script>
+  import "@justinribeiro/lite-youtube";
+</script>

--- a/src/lib/remark-youtube-block.ts
+++ b/src/lib/remark-youtube-block.ts
@@ -1,0 +1,101 @@
+import type { Root } from "mdast";
+import { visit } from "unist-util-visit";
+import { isBareExternalLink } from "./mdast-util-node-is";
+
+/**
+ * Extract YouTube video ID from various YouTube URL formats
+ *
+ * @description Supports multiple YouTube URL formats including:
+ * - Standard watch URLs: https://www.youtube.com/watch?v=VIDEO_ID
+ * - Short URLs: https://youtu.be/VIDEO_ID
+ * - Embed URLs: https://www.youtube.com/embed/VIDEO_ID
+ * - Mobile URLs: https://m.youtube.com/watch?v=VIDEO_ID
+ *
+ * @param url - The YouTube URL to extract the video ID from
+ * @returns The extracted video ID or null if not found
+ *
+ * @example
+ * ```typescript
+ * extractYoutubeId("https://www.youtube.com/watch?v=kpz_U8wHpa8")
+ * // Returns: "kpz_U8wHpa8"
+ *
+ * extractYoutubeId("https://youtu.be/kpz_U8wHpa8")
+ * // Returns: "kpz_U8wHpa8"
+ * ```
+ */
+const extractYoutubeId = (url: string): string | null => {
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/i,
+    /youtube\.com\/watch\?.*v=([a-zA-Z0-9_-]{11})/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Remark plugin to convert bare YouTube URLs to youtube-block components
+ *
+ * @description This plugin automatically transforms standalone YouTube URLs
+ * in MDX content into custom `youtube-block` components. It uses lite-youtube-embed
+ * internally to provide lazy-loading YouTube embeds that only load resources
+ * when the user clicks the play button.
+ *
+ * The plugin:
+ * 1. Identifies paragraphs containing only a single bare external link
+ * 2. Checks if the URL is a valid YouTube link
+ * 3. Extracts the video ID from the URL
+ * 4. Replaces the link with an MDX JSX element (youtube-block)
+ *
+ * @returns A unified transformer function
+ *
+ * @example
+ * ```mdx
+ * // Input MDX:
+ * https://www.youtube.com/watch?v=kpz_U8wHpa8
+ *
+ * // Output (transformed):
+ * <youtube-block videoId="kpz_U8wHpa8" />
+ * ```
+ */
+const remarkYoutubeBlock = () => (tree: Root) => {
+  visit(tree, "paragraph", (node, index, parent) => {
+    if (!parent || typeof index !== "number" || node.children.length !== 1) {
+      return;
+    }
+
+    const child = node.children[0];
+
+    if (!isBareExternalLink(child)) {
+      return;
+    }
+
+    const videoId = extractYoutubeId(child.url);
+
+    if (!videoId) {
+      return;
+    }
+
+    // Replace a paragraph with an MDX JSX element
+    parent.children[index] = {
+      type: "mdxJsxFlowElement",
+      name: "youtube-block",
+      attributes: [
+        {
+          type: "mdxJsxAttribute",
+          name: "videoId",
+          value: videoId,
+        },
+      ],
+      children: [],
+    };
+  });
+};
+
+export default remarkYoutubeBlock;


### PR DESCRIPTION
## Summary

Implements automatic YouTube video embedding in blog posts with lazy-loading functionality to optimize resource usage.

## Changes

- **Added `@justinribeiro/lite-youtube` package** for lightweight YouTube embeds
- **Created `remark-youtube-block` plugin** to transform bare YouTube URLs into `youtube-block` components
- **Implemented `youtube-block.astro` component** with:
  - Lazy-loading (video loads only when play button is clicked)
  - Consistent UI styling with other block components (rounded borders, dark mode support)
  - Support for multiple YouTube URL formats (`youtube.com/watch?v=`, `youtu.be/`, etc.)
  - Customizable YouTube player parameters via `params` prop
  - Tailwind CSS for styling consistency
- **Updated `content-wrapper.astro`** to register the new component mapping
- **Updated `astro.config.ts`** to include the new remark plugin

## Usage

Simply paste a YouTube URL in MDX files:

\`\`\`mdx
https://www.youtube.com/watch?v=kpz_U8wHpa8
\`\`\`

The URL will be automatically converted to a lazy-loaded YouTube embed.

## Benefits

- **Performance**: Videos don't load until user interaction
- **Resource efficient**: Reduces initial page load size
- **Consistent UI**: Matches existing block component styles
- **Easy to use**: No special syntax required, just paste YouTube URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>