### PR TITLE
[main] style: adjust typography and navigation

### DIFF
--- a/src/components/ui/breadcrumb.astro
+++ b/src/components/ui/breadcrumb.astro
@@ -93,7 +93,7 @@ const isSimple = segments.length === 1;
   }
 
   .breadcrumb-current {
-    font-weight: var(--fw-semibold);
+    font-weight: var(--fw-medium);
   }
 
   .breadcrumb-current-link {

--- a/src/features/blog/components/ui/blocks/tweet-block.astro
+++ b/src/features/blog/components/ui/blocks/tweet-block.astro
@@ -237,7 +237,7 @@ const blurryPhotos = tweet.photos
     display: flex;
     align-items: center;
     white-space: nowrap;
-    font-weight: var(--fw-semibold);
+    font-weight: var(--fw-medium);
     text-decoration: none;
     color: inherit;
   }

--- a/src/features/blog/components/ui/category-navigation.astro
+++ b/src/features/blog/components/ui/category-navigation.astro
@@ -81,7 +81,7 @@ const pathname = Astro.url.pathname;
   }
 
   .cat-link--active {
-    background-color: oklch(from var(--c-primary) l c h / 95%);
+    background-color: var(--c-primary);
     color: var(--c-primary-text);
     font-weight: var(--fw-medium);
   }

--- a/src/features/blog/components/ui/entry-list.astro
+++ b/src/features/blog/components/ui/entry-list.astro
@@ -97,9 +97,10 @@ const { entries, class: className, showDate = false, ...rest } = Astro.props;
     justify-content: space-between;
     gap: 1rem;
     padding: 0.75rem 0.5rem;
+    font-size: var(--fs-sm);
     transition: background-color 0.2s;
     text-decoration: none;
