### PR TITLE
[main] refactor: align page title positions across all pages

### DIFF
--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -42,7 +42,7 @@ const { class: className } = Astro.props;
 </head>
 <body class="flex flex-col w-full max-w-6xl min-h-screen min-w-full mx-auto">
 <main class='flex-1 w-full max-w-2xl mx-auto'>
-  <div class={cn('container pt-20 pb-12', className)}>
+  <div class={cn('container pt-20 pb-12 md:pt-28', className)}>
     <slot/>
   </div>
 </main>

--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -70,7 +70,7 @@ const relatedPosts = await getRelatedPosts({ id, category });
   />
   <slot name='head' slot='head' />
   <section>
-    <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[138px] xl:-translate-x-[260px]">
+    <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[170px] xl:-translate-x-[260px]">
       <span class="inline-flex gap-1.5 items-center text-xs">
         <a href="/blog" class="inline-flex gap-1 items-center text-muted-foreground hover:underline">
           <ArrowLeftIcon class="size-3.5" />

--- a/src/layouts/legal-layout.astro
+++ b/src/layouts/legal-layout.astro
@@ -17,7 +17,7 @@ const { title, description } = Astro.props;
       slot='seo'
   />
   <slot name='head' slot='head'/>
-  <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[138px] xl:-translate-x-[260px]">
+  <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[170px] xl:-translate-x-[260px]">
     <a href="/" class="inline-flex gap-1 items-center text-muted-foreground text-xs hover:underline">
       <ArrowLeftIcon class="size-3.5" />
       ホーム
@@ -25,7 +25,7 @@ const { title, description } = Astro.props;
   </div>
   <section class="prose">
     <header>
-      <h1 class="mt-4 font-medium">{title}</h1>
+      <h1 class="font-medium">{title}</h1>
     </header>
     <div>
       <slot />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -10,7 +10,7 @@ import BaseLayout from "#/layouts/base-layout.astro";
       description='Keisuke Hayashi のブログ'
       slot='seo'
   />
-  <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[138px] xl:-translate-x-[260px]">
+  <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[170px] xl:-translate-x-[260px]">
     <a href="/" class="inline-flex gap-1 items-center text-muted-foreground text-xs hover:underline">
       <ArrowLeftIcon class="size-3.5" />
       ホーム

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -21,13 +21,13 @@ export const getStaticPaths = async ({
 const { page } = Astro.props;
 ---
 
-<BaseLayout class="space-y-6">
+<BaseLayout>
   <SEO
       title='ブログ'
       description='Keisuke Hayashi のブログ'
       slot='seo'
   />
-  <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[138px] xl:-translate-x-[260px]">
+  <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[170px] xl:-translate-x-[260px]">
     <a href="/" class="inline-flex gap-1 items-center text-muted-foreground text-xs hover:underline">
       <ArrowLeftIcon class="size-3.5" />
       ホーム
@@ -37,8 +37,8 @@ const { page } = Astro.props;
     <h1 class="font-medium">ブログ</h1>
     <CategoryNavigation class="mt-8" />
   </section>
-  <section>
+  <section class="mt-6">
     <EntryList blogEntries={page.data} showDate />
   </section>
-  <Pagination page={page} baseUrl="/blog" />
+  <Pagination page={page} baseUrl="/blog" class="mt-6" />
 </BaseLayout>

--- a/src/pages/blog/categories/[category]/[...page].astro
+++ b/src/pages/blog/categories/[category]/[...page].astro
@@ -43,13 +43,13 @@ if (!category) {
 }
 ---
 
-<BaseLayout class="space-y-6">
+<BaseLayout>
   <SEO
       title={category.label}
       description=`「${category.label}」カテゴリーの記事一覧`
       slot='seo'
   />
-  <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[138px] xl:-translate-x-[260px]">
+  <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[170px] xl:-translate-x-[260px]">
     <a href="/" class="inline-flex gap-1 items-center text-muted-foreground text-xs hover:underline">
       <ArrowLeftIcon class="size-3.5" />
       ホーム
@@ -59,8 +59,8 @@ if (!category) {
     <h1 class="font-medium">ブログ</h1>
     <CategoryNavigation class="mt-8" />
   </section>
-  <section>
+  <section class="mt-6">
     <EntryList blogEntries={page.data} showDate />
   </section>
-  <Pagination page={page} baseUrl={`/blog/categories/${categorySlug}`} />
+  <Pagination page={page} baseUrl={`/blog/categories/${categorySlug}`} class="mt-6" />
 </BaseLayout>

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -62,7 +62,7 @@ const breadcrumbSchema: WithContext<BreadcrumbList> = {
 };
 ---
 
-<BaseLayout class="space-y-6">
+<BaseLayout>
   <SEO
       title={tag.label}
       description={`「${tag.label}」のタグがついた記事一覧`}
@@ -86,8 +86,8 @@ const breadcrumbSchema: WithContext<BreadcrumbList> = {
       </h1>
     </div>
   </section>
-  <section>
+  <section class="mt-6">
     <EntryList blogEntries={page.data} showDate />
   </section>
-  <Pagination page={page} baseUrl={`/blog/tags/${tag.slug}`} />
+  <Pagination page={page} baseUrl={`/blog/tags/${tag.slug}`} class="mt-6" />
 </BaseLayout>

--- a/src/pages/bucket-list.astro
+++ b/src/pages/bucket-list.astro
@@ -54,7 +54,7 @@ const completedItems = bucketList.data.reduce(
       description='これは僕がこの人生で達成したいこと、手に入れたいことのリストです。'
       slot='seo'
   />
-  <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[138px] xl:-translate-x-[260px]">
+  <div class="mb-4 xl:fixed xl:top-0 xl:translate-y-[170px] xl:-translate-x-[260px]">
     <a href="/" class="inline-flex gap-1 items-center text-muted-foreground text-xs hover:underline">
       <ArrowLeftIcon class="size-3.5"/>
       ホーム

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,7 +14,7 @@ const linkClass =
       set:html={JSON.stringify(websiteSchema)}
       slot='head'
   />
-  <div class="mt-0 md:mt-16">
+  <div>
     <h1 class="font-medium">
       Keisuke Hayashi
     </h1>


### PR DESCRIPTION
## Summary

Unified h1 title positioning across all pages by adjusting layout padding and breadcrumb offsets.

## Changes

- Increase base layout top padding to md:pt-28 for consistent desktop spacing
- Remove redundant margin utilities from home page and legal layout
- Update breadcrumb fixed position offsets to reflect new padding
- Standardize section spacing with explicit margins instead of utility classes

## Motivation

Ensure all page titles align vertically regardless of page type, improving visual consistency.