### PR TITLE
[main] refactor: remove ambientMode feature

### DIFF
--- a/src/components/ui/image/image.astro
+++ b/src/components/ui/image/image.astro
@@ -6,7 +6,7 @@ import type { CustomImageProps } from "./types";
 
 type Props = CustomImageProps;
 
-const { class: className, ambientMode, title, ...rest } = Astro.props;
+const { class: className, title, ...rest } = Astro.props;
 
 const blurryImage = await getImage({
   ...(rest as UnresolvedImageTransform),
@@ -26,13 +26,13 @@ const pictureProps = {
 
 {title ? (
   <figure>
-    <div class:list={["blur-load", "image-rounded", "image-border", ambientMode && "ambient-mode", className]}>
+    <div class:list={["blur-load", "image-rounded", "image-border", className]}>
       <AstroPicture {...pictureProps} />
     </div>
     <figcaption class="image-caption">{title}</figcaption>
   </figure>
 ) : (
-  <div class:list={["blur-load", "image-rounded", "image-border", ambientMode && "ambient-mode", className]}>
+  <div class:list={["blur-load", "image-rounded", "image-border", className]}>
     <AstroPicture {...pictureProps} />
   </div>
 )}
@@ -63,21 +63,6 @@ const pictureProps = {
     &.image-loaded {
       background: none;
       filter: blur(0);
-    }
-  }
-
-  .ambient-mode {
-    position: relative;
-
-    &::before {
-      content: '';
-      position: absolute;
-      inset: -1.5%;
-      max-width: 100vw;
-      background: var(--bg-image) center / cover no-repeat;
-      filter: blur(64px);
-      opacity: 0.25;
-      z-index: -10;
     }
   }
 </style>

--- a/src/components/ui/image/types.ts
+++ b/src/components/ui/image/types.ts
@@ -1,5 +1,3 @@
 import type { LocalImageProps, RemoteImageProps } from "astro:assets";
 
-export type CustomImageProps = {
-  ambientMode?: boolean;
-} & (LocalImageProps | RemoteImageProps);
+export type CustomImageProps = LocalImageProps | RemoteImageProps;

--- a/src/features/blog/components/image-handler.astro
+++ b/src/features/blog/components/image-handler.astro
@@ -14,6 +14,6 @@ const { src, alt, ...props } = Astro.props;
   typeof src === "string" ? (
     <img src={src} alt={alt} {...props} />
   ) : (
-    <Image src={src} alt={alt} ambientMode {...props} />
+    <Image src={src} alt={alt} {...props} />
   )
 }


### PR DESCRIPTION
- Remove ambientMode optional property from CustomImageProps type
- Remove ambient light effect CSS (.ambient-mode class and ::before pseudo-element)
- Simplify Image component by removing unused prop