### PR TITLE
[main] fix: prevent emoji icon shrinking on mobile layout

### DIFF
--- a/src/components/ui/emoji-eye-catch.astro
+++ b/src/components/ui/emoji-eye-catch.astro
@@ -25,6 +25,7 @@ const rowEmojiSvg = await emojiSvg({ emoji, isColored });
 <style>
   .eye-catch {
     display: inline-flex;
+    flex-shrink: 0;
     user-select: none;
     align-items: center;
     justify-content: center;

--- a/src/features/blog/components/ui/entry-list.astro
+++ b/src/features/blog/components/ui/entry-list.astro
@@ -84,10 +84,6 @@ const {
     gap: 1rem;
   }
 
-  .entry-emoji {
-    flex-shrink: 0;
-  }
-
   .entry-date {
     flex-shrink: 0;
     font-size: var(--fs-sm);


### PR DESCRIPTION
- Add flex-shrink: 0 to emoji container component to prevent layout shrinking
- Remove unreachable fallback style in entry list component
- Fix emoji icons displaying with inconsistent sizes on mobile devices