### PR TITLE
Add guestbook page with optional reactions in comments

### DIFF
--- a/src/features/blog/components/ui/comment.astro
+++ b/src/features/blog/components/ui/comment.astro
@@ -2,12 +2,14 @@
 import type { HTMLAttributes } from "astro/types";
 import { cn } from "#/lib/ui";
 
-interface Props extends HTMLAttributes<"div"> {}
+interface Props extends HTMLAttributes<"div"> {
+  reactionsEnabled?: boolean;
+}
 
-const { class: className, ...rest } = Astro.props;
+const { class: className, reactionsEnabled = true, ...rest } = Astro.props;
 ---
 
-<div class={cn('giscus-container min-h-[370px]', className)} {...rest} />
+<div class={cn('giscus-container min-h-[370px]', className)} data-reactions-enabled={reactionsEnabled ? '1' : '0'} {...rest} />
 
 <script>
   const initGiscus = () => {
@@ -27,6 +29,8 @@ const { class: className, ...rest } = Astro.props;
       existingScript.remove();
     }
 
+    const reactionsEnabled = container.getAttribute('data-reactions-enabled') || '1';
+
     const script = document.createElement('script');
     script.src = 'https://giscus.app/client.js';
     script.setAttribute('data-repo', 'kkhys/content');
@@ -35,7 +39,7 @@ const { class: className, ...rest } = Astro.props;
     script.setAttribute('data-category-id', 'DIC_kwDOKgamBs4CaJE6');
     script.setAttribute('data-mapping', 'pathname');
     script.setAttribute('data-strict', '1');
-    script.setAttribute('data-reactions-enabled', '1');
+    script.setAttribute('data-reactions-enabled', reactionsEnabled);
     script.setAttribute('data-emit-metadata', '0');
     script.setAttribute('data-input-position', 'bottom');
     script.setAttribute('data-theme', 'preferred_color_scheme');

--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -1,0 +1,30 @@
+---
+import ArrowLeftIcon from "@lucide/astro/icons/arrow-left";
+import Budoux from "#/components/budoux.astro";
+import SEO from "#/components/seo.astro";
+import Comment from "#/features/blog/components/ui/comment.astro";
+import BaseLayout from "#/layouts/base-layout.astro";
+---
+
+<BaseLayout pagefind>
+  <SEO
+      title='ゲストブック'
+      description='訪問してくれた方のメッセージを残せるゲストブックです。お気軽にコメントをどうぞ。'
+      slot='seo'
+  />
+  <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[138px] xl:-translate-x-[260px]">
+    <a href="/" class="inline-flex gap-1 items-center text-muted-foreground text-xs hover:underline">
+      <ArrowLeftIcon class="size-3.5" />
+      ホーム
+    </a>
+  </div>
+  <h1 class="font-medium">
+    ゲストブック
+  </h1>
+  <Budoux>
+    <p class="text-sm text-muted-foreground mt-2">訪問してくれた方がメッセージを残せるゲストブックです。お気軽にコメントをどうぞ。</p>
+  </Budoux>
+  <section class="mt-8">
+    <Comment reactionsEnabled={false} />
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## Summary

- Add a new guestbook page at `/guestbook` where visitors can leave messages
- Enhance the `Comment` component to support optional reactions via `reactionsEnabled` prop
- Configure guestbook to disable reactions for a cleaner guest message experience

## Changes

### New Features
- **Guestbook Page** (`src/pages/guestbook.astro`)
  - New standalone page for visitor messages
  - Uses giscus-powered comments
  - Follows existing page layout patterns (SEO, navigation, Japanese text with Budoux)
  - Reactions disabled for focused messaging

### Component Enhancement
- **Comment Component** (`src/features/blog/components/ui/comment.astro`)
  - Add `reactionsEnabled` prop (default: `true`)
  - Pass reaction setting to giscus via `data-reactions-enabled` attribute
  - Maintain backward compatibility with existing blog post comments

## Implementation Details

The `Comment` component now accepts an optional `reactionsEnabled` boolean prop:
- **Default behavior**: Reactions enabled (existing blog posts unaffected)
- **Guestbook usage**: `<Comment reactionsEnabled={false} />` hides reactions

## Testing

- [x] Guestbook page accessible at `/guestbook`
- [x] Giscus comments load correctly
- [x] Reactions hidden on guestbook
- [x] Existing blog post comments unchanged (reactions still enabled)