### PR TITLE
[main] fix: correct footnote backref line-height spacing

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -158,6 +158,7 @@
   [data-footnote-backref] {
     font-size: var(--fs-lg);
     font-family: var(--font-mono);
+    line-height: 0;
     margin-left: 0.25rem;
   }
 


### PR DESCRIPTION
- Add line-height: 0 to [data-footnote-backref] element
- Prevent larger font size from affecting line box height calculation
- Ensure consistent vertical spacing in footnotes