### PR TITLE
[main] refactor: unify SEO and navigation components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,13 @@ Coverage targets: `src/utils/*.ts`, `src/lib/*.ts`, `src/lib/api/*.ts` (excludin
 - **CSS**: Vanilla CSS with `light-dark()` for theme switching, scoped `<style>` blocks, `class:list` directive for conditional classes.
 - **Japanese content**: BudouX for line breaking, bilingual support (English titles/slugs, Japanese labels).
 
+## Type Definition Placement
+
+1. **`.astro` files**: Inline `interface Props` in the frontmatter
+2. **`.ts` files**: Co-locate types tightly coupled with logic in the same file
+3. **Shared types (3+ consumers)**: Extract to a dedicated `types.ts`
+4. **Config constants**: Derive types with `as const satisfies` pattern
+
 ## Content Review System
 
 When asked to review an article ("この記事のレビューを行なってください"), automatically launch all 4 review agents in parallel via the `Task` tool: `content-reviewer`, `language-editor`, `readability-enhancer`, `technical-writer`. Integrate results into a unified report.

--- a/src/__tests__/lib/api/cache.test.ts
+++ b/src/__tests__/lib/api/cache.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { createCache, createResolvedCache } from "#/lib/api/cache";
+
+describe("createCache", () => {
+  it("returns the fetcher result", async () => {
+    const cache = createCache<string>();
+    const result = await cache("key", () => Promise.resolve("value"));
+    expect(result).toBe("value");
+  });
+
+  it("calls fetcher only once for the same key", async () => {
+    const cache = createCache<string>();
+    const fetcher = vi.fn(() => Promise.resolve("value"));
+
+    await cache("key", fetcher);
+    await cache("key", fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls fetcher for different keys", async () => {
+    const cache = createCache<string>();
+    const fetcher = vi.fn(() => Promise.resolve("value"));
+
+    await cache("a", fetcher);
+    await cache("b", fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches the Promise (deduplicates concurrent requests)", () => {
+    const cache = createCache<string>();
+    const fetcher = vi.fn(
+      () =>
+        new Promise<string>((resolve) => setTimeout(() => resolve("v"), 10)),
+    );
+
+    const p1 = cache("key", fetcher);
+    const p2 = cache("key", fetcher);
+
+    expect(p1).toBe(p2);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createResolvedCache", () => {
+  it("returns the fetcher result", async () => {
+    const cache = createResolvedCache<string>();
+    const result = await cache("key", () => Promise.resolve("value"));
+    expect(result).toBe("value");
+  });
+
+  it("calls fetcher only once for the same key", async () => {
+    const cache = createResolvedCache<string>();
+    const fetcher = vi.fn(() => Promise.resolve("value"));
+
+    await cache("key", fetcher);
+    await cache("key", fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls fetcher for different keys", async () => {
+    const cache = createResolvedCache<string>();
+    const fetcher = vi.fn(() => Promise.resolve("value"));
+
+    await cache("a", fetcher);
+    await cache("b", fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches the resolved value (not the Promise)", async () => {
+    const cache = createResolvedCache<string>();
+    let callCount = 0;
+    const fetcher = () => Promise.resolve(`value-${++callCount}`);
+
+    const r1 = await cache("key", fetcher);
+    const r2 = await cache("key", fetcher);
+
+    expect(r1).toBe("value-1");
+    expect(r2).toBe("value-1");
+  });
+});

--- a/src/components/seo/base-seo.astro
+++ b/src/components/seo/base-seo.astro
@@ -2,9 +2,9 @@
 import { siteConfig } from "#/config/site";
 
 interface Props {
-  title?: string;
-  description?: string;
-  noindex?: boolean;
+  title?: string | undefined;
+  description?: string | undefined;
+  noindex?: boolean | undefined;
 }
 
 const { title, description, noindex = false } = Astro.props;

--- a/src/components/seo/open-graph.astro
+++ b/src/components/seo/open-graph.astro
@@ -7,13 +7,15 @@ interface Props {
   image: string;
   imageAlt: string;
   type?: "website" | "article" | "profile" | undefined;
-  article?: {
-    publishedTime?: string;
-    modifiedTime?: string;
-    authors?: string[];
-    section?: string;
-    tags?: string[];
-  } | undefined;
+  article?:
+    | {
+        publishedTime?: string;
+        modifiedTime?: string;
+        authors?: string[];
+        section?: string;
+        tags?: string[];
+      }
+    | undefined;
 }
 
 const {

--- a/src/components/seo/open-graph.astro
+++ b/src/components/seo/open-graph.astro
@@ -6,14 +6,14 @@ interface Props {
   description: string;
   image: string;
   imageAlt: string;
-  type?: "website" | "article" | "profile";
+  type?: "website" | "article" | "profile" | undefined;
   article?: {
     publishedTime?: string;
     modifiedTime?: string;
     authors?: string[];
     section?: string;
     tags?: string[];
-  };
+  } | undefined;
 }
 
 const {

--- a/src/components/seo/seo.astro
+++ b/src/components/seo/seo.astro
@@ -9,17 +9,26 @@ interface Props {
   description?: string | undefined;
   image?: string | undefined;
   type?: "website" | "article" | "profile" | undefined;
-  article?: {
-    publishedTime?: string;
-    modifiedTime?: string;
-    authors?: string[];
-    section?: string;
-    tags?: string[];
-  } | undefined;
+  article?:
+    | {
+        publishedTime?: string;
+        modifiedTime?: string;
+        authors?: string[];
+        section?: string;
+        tags?: string[];
+      }
+    | undefined;
   noindex?: boolean | undefined;
 }
 
-const { title, description, image, type = "website", article, noindex } = Astro.props;
+const {
+  title,
+  description,
+  image,
+  type = "website",
+  article,
+  noindex,
+} = Astro.props;
 
 const ogTitle = title ? `${title}｜${siteConfig.title}` : siteConfig.title;
 const ogDescription = description ?? siteConfig.description;

--- a/src/components/seo/seo.astro
+++ b/src/components/seo/seo.astro
@@ -1,0 +1,44 @@
+---
+import BaseSEO from "#/components/seo/base-seo.astro";
+import OpenGraph from "#/components/seo/open-graph.astro";
+import TwitterCard from "#/components/seo/twitter-card.astro";
+import { siteConfig } from "#/config/site";
+
+interface Props {
+  title?: string | undefined;
+  description?: string | undefined;
+  image?: string | undefined;
+  type?: "website" | "article" | "profile" | undefined;
+  article?: {
+    publishedTime?: string;
+    modifiedTime?: string;
+    authors?: string[];
+    section?: string;
+    tags?: string[];
+  } | undefined;
+  noindex?: boolean | undefined;
+}
+
+const { title, description, image, type = "website", article, noindex } = Astro.props;
+
+const ogTitle = title ? `${title}｜${siteConfig.title}` : siteConfig.title;
+const ogDescription = description ?? siteConfig.description;
+---
+
+<BaseSEO title={title} description={description} noindex={noindex} />
+{image && (
+  <OpenGraph
+    title={ogTitle}
+    description={ogDescription}
+    image={image}
+    imageAlt={ogTitle}
+    type={type}
+    article={article}
+  />
+  <TwitterCard
+    title={ogTitle}
+    description={ogDescription}
+    image={image}
+    imageAlt={ogTitle}
+  />
+)}

--- a/src/components/ui/breadcrumb.astro
+++ b/src/components/ui/breadcrumb.astro
@@ -1,0 +1,107 @@
+---
+import ArrowLeftIcon from "#/components/icons/arrow-left.svg";
+
+interface BreadcrumbSegment {
+  label: string;
+  href: string;
+  isCurrent?: boolean | undefined;
+}
+
+interface Props {
+  segments: [BreadcrumbSegment, ...BreadcrumbSegment[]];
+  class?: string | null | undefined;
+}
+
+const { segments, class: className } = Astro.props;
+const first = segments[0];
+const isSimple = segments.length === 1;
+---
+
+<div class:list={["breadcrumb", className]}>
+  {isSimple ? (
+    <a href={first.href} class="breadcrumb-link">
+      <ArrowLeftIcon class="breadcrumb-icon" />
+      {first.label}
+    </a>
+  ) : (
+    <span class="breadcrumb-inner">
+      <a href={first.href} class="breadcrumb-link">
+        <ArrowLeftIcon class="breadcrumb-icon" />
+        {first.label}
+      </a>
+      {segments.slice(1).map((segment) => (
+        <>
+          <span class="breadcrumb-sep">/</span>
+          {segment.isCurrent ? (
+            <b class="breadcrumb-current">
+              <a href={segment.href} class="breadcrumb-current-link">
+                {segment.label}
+              </a>
+            </b>
+          ) : (
+            <a href={segment.href} class="breadcrumb-link">
+              {segment.label}
+            </a>
+          )}
+        </>
+      ))}
+    </span>
+  )}
+</div>
+
+<style>
+  .breadcrumb {
+    margin-bottom: 1rem;
+  }
+
+  @media (width >= 1280px) {
+    .breadcrumb {
+      position: fixed;
+      top: 0;
+      transform: translateY(170px) translateX(-260px);
+    }
+  }
+
+  .breadcrumb-inner {
+    display: inline-flex;
+    gap: 0.375rem;
+    align-items: center;
+    font-size: var(--fs-xs);
+  }
+
+  .breadcrumb-link {
+    display: inline-flex;
+    gap: 0.25rem;
+    align-items: center;
+    color: var(--c-sub);
+    font-size: var(--fs-xs);
+    font-feature-settings: "palt";
+    text-decoration: none;
+  }
+
+  .breadcrumb-link:hover {
+    text-decoration: underline;
+  }
+
+  .breadcrumb-icon {
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+
+  .breadcrumb-sep {
+    color: var(--c-sub);
+  }
+
+  .breadcrumb-current {
+    font-weight: var(--fw-semibold);
+  }
+
+  .breadcrumb-current-link {
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .breadcrumb-current-link:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -1,13 +1,11 @@
 ---
 import type { InferEntrySchema } from "astro:content";
 import { emojiSvg } from "#/components/emoji-svg";
-import ArrowLeftIcon from "#/components/icons/arrow-left.svg";
-import BaseSEO from "#/components/seo/base-seo.astro";
-import OpenGraph from "#/components/seo/open-graph.astro";
-import TwitterCard from "#/components/seo/twitter-card.astro";
+import SEO from "#/components/seo/seo.astro";
+import Breadcrumb from "#/components/ui/breadcrumb.astro";
 import EmojiEyeCatch from "#/components/ui/emoji-eye-catch.astro";
 import Separator from "#/components/ui/separator.astro";
-import { me, siteConfig } from "#/config/site";
+import { me } from "#/config/site";
 import EntryList from "#/features/blog/components/ui/entry-list.astro";
 import TagCloud from "#/features/blog/components/ui/tag-cloud.astro";
 import { getCategoryBySlug } from "#/features/blog/config/category";
@@ -54,51 +52,31 @@ const tagCloudItems = allTagCloudItems.filter(({ title }) =>
 
 const relatedPosts = await getRelatedPosts({ id, category });
 
-const seoTitle = `${title}｜${siteConfig.title}`;
 const seoImage = `${BASE_URL}/api/og/${id}.png`;
 const currentDate = new Date();
 ---
 
 <BaseLayout>
-  <Fragment slot='seo'>
-    <BaseSEO title={title} description={description} />
-    <OpenGraph
-      title={seoTitle}
-      description={description}
-      image={seoImage}
-      imageAlt={seoTitle}
-      type="article"
-      article={{
-        publishedTime: (publishedAt ?? currentDate).toISOString(),
-        modifiedTime: (updatedAt ?? publishedAt ?? currentDate).toISOString(),
-        authors: [me.name],
-        section: categoryObject.label,
-        tags: tagCloudItems.map((tag) => tag.label),
-      }}
-    />
-    <TwitterCard
-      title={seoTitle}
-      description={description}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-  </Fragment>
+  <SEO
+    title={title}
+    description={description}
+    image={seoImage}
+    type="article"
+    article={{
+      publishedTime: (publishedAt ?? currentDate).toISOString(),
+      modifiedTime: (updatedAt ?? publishedAt ?? currentDate).toISOString(),
+      authors: [me.name],
+      section: categoryObject.label,
+      tags: tagCloudItems.map((tag) => tag.label),
+    }}
+    slot='seo'
+  />
   <slot name='head' slot='head' />
   <section>
-    <div class="breadcrumb">
-      <span class="breadcrumb-inner">
-        <a href="/blog" class="breadcrumb-link">
-          <ArrowLeftIcon class="breadcrumb-icon" />
-          ブログ
-        </a>
-        <span class="breadcrumb-sep">/</span>
-        <b class="breadcrumb-category">
-          <a href={`/blog/categories/${categorySlug}`} class="breadcrumb-category-link">
-            {categoryObject.label}
-          </a>
-        </b>
-      </span>
-    </div>
+    <Breadcrumb segments={[
+      { label: "ブログ", href: "/blog" },
+      { label: categoryObject.label, href: `/blog/categories/${categorySlug}`, isCurrent: true },
+    ]} />
     <div class:list={[status === 'draft' && 'draft-header']}>
       <EmojiEyeCatch emoji={emoji} />
       {status === "draft" && (
@@ -130,60 +108,6 @@ const currentDate = new Date();
 </BaseLayout>
 
 <style>
-  .breadcrumb {
-    margin-bottom: 1rem;
-  }
-
-  @media (width >= 1280px) {
-    .breadcrumb {
-      position: fixed;
-      top: 0;
-      transform: translateY(170px) translateX(-260px);
-    }
-  }
-
-  .breadcrumb-inner {
-    display: inline-flex;
-    gap: 0.375rem;
-    align-items: center;
-    font-size: var(--fs-xs);
-  }
-
-  .breadcrumb-link {
-    display: inline-flex;
-    gap: 0.25rem;
-    align-items: center;
-    color: var(--c-sub);
-    font-feature-settings: "palt";
-    text-decoration: none;
-  }
-
-  .breadcrumb-link:hover {
-    text-decoration: underline;
-  }
-
-  .breadcrumb-icon {
-    width: 0.875rem;
-    height: 0.875rem;
-  }
-
-  .breadcrumb-sep {
-    color: var(--c-sub);
-  }
-
-  .breadcrumb-category {
-    font-weight: var(--fw-semibold);
-  }
-
-  .breadcrumb-category-link {
-    text-decoration: none;
-    color: inherit;
-  }
-
-  .breadcrumb-category-link:hover {
-    text-decoration: underline;
-  }
-
   .draft-header {
     display: flex;
     justify-content: space-between;

--- a/src/layouts/page-layout.astro
+++ b/src/layouts/page-layout.astro
@@ -1,10 +1,7 @@
 ---
 import type { InferEntrySchema } from "astro:content";
-import ArrowLeftIcon from "#/components/icons/arrow-left.svg";
-import BaseSEO from "#/components/seo/base-seo.astro";
-import OpenGraph from "#/components/seo/open-graph.astro";
-import TwitterCard from "#/components/seo/twitter-card.astro";
-import { siteConfig } from "#/config/site";
+import SEO from "#/components/seo/seo.astro";
+import Breadcrumb from "#/components/ui/breadcrumb.astro";
 import BaseLayout from "#/layouts/base-layout.astro";
 import { BASE_URL } from "#/utils/base-url";
 
@@ -12,35 +9,19 @@ interface Props extends InferEntrySchema<"pages"> {}
 
 const { title, description } = Astro.props;
 
-const seoTitle = `${title}｜${siteConfig.title}`;
-const seoDescription = description ?? siteConfig.description;
 const seoImage = `${BASE_URL}/api/og/default.png`;
 ---
 
 <BaseLayout>
-  <Fragment slot='seo'>
-    <BaseSEO title={title} description={seoDescription} />
-    <OpenGraph
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-      type="article"
-    />
-    <TwitterCard
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-  </Fragment>
+  <SEO
+    title={title}
+    description={description}
+    image={seoImage}
+    type="article"
+    slot='seo'
+  />
   <slot name='head' slot='head'/>
-  <div class="back-link-wrapper">
-    <a href="/" class="back-link">
-      <ArrowLeftIcon class="back-icon" />
-      ホーム
-    </a>
-  </div>
+  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
   <h1 class="page-title">{title}</h1>
   <section class="prose page-body">
     <slot />

--- a/src/lib/api/cache.ts
+++ b/src/lib/api/cache.ts
@@ -1,0 +1,27 @@
+/**
+ * Factory functions for in-memory caching of async data.
+ */
+
+/** Cache that stores the Promise itself (deduplicates concurrent requests). */
+export const createCache = <T>() => {
+  const store = new Map<string, Promise<T>>();
+  return (key: string, fetcher: () => Promise<T>): Promise<T> => {
+    const cached = store.get(key);
+    if (cached) return cached;
+    const promise = fetcher();
+    store.set(key, promise);
+    return promise;
+  };
+};
+
+/** Cache that stores resolved values (awaits before caching). */
+export const createResolvedCache = <T>() => {
+  const store = new Map<string, T>();
+  return async (key: string, fetcher: () => Promise<T>): Promise<T> => {
+    const cached = store.get(key);
+    if (cached) return cached;
+    const value = await fetcher();
+    store.set(key, value);
+    return value;
+  };
+};

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -1,10 +1,11 @@
 import { GITHUB_ACCESS_TOKEN } from "astro:env/server";
+import { createCache } from "#/lib/api/cache";
 
 type LastUpdatedTimeData = {
   lastUpdatedTime: string | undefined;
 };
 
-const cache = new Map<string, Promise<LastUpdatedTimeData>>();
+const cache = createCache<LastUpdatedTimeData>();
 
 const fetchLastUpdatedTime = async (
   filePath: string,
@@ -41,10 +42,5 @@ const fetchLastUpdatedTime = async (
 
 export const getLastUpdatedTimeByFile = (
   filePath: string,
-): Promise<LastUpdatedTimeData> => {
-  const cached = cache.get(filePath);
-  if (cached) return cached;
-  const promise = fetchLastUpdatedTime(filePath);
-  cache.set(filePath, promise);
-  return promise;
-};
+): Promise<LastUpdatedTimeData> =>
+  cache(filePath, () => fetchLastUpdatedTime(filePath));

--- a/src/lib/api/metadata.ts
+++ b/src/lib/api/metadata.ts
@@ -1,38 +1,30 @@
 import { NODE_ENV } from "astro:env/client";
 import fetchSiteMetadata, { type Metadata } from "fetch-site-metadata";
+import { createResolvedCache } from "#/lib/api/cache";
 
-const metadataCache = new Map<string, Metadata>();
+const cache = createResolvedCache<Metadata>();
 
-export const getMetadata = async (url: string) => {
-  const cachedMetadata = metadataCache.get(url);
-  if (cachedMetadata) return cachedMetadata;
+export const getMetadata = (url: string) =>
+  cache(url, async () => {
+    if (NODE_ENV !== "production" || process.env.CI) {
+      return {
+        title: "リンク",
+        description: "外部リンク",
+        image: undefined,
+        icon: undefined,
+      };
+    }
 
-  if (NODE_ENV !== "production" || process.env.CI) {
-    const fallbackMetadata = {
-      title: "リンク",
-      description: "外部リンク",
-      image: undefined,
-      icon: undefined,
-    };
-    metadataCache.set(url, fallbackMetadata);
-    return fallbackMetadata;
-  }
-
-  return fetchSiteMetadata(url, {
-    suppressAdditionalRequest: true,
-    headers: {
-      accept: "text/html",
-      "accept-language": "ja,en-US;q=0.7,en;q=0.3",
-    },
-  })
-    .then((metadata) => {
-      metadataCache.set(url, metadata);
-      return metadata;
-    })
-    .catch(() => ({
+    return fetchSiteMetadata(url, {
+      suppressAdditionalRequest: true,
+      headers: {
+        accept: "text/html",
+        "accept-language": "ja,en-US;q=0.7,en;q=0.3",
+      },
+    }).catch(() => ({
       title: "Not Found",
       description: "Page not found",
-      image: null,
-      icon: null,
+      image: undefined,
+      icon: undefined,
     }));
-};
+  });

--- a/src/lib/api/tweet.ts
+++ b/src/lib/api/tweet.ts
@@ -1,6 +1,7 @@
 import type { EnrichedTweet } from "react-tweet";
 import { enrichTweet } from "react-tweet";
 import type { Tweet } from "react-tweet/api";
+import { createCache } from "#/lib/api/cache";
 
 /**
  * Generate token for Twitter Syndication API
@@ -12,7 +13,7 @@ const getToken = (id: string) => {
     .replace(/(0+|\.)/g, "");
 };
 
-const cache = new Map<string, Promise<EnrichedTweet>>();
+const cache = createCache<EnrichedTweet>();
 
 const fetchTweet = async (id: string): Promise<EnrichedTweet> => {
   const URL = "https://cdn.syndication.twimg.com/tweet-result?";
@@ -33,10 +34,5 @@ const fetchTweet = async (id: string): Promise<EnrichedTweet> => {
  * @param id - Tweet ID
  * @returns Enriched tweet data
  */
-export const getTweetData = (id: string): Promise<EnrichedTweet> => {
-  const cached = cache.get(id);
-  if (cached) return cached;
-  const promise = fetchTweet(id);
-  cache.set(id, promise);
-  return promise;
-};
+export const getTweetData = (id: string): Promise<EnrichedTweet> =>
+  cache(id, () => fetchTweet(id));

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,21 +1,16 @@
 ---
-import ArrowLeftIcon from "#/components/icons/arrow-left.svg";
-import BaseSEO from "#/components/seo/base-seo.astro";
+import SEO from "#/components/seo/seo.astro";
+import Breadcrumb from "#/components/ui/breadcrumb.astro";
 import BaseLayout from "#/layouts/base-layout.astro";
 ---
 
 <BaseLayout>
-  <BaseSEO
+  <SEO
       title='見つかりませんでした'
       noindex
       slot='seo'
   />
-  <div class="back-link-wrapper">
-    <a href="/" class="back-link">
-      <ArrowLeftIcon class="back-icon" />
-      ホーム
-    </a>
-  </div>
+  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
   <h1 class="page-title">
     ページが見つかりませんでした
   </h1>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,12 +1,9 @@
 ---
 import { getEntry, render } from "astro:content";
 import profileImage from "#/assets/images/profile.jpg";
-import ArrowLeftIcon from "#/components/icons/arrow-left.svg";
-import BaseSEO from "#/components/seo/base-seo.astro";
-import OpenGraph from "#/components/seo/open-graph.astro";
-import TwitterCard from "#/components/seo/twitter-card.astro";
+import SEO from "#/components/seo/seo.astro";
+import Breadcrumb from "#/components/ui/breadcrumb.astro";
 import Image from "#/components/ui/image/image.astro";
-import { siteConfig } from "#/config/site";
 import ContentWrapper from "#/features/pages/components/content-wrapper.astro";
 import BaseLayout from "#/layouts/base-layout.astro";
 import { BASE_URL } from "#/utils/base-url";
@@ -19,33 +16,17 @@ if (!about) {
 
 const { Content: AboutContent } = await render(about);
 
-const seoTitle = `About｜${siteConfig.title}`;
-const seoDescription = about.data.description;
 const seoImage = `${BASE_URL}/api/og/default.png`;
 ---
 
 <BaseLayout>
-  <Fragment slot='seo'>
-    <BaseSEO title="About" description={seoDescription} />
-    <OpenGraph
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-    <TwitterCard
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-  </Fragment>
-  <div class="back-link-wrapper">
-    <a href="/" class="back-link">
-      <ArrowLeftIcon class="back-icon" />
-      ホーム
-    </a>
-  </div>
+  <SEO
+    title="About"
+    description={about.data.description}
+    image={seoImage}
+    slot='seo'
+  />
+  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
   <h1 class="page-title">
     About
   </h1>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,11 +1,8 @@
 ---
 import type { PaginateFunction } from "astro";
-import ArrowLeftIcon from "#/components/icons/arrow-left.svg";
-import BaseSEO from "#/components/seo/base-seo.astro";
-import OpenGraph from "#/components/seo/open-graph.astro";
-import TwitterCard from "#/components/seo/twitter-card.astro";
+import SEO from "#/components/seo/seo.astro";
+import Breadcrumb from "#/components/ui/breadcrumb.astro";
 import { countPerPage } from "#/config/constant";
-import { siteConfig } from "#/config/site";
 import CategoryNavigation from "#/features/blog/components/ui/category-navigation.astro";
 import EntryList from "#/features/blog/components/ui/entry-list.astro";
 import Pagination from "#/features/blog/components/ui/pagination.astro";
@@ -24,33 +21,18 @@ export const getStaticPaths = async ({
 
 const { page } = Astro.props;
 
-const seoTitle = `ブログ｜${siteConfig.title}`;
 const seoDescription = "Keisuke Hayashiのブログ";
 const seoImage = `${BASE_URL}/api/og/default.png`;
 ---
 
 <BaseLayout>
-  <Fragment slot='seo'>
-    <BaseSEO title="ブログ" description={seoDescription} />
-    <OpenGraph
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-    <TwitterCard
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-  </Fragment>
-  <div class="back-link-wrapper">
-    <a href="/" class="back-link">
-      <ArrowLeftIcon class="back-icon" />
-      ホーム
-    </a>
-  </div>
+  <SEO
+    title="ブログ"
+    description={seoDescription}
+    image={seoImage}
+    slot='seo'
+  />
+  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
   <section>
     <h1 class="page-title">ブログ</h1>
     <CategoryNavigation class="blog-nav" />

--- a/src/pages/blog/categories/[category]/[...page].astro
+++ b/src/pages/blog/categories/[category]/[...page].astro
@@ -1,11 +1,8 @@
 ---
 import type { PaginateFunction } from "astro";
-import ArrowLeftIcon from "#/components/icons/arrow-left.svg";
-import BaseSEO from "#/components/seo/base-seo.astro";
-import OpenGraph from "#/components/seo/open-graph.astro";
-import TwitterCard from "#/components/seo/twitter-card.astro";
+import SEO from "#/components/seo/seo.astro";
+import Breadcrumb from "#/components/ui/breadcrumb.astro";
 import { countPerPage } from "#/config/constant";
-import { siteConfig } from "#/config/site";
 import CategoryNavigation from "#/features/blog/components/ui/category-navigation.astro";
 import EntryList from "#/features/blog/components/ui/entry-list.astro";
 import Pagination from "#/features/blog/components/ui/pagination.astro";
@@ -41,33 +38,18 @@ if (!category) {
   throw new Error(`Category "${categorySlug}" not found`);
 }
 
-const seoTitle = `${category.label}｜${siteConfig.title}`;
 const seoDescription = `「${category.label}」カテゴリーの記事一覧`;
 const seoImage = `${BASE_URL}/api/og/default.png`;
 ---
 
 <BaseLayout>
-  <Fragment slot='seo'>
-    <BaseSEO title={category.label} description={seoDescription} />
-    <OpenGraph
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-    <TwitterCard
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-  </Fragment>
-  <div class="back-link-wrapper">
-    <a href="/" class="back-link">
-      <ArrowLeftIcon class="back-icon" />
-      ホーム
-    </a>
-  </div>
+  <SEO
+    title={category.label}
+    description={seoDescription}
+    image={seoImage}
+    slot='seo'
+  />
+  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
   <section>
     <h1 class="page-title">ブログ</h1>
     <CategoryNavigation class="blog-nav" />

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -1,12 +1,9 @@
 ---
 import type { PaginateFunction } from "astro";
 import type { BreadcrumbList, WithContext } from "schema-dts";
-import ArrowLeftIcon from "#/components/icons/arrow-left.svg";
-import BaseSEO from "#/components/seo/base-seo.astro";
-import OpenGraph from "#/components/seo/open-graph.astro";
-import TwitterCard from "#/components/seo/twitter-card.astro";
+import SEO from "#/components/seo/seo.astro";
+import Breadcrumb from "#/components/ui/breadcrumb.astro";
 import { countPerPage } from "#/config/constant";
-import { siteConfig } from "#/config/site";
 import EntryList from "#/features/blog/components/ui/entry-list.astro";
 import Pagination from "#/features/blog/components/ui/pagination.astro";
 import { getTagBySlug } from "#/features/blog/config/tag";
@@ -41,7 +38,6 @@ if (!tag) {
   throw new Error(`Tag "${tagSlug}" not found`);
 }
 
-const seoTitle = `${tag.label}｜${siteConfig.title}`;
 const seoDescription = `「${tag.label}」のタグがついた記事一覧`;
 const seoImage = `${BASE_URL}/api/og/default.png`;
 
@@ -66,33 +62,19 @@ const breadcrumbSchema: WithContext<BreadcrumbList> = {
 ---
 
 <BaseLayout>
-  <Fragment slot='seo'>
-    <BaseSEO title={tag.label} description={seoDescription} />
-    <OpenGraph
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-    <TwitterCard
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-  </Fragment>
+  <SEO
+    title={tag.label}
+    description={seoDescription}
+    image={seoImage}
+    slot='seo'
+  />
   <script
       is:inline
       type='application/ld+json'
       set:html={JSON.stringify(breadcrumbSchema)}
       slot='head'
   />
-  <div class="back-link-wrapper">
-    <a href="/blog" class="back-link">
-      <ArrowLeftIcon class="back-icon" />
-      ブログ
-    </a>
-  </div>
+  <Breadcrumb segments={[{ label: "ブログ", href: "/blog" }]} />
   <section>
     <h1 class="page-title">#{tag.label}</h1>
   </section>

--- a/src/pages/bucket-list.astro
+++ b/src/pages/bucket-list.astro
@@ -1,14 +1,11 @@
 ---
 import { getEntry } from "astro:content";
 import Budoux from "#/components/budoux.astro";
-import ArrowLeftIcon from "#/components/icons/arrow-left.svg";
 import CheckIcon from "#/components/icons/check.svg";
 import MoveUpRightIcon from "#/components/icons/move-up-right.svg";
-import BaseSEO from "#/components/seo/base-seo.astro";
-import OpenGraph from "#/components/seo/open-graph.astro";
-import TwitterCard from "#/components/seo/twitter-card.astro";
+import SEO from "#/components/seo/seo.astro";
+import Breadcrumb from "#/components/ui/breadcrumb.astro";
 import Separator from "#/components/ui/separator.astro";
-import { siteConfig } from "#/config/site";
 import BaseLayout from "#/layouts/base-layout.astro";
 import { getLastUpdatedTimeByFile } from "#/lib/api/github";
 import { BASE_URL } from "#/utils/base-url";
@@ -53,34 +50,19 @@ const completedItems = bucketList.data.reduce(
   0,
 );
 
-const seoTitle = `バケットリスト｜${siteConfig.title}`;
 const seoDescription =
   "これは僕がこの人生で達成したいこと、手に入れたいことのリストです。";
 const seoImage = `${BASE_URL}/api/og/default.png`;
 ---
 
 <BaseLayout>
-  <Fragment slot='seo'>
-    <BaseSEO title="バケットリスト" description={seoDescription} />
-    <OpenGraph
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-    <TwitterCard
-      title={seoTitle}
-      description={seoDescription}
-      image={seoImage}
-      imageAlt={seoTitle}
-    />
-  </Fragment>
-  <div class="back-link-wrapper">
-    <a href="/" class="back-link">
-      <ArrowLeftIcon class="back-icon"/>
-      ホーム
-    </a>
-  </div>
+  <SEO
+    title="バケットリスト"
+    description={seoDescription}
+    image={seoImage}
+    slot='seo'
+  />
+  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
   <h1 class="page-title">
     バケットリスト
   </h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,7 @@
 ---
 import Budoux from "#/components/budoux.astro";
 import MoveUpRightIcon from "#/components/icons/move-up-right.svg";
-import BaseSEO from "#/components/seo/base-seo.astro";
-import OpenGraph from "#/components/seo/open-graph.astro";
-import TwitterCard from "#/components/seo/twitter-card.astro";
-import { siteConfig } from "#/config/site";
+import SEO from "#/components/seo/seo.astro";
 import BaseLayout from "#/layouts/base-layout.astro";
 import { websiteSchema } from "#/lib/json-ld";
 import { BASE_URL } from "#/utils/base-url";
@@ -13,21 +10,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
 ---
 
 <BaseLayout>
-  <Fragment slot='seo'>
-    <BaseSEO />
-    <OpenGraph
-      title={siteConfig.title}
-      description={siteConfig.description}
-      image={seoImage}
-      imageAlt={siteConfig.title}
-    />
-    <TwitterCard
-      title={siteConfig.title}
-      description={siteConfig.description}
-      image={seoImage}
-      imageAlt={siteConfig.title}
-    />
-  </Fragment>
+  <SEO image={seoImage} slot='seo' />
   <script
       is:inline
       type='application/ld+json'

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -181,35 +181,6 @@
 /* ===== Common Layout Patterns ===== */
 
 @layer layout {
-  .back-link-wrapper {
-    margin-bottom: 1rem;
-
-    @media (width >= 1280px) {
-      position: fixed;
-      top: 0;
-      transform: translateY(170px) translateX(-260px);
-    }
-  }
-
-  .back-link {
-    display: inline-flex;
-    gap: 0.25rem;
-    align-items: center;
-    color: var(--c-sub);
-    font-size: var(--fs-xs);
-    font-feature-settings: "palt";
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
-  .back-icon {
-    width: 0.875rem;
-    height: 0.875rem;
-  }
-
   .page-title {
     font-weight: var(--fw-medium);
   }


### PR DESCRIPTION
## Summary

Comprehensive refactoring to eliminate duplication across SEO handling and navigation patterns.

## Changes

- **API Cache Unification**: Extract `createCache` / `createResolvedCache` factories; migrate emoji, github, tweet, metadata to standardized pattern (8 new tests)
- **SEO Component Integration**: Create unified `<SEO>` wrapper combining BaseSEO/OpenGraph/TwitterCard; replace 3-component pattern across 9 pages
- **Navigation Component**: Create `<Breadcrumb>` component replacing separate back-link/breadcrumb HTML patterns; update 8 pages
- **Type Definition Rules**: Document placement conventions in CLAUDE.md

## Test Results

- ✅ 182 tests pass (including 8 new cache tests)
- ✅ lint: no errors
- ✅ check: 0 errors, 0 warnings
- ✅ build: 103 pages built successfully

## Stats

- 389 lines removed, 136 lines added
- 4 logical commits with clear separation of concerns