### PR TITLE
[main] chore: disable vercel automatic git-based deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": {
-      "renovate/*": false
-    }
-  },
-  "installCommand": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm install",
-  "buildCommand": "pnpm build"
+    "deploymentEnabled": false
+  }
 }


### PR DESCRIPTION
- Disable automatic CI/CD deployments triggered by git pushes on Vercel
- All deployments must now be initiated manually via `pnpm deploy`
- Remove unused Vercel build and install commands