### PR TITLE
[main] chore: remove unnecessary playwright browser installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,5 @@ jobs:
       - name: Type check
         run: pnpm check
 
-      - name: Install Playwright Browser
-        run: pnpx playwright install --with-deps chromium
-
       - name: Build
         run: pnpm build


### PR DESCRIPTION
- Remove unnecessary Playwright browser installation from CI workflow
- Mermaid diagrams are pre-rendered to SVG cache, not rendered during build
- Reduces CI duration by eliminating unused Chromium installation