-    color: inherit;
+    color: var(--c-prose-text);
   }
 
   .entry-item:hover {

--- a/src/features/blog/components/ui/tag-cloud.astro
+++ b/src/features/blog/components/ui/tag-cloud.astro
@@ -37,7 +37,7 @@ const { tags, class: className, ...rest } = Astro.props;
     display: inline-flex;
     align-items: center;
     gap: 0.375rem;
-    font-size: var(--fs-sm);
+    font-size: var(--fs-xs);
     line-height: 1.25rem;
     font-weight: var(--fw-medium);
     background-color: oklch(from var(--c-surface) l c h / 50%);
@@ -46,7 +46,7 @@ const { tags, class: className, ...rest } = Astro.props;
     padding-block: 0.25rem;
     padding-inline: 0.25rem 0.625rem;
     text-decoration: none;
-    color: inherit;
+    color: var(--c-prose-text);
     transition:
       background-color 0.2s,
       transform 0.15s ease;

--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -74,7 +74,7 @@ const currentDate = new Date();
   <slot name='head' slot='head' />
   <section>
     <Breadcrumb segments={[
-      { label: "ブログ", href: "/blog" },
+      { label: "Blog", href: "/blog" },
       { label: categoryObject.label, href: `/blog/categories/${categorySlug}`, isCurrent: true },
     ]} />
     <div class:list={[status === 'draft' && 'draft-header']}>
@@ -121,7 +121,7 @@ const currentDate = new Date();
 
   .post-title {
     margin-top: 1rem;
-    font-weight: var(--fw-semibold);
+    font-weight: var(--fw-medium);
   }
 
   .post-meta {

--- a/src/layouts/page-layout.astro
+++ b/src/layouts/page-layout.astro
@@ -21,7 +21,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     slot='seo'
   />
   <slot name='head' slot='head'/>
-  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
+  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
   <h1 class="page-title">{title}</h1>
   <section class="prose page-body">
     <slot />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -10,7 +10,7 @@ import BaseLayout from "#/layouts/base-layout.astro";
       noindex
       slot='seo'
   />
-  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
+  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
   <h1 class="page-title">
     ページが見つかりませんでした
   </h1>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -26,7 +26,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     image={seoImage}
     slot='seo'
   />
-  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
+  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
   <h1 class="page-title">
     About
   </h1>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -27,14 +27,14 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
 
 <BaseLayout>
   <SEO
-    title="ブログ"
+    title="Blog"
     description={seoDescription}
     image={seoImage}
     slot='seo'
   />
-  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
+  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
   <section>
-    <h1 class="page-title">ブログ</h1>
+    <h1 class="page-title">Blog</h1>
     <CategoryNavigation class="blog-nav" />
   </section>
   <section class="blog-entries">

--- a/src/pages/blog/categories/[category]/[...page].astro
+++ b/src/pages/blog/categories/[category]/[...page].astro
@@ -49,9 +49,9 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     image={seoImage}
     slot='seo'
   />
-  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
+  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
   <section>
-    <h1 class="page-title">ブログ</h1>
+    <h1 class="page-title">Blog</h1>
     <CategoryNavigation class="blog-nav" />
   </section>
   <section class="blog-entries">

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -74,7 +74,7 @@ const breadcrumbSchema: WithContext<BreadcrumbList> = {
       set:html={JSON.stringify(breadcrumbSchema)}
       slot='head'
   />
-  <Breadcrumb segments={[{ label: "ブログ", href: "/blog" }]} />
+  <Breadcrumb segments={[{ label: "Blog", href: "/blog" }]} />
   <section>
     <h1 class="page-title">#{tag.label}</h1>
   </section>

--- a/src/pages/bucket-list.astro
+++ b/src/pages/bucket-list.astro
@@ -62,7 +62,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     image={seoImage}
     slot='seo'
   />
-  <Breadcrumb segments={[{ label: "ホーム", href: "/" }]} />
+  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
   <h1 class="page-title">
     バケットリスト
   </h1>
@@ -142,6 +142,8 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     display: flex;
     flex-direction: column;
     gap: 0.625rem;
+    font-size: var(--fs-sm);
+    color: var(--c-prose-text);
   }
 
   @media (width >= 640px) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -57,7 +57,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
   }
 
   .home-link {
-    color: var(--c-text);
+    color: var(--c-prose-text);
     text-decoration: underline 1px;
     text-underline-offset: 4px;
     text-decoration-color: oklch(from var(--c-sub) l c h / 50%);
@@ -76,7 +76,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
   }
 
   .home-link:visited {
-    color: var(--c-text);
+    color: var(--c-prose-text);
 
     & svg {
       stroke: currentColor;
@@ -84,7 +84,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
   }
 
   .home-link:hover {
-    text-decoration-color: var(--c-text);
+    text-decoration-color: var(--c-prose-text);
   }
 
   .home-list {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,9 +17,10 @@
 
     --c-bg: light-dark(var(--uchu-yang), var(--uchu-yin));
     --c-text: light-dark(var(--uchu-yin), var(--uchu-gray-1));
+    --c-prose-text: light-dark(var(--uchu-yin-7), var(--uchu-gray-4));
     --c-sub: light-dark(var(--uchu-yin-6), var(--uchu-yin-4));
 
-    --c-primary: light-dark(var(--uchu-yin-9), var(--uchu-gray-2));
+    --c-primary: light-dark(var(--uchu-yin-8), var(--uchu-gray-3));
     --c-primary-text: light-dark(var(--uchu-yang), var(--uchu-yin-9));
 
     --c-surface: light-dark(var(--uchu-gray-1), var(--uchu-yin-9));
@@ -66,7 +67,6 @@
 
     --fw-normal: 400;
     --fw-medium: 500;
-    --fw-semibold: 600;
 
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   }
@@ -88,8 +88,8 @@
     scrollbar-width: thin;
     background-color: var(--c-bg);
     color: var(--c-text);
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+    /*-webkit-font-smoothing: antialiased;*/
+    /*-moz-osx-font-smoothing: grayscale;*/
   }
 
   h1 {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -1,3 +1,8 @@
+.prose {
+  font-size: var(--fs-sm);
+  color: var(--c-prose-text);
+}
+
 .prose p,
 .prose ul,
 .prose ol,
@@ -8,19 +13,20 @@
 }
 
 .prose > *:not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  margin-block: 2.5rem;
+  margin-block: 2rem;
 }
 
 .prose p {
-  margin-block: 2rem;
+  margin-block: 1.75rem;
 }
 
 .prose h1,
 .prose h2,
 .prose h3 {
   font-size: 1rem;
-  font-weight: var(--fw-semibold);
+  font-weight: var(--fw-medium);
   line-height: 1.75;
+  color: var(--c-text);
   transition: color 1s;
 }
 
@@ -29,13 +35,13 @@
 }
 
 .prose h2 {
-  margin-block: 4rem 1.5rem;
+  margin-block: 3.5rem 1.25rem;
   border-bottom: 1px solid var(--c-border);
-  padding-block: 0.625rem;
+  padding-block: 0.4rem;
 }
 
 .prose h3 {
-  margin-block: 2.5rem 1.5rem;
+  margin-block: 2rem 1.25rem;
 }
 
 .prose :is(h2, h3) + * {


### PR DESCRIPTION
- Set base font-size to 14px with adjusted margins for prose elements
- Add --c-prose-text color variable for blog content with lighter gray in dark mode
- Update --c-primary to lighter shade (yin-8) for better visual hierarchy
- Remove --fw-semibold and consolidate to --fw-medium
- Apply consistent prose-text color and font-size across components (blog list, tags, bucket-list)
- Unify navigation labels to English (Home, Blog)