### PR TITLE
[main] chore: block AI crawlers in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,29 @@
-User-Agent: Google-Extended
+User-agent: *
+Content-Signal: search=yes,ai-train=no
+Allow: /
+
+User-agent: Amazonbot
 Disallow: /
 
-User-Agent: *
-Allow: /
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: meta-externalagent
+Disallow: /
 
 Sitemap: https://kkhys.me/sitemap-index.xml


### PR DESCRIPTION
## Summary
- Block AI crawlers (ClaudeBot, GPTBot, Amazonbot, Bytespider, etc.) in robots.txt
- Add `Content-Signal: search=yes,ai-train=no` header
- Continue to allow search engine crawling

## Test plan
- [x] Verify robots.txt is deployed correctly
- [x] Confirm no issues in Google Search Console