### PR TITLE
[main] style: improve heading margins balance

### DIFF
--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -29,13 +29,13 @@
 }
 
 .prose h2 {
-  margin-block: 4rem 1rem;
+  margin-block: 4rem 1.5rem;
   border-bottom: 1px solid var(--c-border);
   padding-block: 0.625rem;
 }
 
 .prose h3 {
-  margin-block: 3rem 1rem;
+  margin-block: 2.5rem 1.5rem;
 }
 
 .prose :is(h2, h3) + * {


### PR DESCRIPTION
- Adjust h2 margin-bottom from 1rem to 1.5rem for better spacing
- Adjust h3 margin-top from 3rem to 2.5rem and margin-bottom to 1.5rem
- Improve visual hierarchy and spacing in blog post prose