### PR TITLE
[main] style: consolidate global styles and remove component-scoped duplicates

### DIFF
--- a/src/components/ui/emoji-eye-catch.astro
+++ b/src/components/ui/emoji-eye-catch.astro
@@ -31,7 +31,7 @@ const rowEmojiSvg = await emojiSvg({ emoji, isColored });
     border-radius: var(--radius-md);
     background-color: var(--c-surface);
     color: var(--c-surface-text);
-    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    box-shadow: var(--shadow-sm);
     width: 2.5rem;
     height: 2.5rem;
   }

--- a/src/components/ui/footer.astro
+++ b/src/components/ui/footer.astro
@@ -23,23 +23,16 @@
         gap: 0.5rem;
     }
 
+    footer :is(a, span, .separator) {
+        font-size: var(--fs-xs);
+        color: var(--c-sub);
+    }
+
     footer a {
-        font-size: var(--fs-xs);
-        color: var(--c-sub);
         text-decoration: none;
-    }
 
-    footer a:hover {
-        text-decoration: underline;
-    }
-
-    footer span {
-        font-size: var(--fs-xs);
-        color: var(--c-sub);
-    }
-
-    footer .separator {
-        font-size: var(--fs-xs);
-        color: var(--c-sub);
+        &:hover {
+            text-decoration: underline;
+        }
     }
 </style>

--- a/src/components/ui/image/image.astro
+++ b/src/components/ui/image/image.astro
@@ -44,13 +44,7 @@ const pictureProps = {
   }
 
   .image-border {
-    border-color: var(--uchu-yin-8);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .image-border {
-      border: 1px solid var(--c-border);
-    }
+    border: 1px solid light-dark(transparent, var(--c-border));
   }
 
   .image-caption {

--- a/src/features/blog/components/ui/blocks/alert-block.astro
+++ b/src/features/blog/components/ui/blocks/alert-block.astro
@@ -72,54 +72,27 @@ const IconComponent = alertIcons[alertType];
   }
 
   .alert--note {
-    border-color: oklch(from var(--uchu-blue-5) l c h / 50%);
-    color: var(--uchu-blue-6);
+    border-color: oklch(from light-dark(var(--uchu-blue-5), var(--uchu-blue-4)) l c h / 50%);
+    color: light-dark(var(--uchu-blue-6), var(--uchu-blue-4));
   }
 
   .alert--tip {
     border-color: oklch(from var(--uchu-green-5) l c h / 50%);
-    color: var(--uchu-green-6);
+    color: light-dark(var(--uchu-green-6), var(--uchu-green-5));
   }
 
   .alert--important {
-    border-color: oklch(from var(--uchu-purple-5) l c h / 50%);
-    color: var(--uchu-purple-6);
+    border-color: oklch(from light-dark(var(--uchu-purple-5), var(--uchu-purple-4)) l c h / 50%);
+    color: light-dark(var(--uchu-purple-6), var(--uchu-purple-4));
   }
 
   .alert--warning {
     border-color: oklch(from var(--uchu-orange-5) l c h / 50%);
-    color: var(--uchu-orange-6);
+    color: light-dark(var(--uchu-orange-6), var(--uchu-orange-5));
   }
 
   .alert--caution {
-    border-color: oklch(from var(--uchu-red-5) l c h / 50%);
-    color: var(--uchu-red-6);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .alert--note {
-      border-color: oklch(from var(--uchu-blue-4) l c h / 50%);
-      color: var(--uchu-blue-4);
-    }
-
-    .alert--tip {
-      border-color: oklch(from var(--uchu-green-5) l c h / 50%);
-      color: var(--uchu-green-5);
-    }
-
-    .alert--important {
-      border-color: oklch(from var(--uchu-purple-4) l c h / 50%);
-      color: var(--uchu-purple-4);
-    }
-
-    .alert--warning {
-      border-color: oklch(from var(--uchu-orange-5) l c h / 50%);
-      color: var(--uchu-orange-5);
-    }
-
-    .alert--caution {
-      border-color: oklch(from var(--uchu-red-4) l c h / 50%);
-      color: var(--uchu-red-4);
-    }
+    border-color: oklch(from light-dark(var(--uchu-red-5), var(--uchu-red-4)) l c h / 50%);
+    color: light-dark(var(--uchu-red-6), var(--uchu-red-4));
   }
 </style>

