### PR TITLE
[main] chore: set Astro build format to file for Cloudflare Pages

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -24,6 +24,9 @@ export default defineConfig({
     mdx(),
     sitemap(),
   ],
+  build: {
+    format: "file",
+  },
   prefetch: {
     defaultStrategy: "viewport",
     prefetchAll: true,


### PR DESCRIPTION
- Configure Astro to generate single .html files instead of directory/index.html
- Prevents Cloudflare Pages 308 redirects for trailing slashes
- Maintains clean URLs without trailing slash (e.g., /blog instead of /blog/)