### PR TITLE
[main] fix: add annotated tag message in release script

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -33,7 +33,7 @@ const CURRENT_BRANCH = (await $`git rev-parse --abbrev-ref HEAD`.text()).trim();
 
 if (!isDryRun) {
   await $`git checkout main`;
-  await $`git tag -f ${version}`;
+  await $`git tag -f -m ${version} ${version}`;
   await $`git push -f origin ${version}`;
   await $`git checkout ${CURRENT_BRANCH}`;
   console.log(`✅ Released tag: ${version} and returned to ${CURRENT_BRANCH}`);


### PR DESCRIPTION
- Add -m flag to git tag command for annotated tags
- Improves metadata tracking for releases
- Tags now include message instead of being lightweight