### PR TITLE
[main] refactor: simplify youtube-block component

### DIFF
--- a/src/features/blog/components/ui/blocks/youtube-block.astro
+++ b/src/features/blog/components/ui/blocks/youtube-block.astro
@@ -2,170 +2,24 @@
 import type { HTMLAttributes } from "astro/types";
 
 interface Props extends HTMLAttributes<"div"> {
-  /**
-   * YouTube video ID (e.g., "kpz_U8wHpa8")
-   */
   videoId: string;
-  /**
-   * Optional playlist ID
-   */
-  playlistId?: string;
-  /**
-   * Optional video title (improves accessibility)
-   */
-  title?: string;
-  /**
-   * Optional YouTube player parameters (e.g., "controls=0&start=10")
-   * @see https://developers.google.com/youtube/player_parameters
-   */
-  params?: string;
 }
 
-const {
-  videoId,
-  playlistId,
-  title,
-  params,
-  class: className,
-  ...rest
-} = Astro.props;
+const { videoId, class: className, ...rest } = Astro.props;
 ---
 
-<div class="youtube-wrapper">
-  <lite-youtube
-    videoid={videoId}
-    playlistid={playlistId}
-    videotitle={title}
-    params={params}
-    class:list={["youtube-embed", className]}
-    {...rest}
-  ></lite-youtube>
-  <noscript>
-    <a href={`https://www.youtube.com/watch?v=${videoId}`} class="youtube-noscript" target="_blank" rel="noreferrer">
-      YouTubeで動画を見る
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="youtube-noscript-icon"><path d="M13 5H19V11"/><path d="M19 5L5 19"/></svg>
-    </a>
-  </noscript>
-</div>
+<lite-youtube
+  videoid={videoId}
+  class:list={["youtube-embed", className]}
+  {...rest}
+></lite-youtube>
 
 <style>
-  .youtube-wrapper {
-    position: relative;
-  }
-
   .youtube-embed {
-    display: block;
     max-width: 100%;
     border-radius: 1rem;
     border: 1px solid light-dark(transparent, var(--c-border));
-    background-color: black;
-    position: relative;
-    cursor: pointer;
     overflow: hidden;
-    contain: content;
-    background-position: center center;
-    background-size: cover;
-  }
-
-  .youtube-embed::before {
-    content: "";
-    display: block;
-    position: absolute;
-    top: 0;
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAADGCAYAAAAT+OqFAAAAdklEQVQoz42QQQ7AIAgEF/T/D+kbq/RWAlnQyyazA4aoAB4FsBSA/bFjuF1EOL7VbrIrBuusmrt4ZZORfb6ehbWdnRHEIiITaEUKa5EJqUakRSaEYBJSCY2dEstQY7AuxahwXFrvZmWl2rh4JZ07z9dLtesfNj5q0FU3A5ObbwAAAABJRU5ErkJggg==);
-    background-position: top;
-    background-repeat: repeat-x;
-    height: 60px;
-    padding-bottom: 50px;
-    width: 100%;
-    transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
-  }
-
-  .youtube-embed::after {
-    content: "";
-    display: block;
-    padding-bottom: calc(100% / (16 / 9));
-  }
-
-  .youtube-embed :global(iframe) {
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    border: 0;
-  }
-
-  .youtube-embed :global(.lty-playbtn) {
-    width: 68px;
-    height: 48px;
-    position: absolute;
-    cursor: pointer;
-    transform: translate3d(-50%, -50%, 0);
-    top: 50%;
-    left: 50%;
-    z-index: 1;
-    background-color: transparent;
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="%23f00"/><path d="M45 24 27 14v20" fill="%23fff"/></svg>');
-    filter: grayscale(100%);
-    transition: filter 0.1s cubic-bezier(0, 0, 0.2, 1);
-    border: none;
-  }
-
-  .youtube-embed:hover :global(.lty-playbtn),
-  .youtube-embed :global(.lty-playbtn:focus) {
-    filter: none;
-  }
-
-  .youtube-embed :global(.lyt-activated) {
-    cursor: unset;
-  }
-
-  .youtube-embed:global(.lyt-activated)::before,
-  .youtube-embed:global(.lyt-activated) :global(.lty-playbtn) {
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  :global(.lyt-visually-hidden) {
-    clip: rect(0 0 0 0);
-    clip-path: inset(50%);
-    height: 1px;
-    overflow: hidden;
-    position: absolute;
-    white-space: nowrap;
-    width: 1px;
-  }
-
-  .youtube-noscript {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    z-index: 1;
-    display: inline-flex;
-    align-items: center;
-    color: var(--c-link);
-    font-weight: var(--fw-medium);
-    font-size: var(--fs-sm);
-    text-decoration-thickness: 1px;
-    text-underline-offset: 4px;
-    white-space: nowrap;
-
-    &:hover {
-      text-decoration: underline;
-    }
-
-    &:visited {
-      color: var(--c-link-visited);
-    }
-  }
-
-  .youtube-noscript-icon {
-    margin-inline: 0.25rem;
-    margin-top: 0.125rem;
-    width: 0.75rem;
-    height: 0.75rem;
   }
 </style>
 

--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -29,10 +29,9 @@ const { class: className } = Astro.props;
   <noscript>
     <style>
       .blur-load { filter: none !important; background: none !important; }
-      lite-youtube { cursor: default !important; }
+      lite-youtube { display: none !important; }
     </style>
   </noscript>
-
 
 </head>
 <body>


### PR DESCRIPTION
- Remove lite-youtube customization (play button styles, overlay, aspect ratio hacks)
- Remove unused props (playlistId, title, params) and noscript fallback
- Hide youtube-block when JavaScript is disabled
- Keep only essential styling (border-radius, border, overflow)