### PR TITLE
[main] feat: auto-extract blog descriptions from MDX body

### DIFF
--- a/scripts/create-entry.ts
+++ b/scripts/create-entry.ts
@@ -8,7 +8,6 @@ import { generateBech32m } from "#/utils/hash";
 
 interface Frontmatter {
   title: string;
-  description: string;
   emoji: string;
   category: CategoryTitle;
   tags: string;
@@ -99,7 +98,6 @@ const generateMDXContent = (frontmatter: Frontmatter) => {
 
   return `---
 title: ${frontmatter.title}
-description: ${frontmatter.description}
 emoji: ${frontmatter.emoji}
 category: ${frontmatter.category}
 tags: ${frontmatter.tags}
@@ -116,8 +114,6 @@ const main = async () => {
 
   try {
     const title = await prompt("タイトルを入力してください: ");
-    const description =
-      (await prompt('説明を入力してください (空白で"xxx"): ')) || "xxx";
     const emoji = (await prompt("絵文字を入力してください (空白で☑️): ")) || "☑️";
     const category = await selectCategory();
     const publishedAt = await inputPublishedDate();
@@ -126,7 +122,6 @@ const main = async () => {
 
     const frontmatter: Frontmatter = {
       title,
-      description,
       emoji,
       category,
       tags: "[]",
@@ -152,7 +147,6 @@ const main = async () => {
     console.log(`📄 ファイル: ${filePath}`);
     console.log(`🏷️  スラッグ: ${frontmatter.slug}`);
     console.log(`📅 日付: ${frontmatter.publishedAt}`);
-    console.log(`📝 説明: ${frontmatter.description}`);
   } catch (error) {
     console.error("エラーが発生しました:", error);
     process.exit(1);

--- a/src/__tests__/lib/json-ld.test.ts
+++ b/src/__tests__/lib/json-ld.test.ts
@@ -23,7 +23,6 @@ describe("websiteSchema", () => {
 describe("getBlogPostingSchema", () => {
   const baseData = {
     title: "Test Post",
-    description: "A test blog post",
     emoji: "🧪",
     category: "Tech" as const,
     publishedAt: new Date("2024-01-15T00:00:00Z"),
@@ -34,6 +33,7 @@ describe("getBlogPostingSchema", () => {
     const schema = getBlogPostingSchema({
       id: "test123",
       data: baseData,
+      description: "A test blog post",
     });
 
     expect(schema["@context"]).toBe("https://schema.org");
@@ -48,6 +48,7 @@ describe("getBlogPostingSchema", () => {
       getBlogPostingSchema({
         id: "test123",
         data: invalidData,
+        description: "test",
       }),
     ).toThrow("Category not found: Invalid");
   });
@@ -56,6 +57,7 @@ describe("getBlogPostingSchema", () => {
     const schema = getBlogPostingSchema({
       id: "test123",
       data: { ...baseData, tags: ["TypeScript", "React"] },
+      description: "test",
     });
 
     expect(schema.keywords).toContain("TypeScript");
@@ -66,6 +68,7 @@ describe("getBlogPostingSchema", () => {
     const schema = getBlogPostingSchema({
       id: "test123",
       data: { ...baseData, tags: ["NonExistentTag"] },
+      description: "test",
     });
 
     expect(schema.keywords).toBe("NonExistentTag");
@@ -78,6 +81,7 @@ describe("getBlogPostingSchema", () => {
         ...baseData,
         updatedAt: new Date("2024-06-01T00:00:00Z"),
       },
+      description: "test",
     });
 
     expect(schema.dateModified).toBe("2024-06-01T00:00:00.000Z");
@@ -87,6 +91,7 @@ describe("getBlogPostingSchema", () => {
     const schema = getBlogPostingSchema({
       id: "test123",
       data: baseData,
+      description: "test",
     });
 
     expect(schema.dateModified).toBe("2024-01-15T00:00:00.000Z");
@@ -97,6 +102,7 @@ describe("getBlogPostingSchema", () => {
     const schema = getBlogPostingSchema({
       id: "abc123",
       data: baseData,
+      description: "test",
     });
 
     expect(schema.url).toBe("https://example.com/blog/posts/abc123");
@@ -106,6 +112,7 @@ describe("getBlogPostingSchema", () => {
     const schema = getBlogPostingSchema({
       id: "test123",
       data: baseData,
+      description: "test",
     });
 
     expect(schema.articleSection).toBe("プログラミング");

--- a/src/__tests__/utils/extract-description.test.ts
+++ b/src/__tests__/utils/extract-description.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import { extractDescription } from "#/utils/extract-description";
+
+describe("extractDescription", () => {
+  it("extracts plain text from simple MDX body", () => {
+    const body = "これはテスト記事です。\n\n本文の2段落目です。";
+    expect(extractDescription(body)).toBe(
+      "これはテスト記事です。 本文の2段落目です。",
+    );
+  });
+
+  it("returns empty string for empty body", () => {
+    expect(extractDescription("")).toBe("");
+    expect(extractDescription("   ")).toBe("");
+  });
+
+  it("returns full text when shorter than maxLength", () => {
+    const body = "短いテキスト。";
+    expect(extractDescription(body)).toBe("短いテキスト。");
+  });
+
+  it("truncates at punctuation boundary in latter half with ellipsis", () => {
+    // Build a string longer than 120 chars with punctuation in the latter half
+    const body =
+      "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホ。" +
+      "マミムメモヤユヨラリルレロワヲンABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    const result = extractDescription(body);
+    expect(result.endsWith("。")).toBe(true);
+  });
+
+  it("truncates at maxLength with ellipsis when no punctuation in latter half", () => {
+    const body = "a".repeat(200);
+    const result = extractDescription(body);
+    expect(result.length).toBe(120);
+  });
+
+  it("removes import statements", () => {
+    const body =
+      'import { Component } from "react";\nimport styles from "./styles.css";\n\n本文テキストです。';
+    expect(extractDescription(body)).toBe("本文テキストです。");
+  });
+
+  it("removes fenced code blocks", () => {
+    const body =
+      "コードの前。\n\n```typescript\nconst x = 1;\nconsole.log(x);\n```\n\nコードの後。";
+    expect(extractDescription(body)).toBe("コードの前。 コードの後。");
+  });
+
+  it("removes alert blockquotes", () => {
+    const body =
+      "テキスト前。\n\n> [!NOTE]\n> これはノートです。\n> 2行目。\n\nテキスト後。";
+    expect(extractDescription(body)).toBe("テキスト前。 テキスト後。");
+  });
+
+  it("removes blockquote markers but keeps text", () => {
+    const body = "> 引用テキストです。\n\n通常テキスト。";
+    expect(extractDescription(body)).toBe("引用テキストです。 通常テキスト。");
+  });
+
+  it("removes headings", () => {
+    const body = "## 見出し\n\n段落テキスト。\n\n### 小見出し\n\n別の段落。";
+    expect(extractDescription(body)).toBe("段落テキスト。 別の段落。");
+  });
+
+  it("removes images", () => {
+    const body =
+      '前のテキスト。\n\n![alt text](./image.jpg "title")\n\n後のテキスト。';
+    expect(extractDescription(body)).toBe("前のテキスト。 後のテキスト。");
+  });
+
+  it("preserves link text but removes URL", () => {
+    const body = "これは[リンクテキスト](https://example.com)を含む文章です。";
+    expect(extractDescription(body)).toBe(
+      "これはリンクテキストを含む文章です。",
+    );
+  });
+
+  it("removes inline code", () => {
+    const body = "変数 `foo` を使います。";
+    expect(extractDescription(body)).toBe("変数 を使います。");
+  });
+
+  it("removes bold and italic markers", () => {
+    const body = "これは**太字**と*斜体*と***両方***のテスト。";
+    expect(extractDescription(body)).toBe("これは太字と斜体と両方のテスト。");
+  });
+
+  it("removes horizontal rules", () => {
+    const body = "前のテキスト。\n\n---\n\n後のテキスト。";
+    expect(extractDescription(body)).toBe("前のテキスト。 後のテキスト。");
+  });
+
+  it("removes HTML tags", () => {
+    const body = "テキスト<br />改行後<wbr>テキスト。";
+    expect(extractDescription(body)).toBe("テキスト改行後テキスト。");
+  });
+
+  it("removes footnote references", () => {
+    const body = "これは脚注付き[^1]のテキストです。";
+    expect(extractDescription(body)).toBe("これは脚注付きのテキストです。");
+  });
+
+  it("respects custom maxLength with ellipsis", () => {
+    const body = "あ".repeat(50);
+    const result = extractDescription(body, 30);
+    expect(result.length).toBe(30);
+  });
+
+  it("handles complex MDX with multiple elements", () => {
+    const body = `import { Component } from "react";
+
+## はじめに
+
+ブログというものは不思議な魅力がある。
+
+初めてブログを書き始めたのは高校2年生の頃だったと思う。
+
+\`\`\`js
+console.log("hello");
+\`\`\`
+
+![写真](./photo.jpg)
+
+詳しくは[こちら](https://example.com)を参照。`;
+
+    const result = extractDescription(body);
+    expect(result).toContain("ブログというものは不思議な魅力がある");
+    expect(result).not.toContain("import");
+    expect(result).not.toContain("console.log");
+    expect(result).not.toContain("![");
+    expect(result).not.toContain("https://");
+    expect(result).toContain("こちら");
+  });
+});

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -8,7 +8,6 @@ const blog = defineCollection({
   loader: glob({ pattern: "**/*.mdx", base: "./content/blog" }),
   schema: z.object({
     title: z.string(),
-    description: z.string(),
     emoji: z.string(),
     category: z.enum(categoryTitles as [string, ...string[]]),
     tags: z.array(z.enum(allTagTitles as [string, ...string[]])).optional(),

--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -18,6 +18,7 @@ import { BASE_URL } from "#/utils/base-url";
 
 interface Props extends InferEntrySchema<"blog"> {
   id: string;
+  description: string;
 }
 
 const {

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -32,7 +32,10 @@ export const websiteSchema: WithContext<WebSite> = {
 export const getBlogPostingSchema = ({
   id,
   data,
-}: Pick<CollectionEntry<"blog">, "id" | "data">): WithContext<BlogPosting> => {
+  description,
+}: Pick<CollectionEntry<"blog">, "id" | "data"> & {
+  description: string;
+}): WithContext<BlogPosting> => {
   const categoryObject = getCategoryByTitle(data.category);
 
   if (!categoryObject) {
@@ -52,7 +55,7 @@ export const getBlogPostingSchema = ({
       "@type": "ImageObject",
       url: `${import.meta.env.SITE}/api/og/${id}.png`,
     },
-    description: data.description,
+    description,
     publisher: personSchema,
     author: personSchema,
     datePublished: data.publishedAt.toISOString(),

--- a/src/pages/blog/posts/[id].astro
+++ b/src/pages/blog/posts/[id].astro
@@ -9,6 +9,7 @@ import BlogLayout from "#/layouts/blog-layout.astro";
 import { getLastUpdatedTimeByFile } from "#/lib/api/github";
 import { getBlogPostingSchema } from "#/lib/json-ld";
 import { convertDateToString } from "#/utils/date";
+import { extractDescription } from "#/utils/extract-description";
 
 export const getStaticPaths = (async () =>
   (await getPublicBlogEntries()).map((entry) => {
@@ -18,11 +19,12 @@ export const getStaticPaths = (async () =>
       },
       props: {
         entry,
+        description: extractDescription(entry.body ?? ""),
       },
     };
   })) satisfies GetStaticPaths;
 
-const { entry } = Astro.props;
+const { entry, description } = Astro.props;
 const { Content } = await render(entry);
 const publishedAtString = convertDateToString(entry.data.publishedAt);
 
@@ -43,7 +45,11 @@ if (process.env.VERCEL) {
   }
 }
 
-const blogPostingSchema = getBlogPostingSchema(entry);
+const blogPostingSchema = getBlogPostingSchema({
+  id: entry.id,
+  data: entry.data,
+  description,
+});
 const categoryObject = getCategoryByTitle(entry.data.category);
 
 if (!categoryObject) {
@@ -81,7 +87,7 @@ const jsonLd = {
 };
 ---
 
-<BlogLayout id={entry.id} publishedAtString={publishedAtString} {...entry.data}>
+<BlogLayout id={entry.id} publishedAtString={publishedAtString} description={description} {...entry.data}>
   <script
       is:inline
       type='application/ld+json'

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -4,6 +4,7 @@ import type { APIContext } from "astro";
 import { siteConfig } from "#/config/site";
 import { getCategoryBySlug } from "#/features/blog/config/category";
 import { getPublicBlogEntries } from "#/features/blog/utils/entry";
+import { extractDescription } from "#/utils/extract-description";
 
 export const GET = async (context: APIContext) =>
   rss({
@@ -11,8 +12,9 @@ export const GET = async (context: APIContext) =>
     title: siteConfig.title,
     description: siteConfig.description,
     site: context.site ?? context.url.origin,
-    items: (await getPublicBlogEntries()).map(({ id, data }) => ({
+    items: (await getPublicBlogEntries()).map(({ id, data, body }) => ({
       title: data.title,
+      description: extractDescription(body ?? ""),
       pubDate: data.publishedAt,
       link: `/blog/posts/${id}`,
       categories: [getCategoryBySlug(data.category.toLowerCase())?.label ?? ""],

--- a/src/utils/extract-description.ts
+++ b/src/utils/extract-description.ts
@@ -1,0 +1,82 @@
+/**
+ * Extracts a plain-text description from an MDX body string.
+ * Strips Markdown/MDX syntax and truncates at a punctuation boundary.
+ */
+export const extractDescription = (body: string, maxLength = 120): string => {
+  if (!body.trim()) return "";
+
+  let text = body;
+
+  // Remove import statements
+  text = text.replace(/^import\s+.*$/gm, "");
+
+  // Remove fenced code blocks
+  text = text.replace(/```[\s\S]*?```/g, "");
+
+  // Remove alert blockquotes (> [!NOTE] etc. and continuation lines)
+  text = text.replace(
+    /^> \[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\].*(?:\n(?:>\s?.*)?)*$/gm,
+    "",
+  );
+
+  // Remove blockquote markers
+  text = text.replace(/^>\s?/gm, "");
+
+  // Remove headings
+  text = text.replace(/^#{1,6}\s+.*$/gm, "");
+
+  // Remove images
+  text = text.replace(/!\[.*?\]\(.*?\)/g, "");
+
+  // Convert links to text only
+  text = text.replace(/\[([^\]]*)\]\(.*?\)/g, "$1");
+
+  // Remove inline code
+  text = text.replace(/`[^`]+`/g, "");
+
+  // Remove bold/italic markers
+  text = text.replace(/\*{1,3}(.*?)\*{1,3}/g, "$1");
+  text = text.replace(/_{1,3}(.*?)_{1,3}/g, "$1");
+
+  // Remove horizontal rules
+  text = text.replace(/^[-*_]{3,}$/gm, "");
+
+  // Remove HTML tags
+  text = text.replace(/<[^>]+>/g, "");
+
+  // Remove footnote references
+  text = text.replace(/\[\^[^\]]*\]/g, "");
+
+  // Normalize whitespace and join
+  text = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (text.length <= maxLength) return text;
+
+  // Truncate at a punctuation boundary within the latter half
+  const searchStart = Math.floor(maxLength / 2);
+  const candidate = text.slice(0, maxLength);
+  const punctuationPattern = /[。、！？!?]/g;
+  let lastIndex = -1;
+
+  for (
+    let match = punctuationPattern.exec(candidate);
+    match !== null;
+    match = punctuationPattern.exec(candidate)
+  ) {
+    if (match.index >= searchStart) {
+      lastIndex = match.index;
+    }
+  }
+
+  if (lastIndex >= 0) {
+    return text.slice(0, lastIndex + 1);
+  }
+
+  return text.slice(0, maxLength);
+};


### PR DESCRIPTION
## Summary

Removes manual `description` frontmatter from blog posts by automatically extracting clean, truncated plain text from MDX body content. Simplifies blog authoring workflow.

## Changes

- Add `extractDescription()` utility to strip Markdown/MDX syntax and truncate at sentence boundaries (120 chars max)
- Remove `description` field from blog content schema (pages collection keeps it)
- Integrate auto-extraction into [id].astro, blog-layout.astro, json-ld.ts, and rss.xml.ts
- Remove description prompt from create-entry.ts interactive mode
- Update 55 blog MDX files to remove manual description entries

## Test Plan

- [x] Unit tests: 174/174 passing (19 new extract-description tests)
- [x] Type check: 0 errors
- [x] Lint: All files passing
- [x] Build validation: Production build succeeds