### PR TITLE
[main] style: restore font-smoothing properties for better rendering

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -76,6 +76,8 @@ html {
   scrollbar-width: thin;
   background-color: var(--c-bg);
   color: var(--c-text);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 h1 {


### PR DESCRIPTION
- Restore -webkit-font-smoothing and -moz-osx-font-smoothing properties
- Fix text appearing overly bold due to browser rendering
- Improve font rendering consistency across browsers