--- a/src/features/blog/components/ui/blocks/checkbox.astro
+++ b/src/features/blog/components/ui/blocks/checkbox.astro
@@ -23,7 +23,7 @@ const { type, checked, ...rest } = Astro.props;
     height: 1rem;
     border-radius: 0.125rem;
     border: 1px solid var(--c-primary);
-    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    box-shadow: var(--shadow-sm);
   }
 
   .checkbox:disabled {

--- a/src/features/blog/components/ui/blocks/link-card.astro
+++ b/src/features/blog/components/ui/blocks/link-card.astro
@@ -64,7 +64,7 @@ const { title, description, image } = await getMetadata(props.href);
     align-items: center;
     color: inherit;
     text-decoration: none;
-    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    box-shadow: var(--shadow-sm);
     transition: background-color 0.2s;
   }
 

--- a/src/features/blog/components/ui/blocks/tweet-block.astro
+++ b/src/features/blog/components/ui/blocks/tweet-block.astro
@@ -310,7 +310,7 @@ const blurryPhotos = tweet.photos
     border-radius: 0.75rem;
     border: 1px solid var(--c-border);
     object-fit: cover;
-    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    box-shadow: var(--shadow-sm);
   }
 
   .tweet-carousel {
@@ -347,7 +347,7 @@ const blurryPhotos = tweet.photos
     border-radius: 0.75rem;
     border: 1px solid var(--c-border);
     object-fit: cover;
-    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    box-shadow: var(--shadow-sm);
   }
 </style>
 

