### PR TITLE
[main] feat: update blog date format to dot-separated YYYY.MM.DD

### DIFF
--- a/src/__tests__/utils/date.test.ts
+++ b/src/__tests__/utils/date.test.ts
@@ -2,19 +2,19 @@ import { describe, expect, it } from "vitest";
 import { convertDateToString } from "#/utils/date";
 
 describe("convertDateToString", () => {
-  it("formats a regular date in Japanese locale", () => {
-    expect(convertDateToString(new Date("2024-01-15"))).toBe("2024年1月15日");
+  it("formats a regular date with dot-separated format", () => {
+    expect(convertDateToString(new Date("2024-01-15"))).toBe("2024.01.15");
   });
 
   it("formats year-end date", () => {
-    expect(convertDateToString(new Date("2024-12-31"))).toBe("2024年12月31日");
+    expect(convertDateToString(new Date("2024-12-31"))).toBe("2024.12.31");
   });
 
   it("formats year-start date", () => {
-    expect(convertDateToString(new Date("2024-01-01"))).toBe("2024年1月1日");
+    expect(convertDateToString(new Date("2024-01-01"))).toBe("2024.01.01");
   });
 
   it("formats leap year date", () => {
-    expect(convertDateToString(new Date("2024-02-29"))).toBe("2024年2月29日");
+    expect(convertDateToString(new Date("2024-02-29"))).toBe("2024.02.29");
   });
 });

--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -208,6 +208,7 @@ const currentDate = new Date();
 
   .post-date {
     font-size: var(--fs-sm);
+    font-variant-numeric: tabular-nums;
     color: var(--c-sub);
   }
 

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,6 +1,6 @@
-export const convertDateToString = (date: Date) =>
-  new Intl.DateTimeFormat("ja-JP", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  }).format(date);
+export const convertDateToString = (date: Date) => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}.${m}.${d}`;
+};


### PR DESCRIPTION
## Summary
- Change blog date format from Japanese locale (e.g. `2024年1月15日`) to dot-separated format (e.g. `2024.01.15`) on both listing and detail pages
- Add `font-variant-numeric: tabular-nums` to post date in blog detail page to align digit widths (already set on listing page)

## Test plan
- [x] All unit tests pass with `pnpm test`