### PR TITLE
[main] refactor: remove source code link from footer

### DIFF
--- a/src/components/ui/footer.astro
+++ b/src/components/ui/footer.astro
@@ -1,34 +1,17 @@
 ---
-import MoveUpRightIcon from "#/components/icons/move-up-right.svg";
-import { siteConfig } from "#/config/site";
-
-type FooterLink = {
-  href: string;
-  title: string;
-  external?: boolean;
-};
-
 const footerLinks = [
   { href: "/legal/privacy-policy", title: "プライバシーポリシー" },
-  {
-    href: siteConfig.github.me,
-    title: "ソースコード",
-    external: true,
-  },
-] satisfies FooterLink[];
+];
 ---
 
 <footer class="container flex flex-col items-center justify-between gap-4 max-w-6xl mx-auto text-xs text-muted-foreground py-6 mt-28 md:px-8 md:py-0 md:h-24 md:flex-row">
     <nav class="flex divide-x">
-      {footerLinks.map(({ href, title, external }) => (
+      {footerLinks.map(({ href, title }) => (
           <a
               href={href}
-              class="flex items-center gap-0.5 px-2 hover:text-foreground"
-              target={external ? "_blank" : undefined}
-              rel={external ? "noreferrer" : undefined}
+              class="px-2 hover:text-foreground"
           >
             {title}
-            {external && <MoveUpRightIcon class="size-2.5" />}
           </a>
       ))}
     </nav>


### PR DESCRIPTION
- Remove the "ソースコード" (source code) link from footer
- Remove unnecessary imports and type definitions
- Simplify footer link structure