### PR TITLE
[main] fix: fix active state styling for 'all categories' tab in blog home

### DIFF
--- a/src/features/blog/components/ui/category-navigation.astro
+++ b/src/features/blog/components/ui/category-navigation.astro
@@ -10,7 +10,7 @@ const pathname = Astro.url.pathname;
 ---
 
 <nav class:list={['category-scroll palt', className]} {...rest}>
-  {/^\/blog(\/\d+)?\/?$/.test(pathname) ? (
+  {/^\/blog(\/\d+)?(\.html)?\/?$/.test(pathname) ? (
       <span class="cat-link cat-link--active">
       すべて
     </span>


### PR DESCRIPTION
- Fix regex pattern to handle `.html` file extension in pathname
- Correct active state detection for blog homepage
- Ensure 'すべて' (all) tab is highlighted when viewing blog