### PR TITLE
[main] fix: unwrap images from paragraphs in MDX

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -13,6 +13,7 @@ import remarkBlockQuoteAlert from "./src/lib/remark-blockquote-alert";
 import remarkFootnoteTitle from "./src/lib/remark-footnote-title";
 import remarkLinkCard from "./src/lib/remark-link-card";
 import remarkTweetBlock from "./src/lib/remark-tweet-block";
+import remarkUnwrapImages from "./src/lib/remark-unwrap-images";
 import remarkVideoBlock from "./src/lib/remark-video-block";
 import remarkYoutubeBlock from "./src/lib/remark-youtube-block";
 
@@ -33,6 +34,7 @@ export default defineConfig({
     syntaxHighlight: false,
     smartypants: false,
     remarkPlugins: [
+      remarkUnwrapImages,
       remarkTweetBlock,
       remarkVideoBlock,
       remarkYoutubeBlock,

--- a/src/__tests__/lib/remark-unwrap-images.test.ts
+++ b/src/__tests__/lib/remark-unwrap-images.test.ts
@@ -1,0 +1,89 @@
+import type { Heading, Image, Paragraph, Root, Text } from "mdast";
+import { describe, expect, it } from "vitest";
+import remarkUnwrapImages from "#/lib/remark-unwrap-images";
+
+const makeImage = (url: string, alt = ""): Image => ({
+  type: "image",
+  url,
+  alt,
+});
+
+const makeParagraph = (children: Paragraph["children"]): Paragraph => ({
+  type: "paragraph",
+  children,
+});
+
+const makeTree = (children: Root["children"]): Root => ({
+  type: "root",
+  children,
+});
+
+describe("remarkUnwrapImages", () => {
+  it("unwraps an image that is the sole child of a paragraph", () => {
+    const tree = makeTree([makeParagraph([makeImage("./photo.jpg")])]);
+
+    remarkUnwrapImages()(tree);
+
+    const node = tree.children[0] as Image;
+    expect(node.type).toBe("image");
+    expect(node.url).toBe("./photo.jpg");
+  });
+
+  it("skips paragraphs with multiple children", () => {
+    const tree = makeTree([
+      makeParagraph([
+        makeImage("./photo.jpg"),
+        { type: "text", value: " caption" } as Text,
+      ]),
+    ]);
+
+    remarkUnwrapImages()(tree);
+
+    const node = tree.children[0] as Paragraph;
+    expect(node.type).toBe("paragraph");
+  });
+
+  it("skips paragraphs with non-image children", () => {
+    const tree = makeTree([
+      makeParagraph([{ type: "text", value: "hello" } as Text]),
+    ]);
+
+    remarkUnwrapImages()(tree);
+
+    const node = tree.children[0] as Paragraph;
+    expect(node.type).toBe("paragraph");
+  });
+
+  it("handles multiple images in separate paragraphs", () => {
+    const tree = makeTree([
+      makeParagraph([makeImage("./a.jpg")]),
+      makeParagraph([makeImage("./b.jpg")]),
+    ]);
+
+    remarkUnwrapImages()(tree);
+
+    expect(tree.children).toHaveLength(2);
+    expect((tree.children[0] as Image).type).toBe("image");
+    expect((tree.children[0] as Image).url).toBe("./a.jpg");
+    expect((tree.children[1] as Image).type).toBe("image");
+    expect((tree.children[1] as Image).url).toBe("./b.jpg");
+  });
+
+  it("preserves non-paragraph siblings", () => {
+    const tree = makeTree([
+      { type: "heading", depth: 1, children: [] },
+      makeParagraph([makeImage("./photo.jpg")]),
+      makeParagraph([{ type: "text", value: "text" } as Text]),
+    ]);
+
+    remarkUnwrapImages()(tree);
+
+    expect(tree.children).toHaveLength(3);
+    const first = tree.children[0] as Heading;
+    const second = tree.children[1] as Image;
+    const third = tree.children[2] as Paragraph;
+    expect(first.type).toBe("heading");
+    expect(second.type).toBe("image");
+    expect(third.type).toBe("paragraph");
+  });
+});

--- a/src/lib/remark-unwrap-images.ts
+++ b/src/lib/remark-unwrap-images.ts
@@ -1,0 +1,25 @@
+import type { Root } from "mdast";
+import { SKIP, visit } from "unist-util-visit";
+
+// Unwrap images that are the sole child of a paragraph node.
+// Prevents invalid <p><figure>...</figure></p> HTML when Astro
+// transforms images with titles into <figure> elements.
+const remarkUnwrapImages = () => (tree: Root) => {
+  visit(tree, "paragraph", (node, index, parent) => {
+    const child = node.children[0];
+    if (
+      !parent ||
+      typeof index !== "number" ||
+      node.children.length !== 1 ||
+      !child ||
+      child.type !== "image"
+    ) {
+      return;
+    }
+
+    parent.children.splice(index, 1, child);
+    return [SKIP, index];
+  });
+};
+
+export default remarkUnwrapImages;


### PR DESCRIPTION
- Implement remark-unwrap-images plugin to prevent invalid <p><figure>...</figure></p> HTML
- Add comprehensive test coverage for the plugin with 5 test cases
- Register plugin in MDX pipeline at the start for early processing