### PR TITLE
style: remove category and tag links from homepage intro

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     </h1>
     <Budoux>
       <div class="home-body prose">
-        <p><a href="/about" class="home-link">コードを書いて暮らしています</a>。色々なものを作ることが好きです。<a href="/blog/categories/tech" class="home-link">プログラミング</a>のことから<a href="/blog/tags/sewing" class="home-link">手縫いの服づくり</a>まで、<a href="/blog/categories/life" class="home-link">日々のこと</a>や<a href="/blog/categories/object" class="home-link">手に馴染む道具</a>の話をブログに残しています。</p>
+        <p><a href="/about" class="home-link">コードを書いて暮らしています</a>。色々なものを作ることが好きです。プログラミングのことから手縫いの服づくりまで、日々のことや手に馴染む道具の話をブログに残しています。</p>
         <p>コードを書いていないときは、珈琲を淹れたりチョコレートを食べたりジムで体を動かしたりしています。日々考えたことは<a href="https://memo.kkhys.me" target="_blank" rel="noreferrer" class="home-link external-link">メモ<MoveUpRightIcon class="external-icon" /></a>に書き留めて、いつかやりたいことは<a href="/bucket-list" class="home-link">バケットリスト</a>にまとめています。</p>
         <p>私の好きな文章には次のようなものがあります。</p>
         <ul class="home-list">


### PR DESCRIPTION
## Summary

Remove unnecessary internal links from the homepage introduction paragraph while keeping the about page link. This simplifies the visual navigation hierarchy.

## Changes

- Remove links to `/blog/categories/tech`, `/blog/tags/sewing`, `/blog/categories/life`, `/blog/categories/object`
- Keep the `/about` link intact
- Simplify the intro paragraph while maintaining the same message

## Test plan

- [x] Verify homepage renders correctly
- [x] Verify the about link still works
- [x] Check that removed links are truly gone