### PR TITLE
[main] style: remove unused text-wrap balance rule

### DIFF
--- a/src/features/blog/components/ui/entry-list.astro
+++ b/src/features/blog/components/ui/entry-list.astro
@@ -82,10 +82,6 @@ const {
     display: flex;
     align-items: center;
     gap: 1rem;
-
-    & p {
-      text-wrap: balance;
-    }
   }
 
   .entry-date {


### PR DESCRIPTION
- Remove unused text-wrap: balance rule from .entry-left selector