### PR TITLE
[main] refactor: decouple tags from categories

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,35 +1,22 @@
 import { defineCollection, z } from "astro:content";
 import { file, glob } from "astro/loaders";
 import { categoryTitles } from "#/features/blog/config/category";
-import { allTagTitles, tagsTitlesByCategory } from "#/features/blog/config/tag";
+import { allTagTitles } from "#/features/blog/config/tag";
 
 const blog = defineCollection({
   loader: glob({ pattern: "**/*.mdx", base: "./content/blog" }),
-  schema: z
-    .object({
-      title: z.string(),
-      description: z.string(),
-      emoji: z.string(),
-      category: z.enum(categoryTitles as [string, ...string[]]),
-      tags: z.array(z.enum(allTagTitles as [string, ...string[]])).optional(),
-      status: z.enum(["draft", "published"]).default("draft"),
-      publishedAt: z.date(),
-      publishedAtString: z.string().optional(),
-      updatedAt: z.date().optional(),
-      updatedAtString: z.string().optional(),
-    })
-    .refine(
-      ({ category, tags }) => {
-        if (!tags) return true;
-        const validTags =
-          tagsTitlesByCategory[category as keyof typeof tagsTitlesByCategory];
-        return tags.every((tag) => validTags.includes(tag));
-      },
-      {
-        message: "category に対応した tags のみ選択できます。",
-        path: ["tags"],
-      },
-    ),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    emoji: z.string(),
+    category: z.enum(categoryTitles as [string, ...string[]]),
+    tags: z.array(z.enum(allTagTitles as [string, ...string[]])).optional(),
+    status: z.enum(["draft", "published"]).default("draft"),
+    publishedAt: z.date(),
+    publishedAtString: z.string().optional(),
+    updatedAt: z.date().optional(),
+    updatedAtString: z.string().optional(),
+  }),
 });
 
 const legal = defineCollection({

--- a/src/features/blog/config/category.ts
+++ b/src/features/blog/config/category.ts
@@ -1,5 +1,3 @@
-import { tags } from "#/features/blog/config/tag";
-
 type Category = Record<"title" | "label" | "slug" | "emoji", string>;
 export type CategoryTitle = (typeof categories)[number]["title"];
 
@@ -37,10 +35,3 @@ export const getCategoryBySlug = (slug: string) =>
 
 export const getCategoryByTitle = (title: string) =>
   categories.find((category) => category.title === title);
-
-export const getCategoryByTagSlug = (tagSlug: string) =>
-  categories.find((category) =>
-    tags[category.slug as keyof typeof tags]?.some(
-      (tag) => tag.slug === tagSlug,
-    ),
-  );

--- a/src/features/blog/config/tag.ts
+++ b/src/features/blog/config/tag.ts
@@ -1,204 +1,180 @@
-import type { CategoryTitle } from "#/features/blog/config/category";
-
 export type Tag = Record<"title" | "label" | "slug" | "emoji", string>;
 
-export const tags = {
-  diy: [
-    {
-      title: "Desk",
-      label: "デスク",
-      slug: "desk",
-      emoji: "🪑",
-    },
-    {
-      title: "Pottery",
-      label: "陶芸",
-      slug: "pottery",
-      emoji: "🏺",
-    },
-    {
-      title: "Clothes",
-      label: "服",
-      slug: "clothes",
-      emoji: "👗",
-    },
-    {
-      title: "Sewing",
-      label: "裁縫",
-      slug: "sewing",
-      emoji: "🪡",
-    },
-  ],
-  life: [
-    {
-      title: "Travel",
-      label: "旅行",
-      slug: "travel",
-      emoji: "🌎",
-    },
-    {
-      title: "Memorial",
-      label: "思い出",
-      slug: "memorial",
-      emoji: "🌸",
-    },
-    {
-      title: "Essay",
-      label: "エッセイ",
-      slug: "essay",
-      emoji: "📝",
-    },
-    {
-      title: "Random note",
-      label: "雑記",
-      slug: "random-note",
-      emoji: "🗑",
-    },
-  ],
-  object: [
-    // {
-    //   title: "Fashion",
-    //   slug: "fashion",
-    //   emoji: "👗",
-    // },
-    {
-      title: "Camera",
-      label: "カメラ",
-      slug: "camera",
-      emoji: "📷",
-    },
-    {
-      title: "Desk setup",
-      label: "デスク周り",
-      slug: "desk-setup",
-      emoji: "🪑",
-    },
-    {
-      title: "Desk goods",
-      label: "デスクグッズ",
-      slug: "desk-goods",
-      emoji: "✂",
-    },
-    {
-      title: "Gadget",
-      label: "ガジェット",
-      slug: "gadget",
-      emoji: "📱",
-    },
-    {
-      title: "Apple",
-      label: "Apple",
-      slug: "apple",
-      emoji: "🍎",
-    },
-  ],
-  tech: [
-    {
-      title: "Release note",
-      label: "リリースノート",
-      slug: "release-note",
-      emoji: "🚀",
-    },
-    {
-      title: "TypeScript",
-      label: "TypeScript",
-      slug: "typescript",
-      emoji: "🧩",
-    },
-    {
-      title: "React",
-      label: "React",
-      slug: "react",
-      emoji: "⚛",
-    },
-    {
-      title: "Play Framework",
-      label: "Play Framework",
-      slug: "play-framework",
-      emoji: "▶",
-    },
-    {
-      title: "Next.js",
-      label: "Next.js",
-      slug: "next-js",
-      emoji: "🔼",
-    },
-    {
-      title: "Security",
-      label: "セキュリティ",
-      slug: "security",
-      emoji: "🔒",
-    },
-    {
-      title: "Idea",
-      label: "アイデア",
-      slug: "idea",
-      emoji: "💡",
-    },
-    {
-      title: "Font",
-      label: "フォント",
-      slug: "font",
-      emoji: "🔤",
-    },
-    {
-      title: "Mermaid",
-      label: "Mermaid",
-      slug: "mermaid",
-      emoji: "🧜",
-    },
-    {
-      title: "Tips",
-      label: "Tips",
-      slug: "tips",
-      emoji: "📌",
-    },
-    {
-      title: "Mastodon",
-      label: "Mastodon",
-      slug: "mastodon",
-      emoji: "🐘",
-    },
-    {
-      title: "Linux",
-      label: "Linux",
-      slug: "linux",
-      emoji: "🐧",
-    },
-    {
-      title: "Environment",
-      label: "環境構築",
-      slug: "environment",
-      emoji: "🌳",
-    },
-    {
-      title: "Event",
-      label: "イベント",
-      slug: "event",
-      emoji: "🎉",
-    },
-    {
-      title: "AI",
-      label: "AI",
-      slug: "ai",
-      emoji: "🧠",
-    },
-  ],
-} as const satisfies Record<string, Tag[]>;
+export const tags = [
+  {
+    title: "AI",
+    label: "AI",
+    slug: "ai",
+    emoji: "🧠",
+  },
+  {
+    title: "Apple",
+    label: "Apple",
+    slug: "apple",
+    emoji: "🍎",
+  },
+  {
+    title: "Camera",
+    label: "カメラ",
+    slug: "camera",
+    emoji: "📷",
+  },
+  {
+    title: "Clothes",
+    label: "服",
+    slug: "clothes",
+    emoji: "👗",
+  },
+  {
+    title: "Desk",
+    label: "デスク",
+    slug: "desk",
+    emoji: "🪑",
+  },
+  {
+    title: "Desk goods",
+    label: "デスクグッズ",
+    slug: "desk-goods",
+    emoji: "✂",
+  },
+  {
+    title: "Desk setup",
+    label: "デスク周り",
+    slug: "desk-setup",
+    emoji: "🪑",
+  },
+  {
+    title: "Environment",
+    label: "環境構築",
+    slug: "environment",
+    emoji: "🌳",
+  },
+  {
+    title: "Essay",
+    label: "エッセイ",
+    slug: "essay",
+    emoji: "📝",
+  },
+  {
+    title: "Event",
+    label: "イベント",
+    slug: "event",
+    emoji: "🎉",
+  },
+  {
+    title: "Font",
+    label: "フォント",
+    slug: "font",
+    emoji: "🔤",
+  },
+  {
+    title: "Gadget",
+    label: "ガジェット",
+    slug: "gadget",
+    emoji: "📱",
+  },
+  {
+    title: "Idea",
+    label: "アイデア",
+    slug: "idea",
+    emoji: "💡",
+  },
+  {
+    title: "Linux",
+    label: "Linux",
+    slug: "linux",
+    emoji: "🐧",
+  },
+  {
+    title: "Mastodon",
+    label: "Mastodon",
+    slug: "mastodon",
+    emoji: "🐘",
+  },
+  {
+    title: "Memorial",
+    label: "思い出",
+    slug: "memorial",
+    emoji: "🌸",
+  },
+  {
+    title: "Mermaid",
+    label: "Mermaid",
+    slug: "mermaid",
+    emoji: "🧜",
+  },
+  {
+    title: "Next.js",
+    label: "Next.js",
+    slug: "next-js",
+    emoji: "🔼",
+  },
+  {
+    title: "Play Framework",
+    label: "Play Framework",
+    slug: "play-framework",
+    emoji: "▶",
+  },
+  {
+    title: "Pottery",
+    label: "陶芸",
+    slug: "pottery",
+    emoji: "🏺",
+  },
+  {
+    title: "Random note",
+    label: "雑記",
+    slug: "random-note",
+    emoji: "🗑",
+  },
+  {
+    title: "React",
+    label: "React",
+    slug: "react",
+    emoji: "⚛",
+  },
+  {
+    title: "Release note",
+    label: "リリースノート",
+    slug: "release-note",
+    emoji: "🚀",
+  },
+  {
+    title: "Security",
+    label: "セキュリティ",
+    slug: "security",
+    emoji: "🔒",
+  },
+  {
+    title: "Sewing",
+    label: "裁縫",
+    slug: "sewing",
+    emoji: "🪡",
+  },
+  {
+    title: "Tips",
+    label: "Tips",
+    slug: "tips",
+    emoji: "📌",
+  },
+  {
+    title: "Travel",
+    label: "旅行",
+    slug: "travel",
+    emoji: "🌎",
+  },
+  {
+    title: "TypeScript",
+    label: "TypeScript",
+    slug: "typescript",
+    emoji: "🧩",
+  },
+] as const satisfies Tag[];
 
-export const flatTags = Object.values(tags).flat();
-
-export const allTagTitles = flatTags.map(({ title }) => title);
-
-export const tagsTitlesByCategory: Record<CategoryTitle, string[]> = {
-  Tech: tags.tech.map((t) => t.title),
-  Life: tags.life.map((t) => t.title),
-  Object: tags.object.map((t) => t.title),
-  DIY: tags.diy.map((t) => t.title),
-};
+export const allTagTitles = tags.map(({ title }) => title);
 
 export const getTagBySlug = (slug: string) =>
-  flatTags.find((tag) => tag.slug === slug);
+  tags.find((tag) => tag.slug === slug);
 
 export const getTagByTitle = (title: string) =>
-  flatTags.find((tag) => tag.title === title);
+  tags.find((tag) => tag.title === title);

--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -10,7 +10,7 @@ import EntryList from "#/features/blog/components/ui/entry-list.astro";
 import TableOfContent from "#/features/blog/components/ui/table-of-content.astro";
 import TagCloud from "#/features/blog/components/ui/tag-cloud.astro";
 import { getCategoryBySlug } from "#/features/blog/config/category";
-import { flatTags } from "#/features/blog/config/tag";
+import { tags as allTags } from "#/features/blog/config/tag";
 import { getRelatedPosts } from "#/features/blog/utils/entry";
 import BaseLayout from "#/layouts/base-layout.astro";
 import { BASE_URL } from "#/lib/base-url";
@@ -43,9 +43,9 @@ if (!categoryObject) {
 }
 
 const allTagCloudItems = await Promise.all(
-  flatTags?.map(async (flatTag) => ({
-    ...flatTag,
-    emojiSvg: await emojiSvg({ emoji: flatTag.emoji, isColored: true }),
+  allTags?.map(async (tag) => ({
+    ...tag,
+    emojiSvg: await emojiSvg({ emoji: tag.emoji, isColored: true }),
   })) || [],
 );
 

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -6,7 +6,6 @@ import SEO from "#/components/seo.astro";
 import { countPerPage } from "#/config/constant";
 import EntryList from "#/features/blog/components/ui/entry-list.astro";
 import Pagination from "#/features/blog/components/ui/pagination.astro";
-import { getCategoryByTagSlug } from "#/features/blog/config/category";
 import { getTagBySlug } from "#/features/blog/config/tag";
 import { getPublicBlogEntries } from "#/features/blog/utils/entry";
 import BaseLayout from "#/layouts/base-layout.astro";
@@ -43,12 +42,6 @@ if (!tag) {
   throw new Error(`Tag "${tagSlug}" not found`);
 }
 
-const category = getCategoryByTagSlug(tagSlug);
-
-if (!category) {
-  throw new Error(`Category for tag "${tagSlug}" not found`);
-}
-
 const breadcrumbSchema: WithContext<BreadcrumbList> = {
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",
@@ -62,12 +55,6 @@ const breadcrumbSchema: WithContext<BreadcrumbList> = {
     {
       "@type": "ListItem",
       position: 2,
-      name: category.label,
-      item: `${import.meta.env.SITE}/blog/categories/${category.slug}`,
-    },
-    {
-      "@type": "ListItem",
-      position: 3,
       name: tag.label,
       item: `${import.meta.env.SITE}/blog/tags/${tag.slug}`,
     },
@@ -89,9 +76,9 @@ const breadcrumbSchema: WithContext<BreadcrumbList> = {
   />
   <section>
     <div class="inline-flex gap-1.5 items-center text-xs">
-      <a href={`/blog/categories/${category.slug}`} class="inline-flex gap-1 items-center text-muted-foreground hover:underline">
+      <a href="/blog" class="inline-flex gap-1 items-center text-muted-foreground hover:underline">
         <ArrowLeftIcon class="size-3.5" />
-        {category.label}
+        ブログ
       </a>
       <span class="text-muted-foreground">/</span>
       <h1 class="font-semibold">


### PR DESCRIPTION
- Convert tags from category-scoped structure to flat array
- Remove category-tag validation from content schema
- Simplify tag page breadcrumb navigation
- Update imports and remove unused functions

This change makes tags independent entities not tied to specific categories, allowing greater flexibility in tag organization while simplifying the codebase.