### PR TITLE
[main] fix: remove unnecessary separator in blog layout

### DIFF
--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -115,7 +115,6 @@ const relatedPosts = await getRelatedPosts({ id, category });
       <div class="mt-12 space-y-6">
         <div class="font-medium leading-7">こちらもおすすめ</div>
         <EntryList blogEntries={relatedPosts} />
-        <Separator class="mt-8" />
       </div>
     )}
   </section>


### PR DESCRIPTION
- Remove unused separator component from related posts section