### PR TITLE
chore: migrate content submodule to private repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          token: ${{ secrets.PAT }}
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
-          token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+          token: ${{ secrets.SUBMODULE_TOKEN }}
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "content"]
 	path = content
-	url = https://github.com/kkhys/content.git
+	url = https://github.com/kkhys/me-content.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "content"]
-	path = content
+[submodule "me-content"]
+	path = me-content
 	url = https://github.com/kkhys/me-content.git

--- a/scripts/render-mermaid.ts
+++ b/scripts/render-mermaid.ts
@@ -32,7 +32,7 @@ const main = async () => {
   mkdirSync(CACHE_DIR, { recursive: true });
 
   const mdxFiles: string[] = [];
-  for await (const file of glob("content/blog/**/index.mdx")) {
+  for await (const file of glob("me-content/blog/**/index.mdx")) {
     mdxFiles.push(file);
   }
 

--- a/src/__tests__/lib/api/github.test.ts
+++ b/src/__tests__/lib/api/github.test.ts
@@ -28,7 +28,7 @@ describe("getLastUpdatedTimeByFile", () => {
         ]),
     } as Response);
 
-    const result = await getLastUpdatedTimeByFile("content/blog/test.mdx");
+    const result = await getLastUpdatedTimeByFile("me-content/blog/test.mdx");
     expect(result.lastUpdatedTime).toBe("2024-01-15T00:00:00Z");
   });
 
@@ -39,7 +39,7 @@ describe("getLastUpdatedTimeByFile", () => {
       json: () => Promise.resolve([]),
     } as Response);
 
-    const result = await getLastUpdatedTimeByFile("content/blog/empty.mdx");
+    const result = await getLastUpdatedTimeByFile("me-content/blog/empty.mdx");
     expect(result.lastUpdatedTime).toBeUndefined();
     warnSpy.mockRestore();
   });
@@ -51,7 +51,7 @@ describe("getLastUpdatedTimeByFile", () => {
       status: 404,
     } as Response);
 
-    const result = await getLastUpdatedTimeByFile("content/blog/error.mdx");
+    const result = await getLastUpdatedTimeByFile("me-content/blog/error.mdx");
     expect(result.lastUpdatedTime).toBeUndefined();
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
@@ -65,7 +65,7 @@ describe("getLastUpdatedTimeByFile", () => {
     const mod = await import("#/lib/api/github");
 
     const result = await mod.getLastUpdatedTimeByFile(
-      "content/blog/no-token.mdx",
+      "me-content/blog/no-token.mdx",
     );
     expect(result.lastUpdatedTime).toBeUndefined();
     expect(fetch).not.toHaveBeenCalled();
@@ -80,8 +80,8 @@ describe("getLastUpdatedTimeByFile", () => {
         ]),
     } as Response);
 
-    await getLastUpdatedTimeByFile("content/blog/cached.mdx");
-    await getLastUpdatedTimeByFile("content/blog/cached.mdx");
+    await getLastUpdatedTimeByFile("me-content/blog/cached.mdx");
+    await getLastUpdatedTimeByFile("me-content/blog/cached.mdx");
 
     // fetch is called once for this path
     const calls = vi

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -5,7 +5,7 @@ import { externalSites } from "#/features/blog/config/external-site";
 import { allTagTitles } from "#/features/blog/config/tag";
 
 const blog = defineCollection({
-  loader: glob({ pattern: "**/*.mdx", base: "./content/blog" }),
+  loader: glob({ pattern: "**/*.mdx", base: "./me-content/blog" }),
   schema: z.object({
     title: z.string(),
     emoji: z.string(),
@@ -28,7 +28,7 @@ const pages = defineCollection({
 });
 
 const bucketList = defineCollection({
-  loader: file("content/bucket-list/data.yaml"),
+  loader: file("me-content/bucket-list/data.yaml"),
   schema: z.array(
     z.record(
       z.string(),

--- a/src/lib/api/github.ts
+++ b/src/lib/api/github.ts
@@ -14,7 +14,7 @@ const fetchLastUpdatedTime = async (
     return { lastUpdatedTime: undefined };
   }
 
-  const API_URL = "https://api.github.com/repos/kkhys/content/commits?";
+  const API_URL = "https://api.github.com/repos/kkhys/me-content/commits?";
 
   const params = new URLSearchParams({
     path: filePath,

--- a/src/pages/blog/posts/[id].astro
+++ b/src/pages/blog/posts/[id].astro
@@ -28,7 +28,7 @@ const { entry, description } = Astro.props;
 const { Content } = await render(entry);
 const publishedAtString = convertDateToString(entry.data.publishedAt);
 
-const contentPath = entry.filePath?.replace("content/", "");
+const contentPath = entry.filePath?.replace("me-content/", "");
 
 if (!contentPath) {
   throw new Error("Content path is not defined");

--- a/src/pages/bucket-list.astro
+++ b/src/pages/bucket-list.astro
@@ -2,7 +2,6 @@
 import { getEntry } from "astro:content";
 import Budoux from "#/components/budoux.astro";
 import CheckIcon from "#/components/icons/check.svg";
-import MoveUpRightIcon from "#/components/icons/move-up-right.svg";
 import SEO from "#/components/seo/seo.astro";
 import Breadcrumb from "#/components/ui/breadcrumb.astro";
 import Separator from "#/components/ui/separator.astro";
@@ -117,10 +116,6 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     {updatedAtString && (
         <p>最終更新日: {updatedAtString}</p>
     )}
-    <a href="https://github.com/kkhys/me-content/commits/main/bucket-list/data.yaml" target="_blank" rel="noreferrer" class="bucket-history-link">
-      変更履歴
-      <MoveUpRightIcon class="bucket-history-icon" />
-    </a>
   </div>
 </BaseLayout>
 
@@ -233,24 +228,5 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     flex-direction: column;
     align-items: flex-start;
     gap: 0.375rem;
-  }
-
-  .bucket-history-link {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.125rem;
-    text-underline-offset: 4px;
-    text-decoration: none;
-    color: inherit;
-  }
-
-  .bucket-history-link:hover {
-    text-decoration: underline;
-  }
-
-  .bucket-history-icon {
-    width: 0.625rem;
-    height: 0.625rem;
   }
 </style>

--- a/src/pages/bucket-list.astro
+++ b/src/pages/bucket-list.astro
@@ -117,7 +117,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     {updatedAtString && (
         <p>最終更新日: {updatedAtString}</p>
     )}
-    <a href="https://github.com/kkhys/content/commits/main/bucket-list/data.yaml" target="_blank" rel="noreferrer" class="bucket-history-link">
+    <a href="https://github.com/kkhys/me-content/commits/main/bucket-list/data.yaml" target="_blank" rel="noreferrer" class="bucket-history-link">
       変更履歴
       <MoveUpRightIcon class="bucket-history-icon" />
     </a>


### PR DESCRIPTION
## Summary
- Migrate content submodule from `kkhys/content` to `kkhys/me-content` (private repo)
- Rename submodule directory from `content/` to `me-content/`
- Add `token: ${{ secrets.GITHUB_ACCESS_TOKEN }}` to `actions/checkout` in CI for private submodule access
- Update all references across the codebase (content.config.ts, github.ts, bucket-list.astro, [id].astro, render-mermaid.ts, tests)