### PR TITLE
main: style: darken heading anchor icon in dark mode

### DIFF
--- a/src/features/blog/components/ui/blocks/heading.astro
+++ b/src/features/blog/components/ui/blocks/heading.astro
@@ -59,24 +59,24 @@ const { as: Tag, id, ...rest } = Astro.props;
     width: 1.25rem;
     height: 1.25rem;
     border-radius: var(--radius-md);
-    background-color: light-dark(var(--uchu-gray-1), var(--uchu-yin-8));
-    box-shadow: inset 0 0 0 1px light-dark(var(--uchu-gray-3), var(--uchu-gray-7));
+    background-color: light-dark(var(--uchu-gray-1), var(--uchu-yin-9));
+    box-shadow: inset 0 0 0 1px light-dark(var(--uchu-gray-3), var(--uchu-yin-7));
     transition: box-shadow 0.2s;
   }
 
   .anchor-box:hover {
-    background-color: light-dark(var(--uchu-gray-1), var(--uchu-yin-7));
-    box-shadow: inset 0 0 0 1px light-dark(var(--uchu-gray-5), var(--uchu-gray-6));
+    background-color: light-dark(var(--uchu-gray-1), var(--uchu-yin-8));
+    box-shadow: inset 0 0 0 1px light-dark(var(--uchu-gray-5), var(--uchu-yin-6));
   }
 
   .anchor-icon {
     width: 0.75rem;
     height: 0.75rem;
-    stroke: light-dark(var(--uchu-gray-5), var(--uchu-gray-4));
+    stroke: light-dark(var(--uchu-gray-5), var(--uchu-yin-6));
     transition: stroke 0.2s;
   }
 
   .anchor-box:hover .anchor-icon {
-    stroke: light-dark(var(--uchu-gray-5), white);
+    stroke: light-dark(var(--uchu-gray-5), var(--uchu-yin-4));
   }
 </style>


### PR DESCRIPTION
## Summary
- Adjust heading anchor icon colors in dark mode to be less prominent
- Use darker yin palette colors instead of bright gray palette
- Improve visual consistency with dark theme background

## Test plan
- [x] Verify anchor icon appearance in dark mode on blog posts
- [x] Verify anchor icon is less visually prominent
- [x] Verify hover state still shows clear visual feedback
- [x] Test on tablet/desktop (768px+) where icon appears