### PR TITLE
[main] chore: remove Vercel environment variable dependencies

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -55,7 +55,6 @@ export default defineConfig({
   image: {
     remotePatterns: [{ protocol: "https" }],
     service:
-      process.env.VERCEL_ENV === "preview" ||
       process.env.GITHUB_ACTIONS === "true"
         ? { entrypoint: "astro/assets/services/noop" }
         : { entrypoint: "astro/assets/services/sharp" },
@@ -71,22 +70,6 @@ export default defineConfig({
       GITHUB_ACCESS_TOKEN: envField.string({
         context: "server",
         access: "secret",
-      }),
-      PUBLIC_VERCEL_ENV: envField.string({
-        context: "client",
-        access: "public",
-        optional: true,
-        default: "development",
-      }),
-      PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: envField.string({
-        context: "client",
-        access: "public",
-        optional: true,
-      }),
-      PUBLIC_VERCEL_URL: envField.string({
-        context: "client",
-        access: "public",
-        optional: true,
       }),
       NODE_ENV: envField.enum({
         context: "client",

--- a/src/__tests__/utils/base-url.test.ts
+++ b/src/__tests__/utils/base-url.test.ts
@@ -1,40 +1,8 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 describe("BASE_URL", () => {
-  afterEach(() => {
-    vi.resetModules();
-  });
-
-  it("returns production URL when VERCEL_ENV is production", async () => {
-    vi.doMock("astro:env/client", () => ({
-      PUBLIC_VERCEL_ENV: "production",
-      PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: "kkhys.me",
-      PUBLIC_VERCEL_URL: "preview-abc.vercel.app",
-    }));
-
+  it("returns site URL from import.meta.env.SITE", async () => {
     const { BASE_URL } = await import("#/utils/base-url");
-    expect(BASE_URL).toBe("https://kkhys.me");
-  });
-
-  it("returns preview URL when VERCEL_ENV is preview", async () => {
-    vi.doMock("astro:env/client", () => ({
-      PUBLIC_VERCEL_ENV: "preview",
-      PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: "kkhys.me",
-      PUBLIC_VERCEL_URL: "preview-abc.vercel.app",
-    }));
-
-    const { BASE_URL } = await import("#/utils/base-url");
-    expect(BASE_URL).toBe("https://preview-abc.vercel.app");
-  });
-
-  it("returns localhost when no URL is available", async () => {
-    vi.doMock("astro:env/client", () => ({
-      PUBLIC_VERCEL_ENV: undefined,
-      PUBLIC_VERCEL_PROJECT_PRODUCTION_URL: undefined,
-      PUBLIC_VERCEL_URL: undefined,
-    }));
-
-    const { BASE_URL } = await import("#/utils/base-url");
-    expect(BASE_URL).toBe("http://localhost:4321");
+    expect(BASE_URL).toBe("https://example.com");
   });
 });

--- a/src/lib/api/metadata.ts
+++ b/src/lib/api/metadata.ts
@@ -1,4 +1,4 @@
-import { NODE_ENV, PUBLIC_VERCEL_ENV } from "astro:env/client";
+import { NODE_ENV } from "astro:env/client";
 import fetchSiteMetadata, { type Metadata } from "fetch-site-metadata";
 
 const metadataCache = new Map<string, Metadata>();
@@ -7,10 +7,7 @@ export const getMetadata = async (url: string) => {
   const cachedMetadata = metadataCache.get(url);
   if (cachedMetadata) return cachedMetadata;
 
-  const isProduction =
-    NODE_ENV === "production" && PUBLIC_VERCEL_ENV === "production";
-
-  if (!isProduction) {
+  if (NODE_ENV !== "production" || process.env.CI) {
     const fallbackMetadata = {
       title: "リンク",
       description: "外部リンク",

--- a/src/utils/base-url.ts
+++ b/src/utils/base-url.ts
@@ -1,12 +1,1 @@
-import {
-  PUBLIC_VERCEL_ENV,
-  PUBLIC_VERCEL_PROJECT_PRODUCTION_URL,
-  PUBLIC_VERCEL_URL,
-} from "astro:env/client";
-
-const url =
-  PUBLIC_VERCEL_ENV === "production"
-    ? PUBLIC_VERCEL_PROJECT_PRODUCTION_URL
-    : PUBLIC_VERCEL_URL;
-
-export const BASE_URL = url ? `https://${url}` : "http://localhost:4321";
+export const BASE_URL = import.meta.env.SITE ?? "http://localhost:4321";


### PR DESCRIPTION
- Remove PUBLIC_VERCEL_ENV, PUBLIC_VERCEL_PROJECT_PRODUCTION_URL, PUBLIC_VERCEL_URL from env schema
- Replace Vercel env checks with NODE_ENV and CI for metadata fetching
- Use import.meta.env.SITE for BASE_URL instead of Vercel URL variables
- Update tests to reflect environment-agnostic behavior
- Enable local production builds (pnpm build) to work correctly