--- a/src/features/blog/components/ui/blocks/youtube-block.astro
+++ b/src/features/blog/components/ui/blocks/youtube-block.astro
@@ -45,7 +45,7 @@ const {
     display: block;
     max-width: 100%;
     border-radius: 1rem;
-    border-color: var(--uchu-yin-8);
+    border: 1px solid light-dark(transparent, var(--c-border));
     background-color: black;
     position: relative;
     cursor: pointer;
@@ -53,12 +53,6 @@ const {
     contain: content;
     background-position: center center;
     background-size: cover;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .youtube-embed {
-      border: 1px solid var(--c-border);
-    }
   }
 
   .youtube-embed::before {

--- a/src/features/blog/components/ui/table-of-content.astro
+++ b/src/features/blog/components/ui/table-of-content.astro
@@ -64,16 +64,10 @@ const { headings, class: className } = Astro.props;
   .toc-bar {
     height: 2px;
     border-radius: 1px;
-    background-color: var(--uchu-gray-2);
+    background-color: light-dark(var(--uchu-gray-2), var(--uchu-yin-8));
     transition: background-color 0.2s;
     width: 1rem;
     margin-left: 0;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .toc-bar {
-      background-color: var(--uchu-yin-8);
-    }
   }
 
   .toc-bar--indent {
@@ -83,10 +77,8 @@ const { headings, class: className } = Astro.props;
 
   .toc-bar :global(.active) {
     background: var(--c-surface-text);
-  }
 
-  @media (prefers-color-scheme: dark) {
-    .toc-bar :global(.active) {
+    @media (prefers-color-scheme: dark) {
       box-shadow: var(--uchu-gray-3) 0 0 3px;
     }
   }
@@ -102,7 +94,7 @@ const { headings, class: className } = Astro.props;
     width: 250px;
     max-height: 600px;
     margin-right: 0.625rem;
-    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    box-shadow: var(--shadow-sm);
     overflow-x: auto;
     opacity: 0;
     transform: translateX(1.5rem);

--- a/src/layouts/legal-layout.astro
+++ b/src/layouts/legal-layout.astro
@@ -41,47 +41,13 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
       ホーム
     </a>
   </div>
-  <h1 class="legal-title">{title}</h1>
+  <h1 class="page-title">{title}</h1>
   <section class="prose legal-body">
     <slot />
   </section>
 </BaseLayout>
 
 <style>
-  .back-link-wrapper {
-    margin-bottom: 1rem;
-  }
-
-  @media (width >= 1280px) {
-    .back-link-wrapper {
-      position: fixed;
-      top: 0;
-      transform: translateY(170px) translateX(-260px);
-    }
-  }
-
-  .back-link {
-    display: inline-flex;
-    gap: 0.25rem;
-    align-items: center;
-    color: var(--c-sub);
-    font-size: var(--fs-xs);
-    text-decoration: none;
-  }
-
-  .back-link:hover {
-    text-decoration: underline;
-  }
-
-  .back-icon {
-    width: 0.875rem;
-    height: 0.875rem;
-  }
-
-  .legal-title {
-    font-weight: var(--fw-medium);
-  }
-
   .legal-body {
     margin-top: 2rem;
   }

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -9,7 +9,7 @@ import BaseLayout from "#/layouts/base-layout.astro";
       noindex
       slot='seo'
   />
-  <h1 class="error-title">
+  <h1 class="page-title">
     ページが見つかりませんでした
   </h1>
   <a href="/" class="btn btn--outline">ホームに戻る</a>
@@ -22,9 +22,5 @@ import BaseLayout from "#/layouts/base-layout.astro";
     align-items: flex-start;
     justify-content: center;
     gap: 1rem;
-  }
-
-  .error-title {
-    font-weight: var(--fw-medium);
   }
 </style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -45,40 +45,6 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
 </BaseLayout>
 
 <style>
-  .back-link-wrapper {
-    margin-bottom: 1rem;
-  }
-
-  @media (width >= 1280px) {
-    .back-link-wrapper {
-      position: fixed;
-      top: 0;
-      transform: translateY(170px) translateX(-260px);
-    }
-  }
-
-  .back-link {
-    display: inline-flex;
-    gap: 0.25rem;
-    align-items: center;
-    color: var(--c-sub);
-    font-size: var(--fs-xs);
-    text-decoration: none;
-  }
-
-  .back-link:hover {
-    text-decoration: underline;
-  }
-
-  .back-icon {
-    width: 0.875rem;
-    height: 0.875rem;
-  }
-
-  .page-title {
-    font-weight: var(--fw-medium);
-  }
-
   .about-body {
     margin-top: 2rem;
   }

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -62,40 +62,6 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
 </BaseLayout>
 
 <style>
-  .back-link-wrapper {
-    margin-bottom: 1rem;
-  }
-
-  @media (width >= 1280px) {
-    .back-link-wrapper {
-      position: fixed;
-      top: 0;
-      transform: translateY(170px) translateX(-260px);
-    }
-  }
-
-  .back-link {
-    display: inline-flex;
-    gap: 0.25rem;
-    align-items: center;
-    color: var(--c-sub);
-    font-size: var(--fs-xs);
-    text-decoration: none;
-  }
-
-  .back-link:hover {
-    text-decoration: underline;
-  }
-
-  .back-icon {
-    width: 0.875rem;
-    height: 0.875rem;
-  }
-
-  .page-title {
-    font-weight: var(--fw-medium);
-  }
-
   .blog-nav {
     margin-top: 2rem;
   }

--- a/src/pages/blog/categories/[category]/[...page].astro
+++ b/src/pages/blog/categories/[category]/[...page].astro
@@ -84,40 +84,6 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
 </BaseLayout>
 
 <style>
-  .back-link-wrapper {
-    margin-bottom: 1rem;
-  }
-
-  @media (width >= 1280px) {
-    .back-link-wrapper {
-      position: fixed;
-      top: 0;
-      transform: translateY(170px) translateX(-260px);
-    }
-  }
-
-  .back-link {
-    display: inline-flex;
-    gap: 0.25rem;
-    align-items: center;
-    color: var(--c-sub);
-    font-size: var(--fs-xs);
-    text-decoration: none;
-  }
-
-  .back-link:hover {
-    text-decoration: underline;
-  }
-
-  .back-icon {
-    width: 0.875rem;
-    height: 0.875rem;
-  }
-
-  .page-title {
-    font-weight: var(--fw-medium);
-  }
-
   .blog-nav {
     margin-top: 2rem;
   }

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -108,40 +108,6 @@ const breadcrumbSchema: WithContext<BreadcrumbList> = {
 </BaseLayout>
 
 <style>
-  .back-link-wrapper {
-    margin-bottom: 1rem;
-  }
-
-  @media (width >= 1280px) {
-    .back-link-wrapper {
-      position: fixed;
-      top: 0;
-      transform: translateY(170px) translateX(-260px);
-    }
-  }
-
-  .back-link {
-    display: inline-flex;
-    gap: 0.25rem;
-    align-items: center;
-    color: var(--c-sub);
-    font-size: var(--fs-xs);
-    text-decoration: none;
-  }
-
-  .back-link:hover {
-    text-decoration: underline;
-  }
-
-  .back-icon {
-    width: 0.875rem;
-    height: 0.875rem;
-  }
-
-  .page-title {
-    font-weight: var(--fw-medium);
-  }
-
   .blog-entries {
     margin-top: 1.5rem;
   }

--- a/src/pages/bucket-list.astro
+++ b/src/pages/bucket-list.astro
@@ -143,40 +143,6 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
 </BaseLayout>
 
 <style>
-  .back-link-wrapper {
-    margin-bottom: 1rem;
-  }
-
-  @media (width >= 1280px) {
-    .back-link-wrapper {
-      position: fixed;
-      top: 0;
-      transform: translateY(170px) translateX(-260px);
-    }
-  }
-
-  .back-link {
-    display: inline-flex;
-    gap: 0.25rem;
-    align-items: center;
-    color: var(--c-sub);
-    font-size: var(--fs-xs);
-    text-decoration: none;
-  }
-
-  .back-link:hover {
-    text-decoration: underline;
-  }
-
-  .back-icon {
-    width: 0.875rem;
-    height: 0.875rem;
-  }
-
-  .page-title {
-    font-weight: var(--fw-medium);
-  }
-
   .page-description {
     font-size: var(--fs-sm);
     color: var(--c-sub);
@@ -230,7 +196,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     height: 1rem;
     border-radius: 2px;
     border: 1px solid var(--c-primary);
-    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    box-shadow: var(--shadow-sm);
     opacity: 0.5;
     margin-top: 0.25rem;
     flex-shrink: 0;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -58,6 +58,8 @@
   --fw-normal: 400;
   --fw-medium: 500;
   --fw-semibold: 600;
+
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 }
 
 /* ===== Base Styles ===== */
@@ -114,20 +116,22 @@ li {
   padding-inline-start: 0.625rem;
 }
 
-[data-footnotes]::before {
-  content: "";
-  display: block;
-  height: 1px;
-  width: 100%;
-  background-color: var(--c-hr);
-}
+[data-footnotes] {
+  &::before {
+    content: "";
+    display: block;
+    height: 1px;
+    width: 100%;
+    background-color: var(--c-hr);
+  }
 
-[data-footnotes] > ol {
-  margin-top: 1.5rem;
-}
+  & > ol {
+    margin-top: 1.5rem;
 
-[data-footnotes] > ol > li {
-  scroll-margin-top: 3rem;
+    & > li {
+      scroll-margin-top: 3rem;
+    }
+  }
 }
 
 [data-footnote-ref] {
@@ -142,17 +146,53 @@ li {
   margin-left: 0.25rem;
 }
 
-.expressive-code pre {
-  max-height: 650px !important;
+.expressive-code {
+  & pre {
+    max-height: 650px !important;
+  }
+
+  & .copy button {
+    border-radius: var(--radius-md) !important;
+
+    &::after {
+      mask-size: 0.8rem;
+      margin: 0.6rem !important;
+    }
+  }
 }
 
-.expressive-code .copy button {
-  border-radius: var(--radius-md) !important;
+/* ===== Common Layout Patterns ===== */
+
+.back-link-wrapper {
+  margin-bottom: 1rem;
+
+  @media (width >= 1280px) {
+    position: fixed;
+    top: 0;
+    transform: translateY(170px) translateX(-260px);
+  }
 }
 
-.expressive-code .copy button::after {
-  mask-size: 0.8rem;
-  margin: 0.6rem !important;
+.back-link {
+  display: inline-flex;
+  gap: 0.25rem;
+  align-items: center;
+  color: var(--c-sub);
+  font-size: var(--fs-xs);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.back-icon {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.page-title {
+  font-weight: var(--fw-medium);
 }
 
 /* ===== Button Components ===== */
@@ -179,60 +219,60 @@ li {
   padding: 0.5rem 1rem;
   background-color: var(--c-primary);
   color: var(--c-primary-text);
-  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-}
+  box-shadow: var(--shadow-sm);
 
-.btn:hover {
-  opacity: 0.9;
-}
+  &:hover {
+    opacity: 0.9;
+  }
 
-.btn:active:not(:disabled) {
-  transform: scale(0.95);
-}
+  &:active:not(:disabled) {
+    transform: scale(0.95);
+  }
 
-.btn:disabled {
-  pointer-events: none;
-  opacity: 0.5;
-}
+  &:disabled {
+    pointer-events: none;
+    opacity: 0.5;
+  }
 
-.btn:focus-visible {
-  border-color: var(--c-ring);
-  box-shadow: 0 0 0 3px oklch(from var(--c-ring) l c h / 50%);
-}
+  &:focus-visible {
+    border-color: var(--c-ring);
+    box-shadow: 0 0 0 3px oklch(from var(--c-ring) l c h / 50%);
+  }
 
-.btn svg {
-  pointer-events: none;
-  flex-shrink: 0;
-}
+  & svg {
+    pointer-events: none;
+    flex-shrink: 0;
 
-.btn svg:not([class*="size-"]) {
-  width: 1rem;
-  height: 1rem;
+    &:not([class*="size-"]) {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
 }
 
 .btn--outline {
   border: 1px solid var(--c-border);
   background-color: var(--c-bg);
   color: inherit;
-  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-}
+  box-shadow: var(--shadow-sm);
 
-.btn--outline:hover {
-  background-color: var(--c-surface);
-  color: var(--c-surface-text);
-  opacity: 1;
+  &:hover {
+    background-color: var(--c-surface);
+    color: var(--c-surface-text);
+    opacity: 1;
+  }
 }
 
 .btn--ghost {
   background-color: transparent;
   color: inherit;
   box-shadow: none;
-}
 
-.btn--ghost:hover {
-  background-color: var(--c-surface);
-  color: var(--c-surface-text);
-  opacity: 1;
+  &:hover {
+    background-color: var(--c-surface);
+    color: var(--c-surface-text);
+    opacity: 1;
+  }
 }
 
 .btn--size-icon {
@@ -258,20 +298,20 @@ li {
   border-radius: 9999px;
   border: 1px solid var(--c-border);
   opacity: 1;
-}
 
-.play-button:hover {
-  background-color: rgb(0 0 0 / 0.4);
-}
+  &:hover {
+    background-color: rgb(0 0 0 / 0.4);
+  }
 
-.play-button:active {
-  transform: translate(-50%, -50%) scale(0.95);
-}
+  &:active {
+    transform: translate(-50%, -50%) scale(0.95);
+  }
 
-.play-button svg {
-  width: 2rem;
-  height: 2rem;
-  fill: white;
+  & svg {
+    width: 2rem;
+    height: 2rem;
+    fill: white;
+  }
 }
 
 /* ===== Utility Classes ===== */

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -42,32 +42,24 @@
   margin-top: 0;
 }
 
-.prose p > a,
-.prose td > a,
-.prose li > a {
+.prose :is(p, td, li) > a {
   color: var(--c-link);
   font-weight: var(--fw-medium);
   text-decoration-thickness: 1px;
   text-underline-offset: 4px;
   transition: text-decoration 0.2s;
-}
 
-.prose p > a:hover,
-.prose td > a:hover,
-.prose li > a:hover {
-  text-decoration: underline;
-}
+  &:hover {
+    text-decoration: underline;
+  }
 
-.prose p > a:visited,
-.prose td > a:visited,
-.prose li > a:visited {
-  color: var(--c-link-visited);
-}
+  &:visited {
+    color: var(--c-link-visited);
 
-.prose p > a:visited svg,
-.prose td > a:visited svg,
-.prose li > a:visited svg {
-  stroke: inherit;
+    & svg {
+      stroke: inherit;
+    }
+  }
 }
 
 .prose strong {
@@ -118,25 +110,20 @@
   margin-block: 0.25rem;
 }
 
-.prose ol > li::marker {
-  color: var(--c-text);
-}
-
-.prose ul > li::marker,
-.prose ol > li::marker {
+.prose :is(ul, ol) > li::marker {
   color: var(--c-sub);
 }
 
 .prose .contains-task-list {
   list-style: none;
   padding-left: 0;
-}
 
-.prose .contains-task-list > li {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding-left: 0;
+  & > li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding-left: 0;
+  }
 }
 
 .prose hr {
@@ -174,10 +161,10 @@
 
 .prose tbody tr {
   border-bottom: 1px solid light-dark(var(--uchu-gray-1), var(--uchu-yin-9));
-}
 
-.prose tbody tr:last-child {
-  border-bottom: 0;
+  &:last-child {
+    border-bottom: 0;
+  }
 }
 
 .prose tbody td {


### PR DESCRIPTION
## Summary

Consolidate common CSS patterns into global styles and remove duplicate component-scoped styles across 18 files.

## Changes

- Add shared layout patterns (back-link, back-link-wrapper, page-title) to global.css
- Refactor CSS selectors to use nested syntax for better organization
- Remove local style blocks from layout pages (legal, 404, about, bucket-list)
- Remove local style blocks from blog pages (pagination, category, tag pages)
- Remove local style blocks from UI components (9 components total)
- Add --shadow-sm design token to global CSS variables

## Benefits

- Reduced CSS duplication (386 lines removed)
- Centralized style management
- Improved code organization with nested selectors
- Easier maintenance and future style updates