### PR TITLE
[main] feat: add favicon generation system

### DIFF
--- a/src/components/seo/favicon/apple-touch-icon-png.tsx
+++ b/src/components/seo/favicon/apple-touch-icon-png.tsx
@@ -1,0 +1,9 @@
+import { generateIcon } from "./utils";
+
+export const AppleTouchIconPng = async () => {
+  return (await generateIcon(
+    { width: 180, height: 180 },
+    { width: 140, height: 140 },
+    "png",
+  )) as Buffer;
+};

--- a/src/components/seo/favicon/icon-192-png.tsx
+++ b/src/components/seo/favicon/icon-192-png.tsx
@@ -1,0 +1,9 @@
+import { generateIcon } from "./utils";
+
+export const Icon192Png = async () => {
+  return (await generateIcon(
+    { width: 192, height: 192 },
+    undefined,
+    "png",
+  )) as Buffer;
+};

--- a/src/components/seo/favicon/icon-512-png.tsx
+++ b/src/components/seo/favicon/icon-512-png.tsx
@@ -1,0 +1,9 @@
+import { generateIcon } from "./utils";
+
+export const Icon512Png = async () => {
+  return (await generateIcon(
+    { width: 512, height: 512 },
+    undefined,
+    "png",
+  )) as Buffer;
+};

--- a/src/components/seo/favicon/icon-mask-png.tsx
+++ b/src/components/seo/favicon/icon-mask-png.tsx
@@ -1,0 +1,9 @@
+import { generateIcon } from "./utils";
+
+export const IconMaskPng = async () => {
+  return (await generateIcon(
+    { width: 512, height: 512 },
+    { width: 409, height: 409 },
+    "png",
+  )) as Buffer;
+};

--- a/src/components/seo/favicon/icon-svg.tsx
+++ b/src/components/seo/favicon/icon-svg.tsx
@@ -1,0 +1,9 @@
+import { generateIcon } from "./utils";
+
+export const IconSvg = async () => {
+  return (await generateIcon(
+    { width: 500, height: 500 },
+    undefined,
+    "svg",
+  )) as string;
+};

--- a/src/components/seo/favicon/utils.tsx
+++ b/src/components/seo/favicon/utils.tsx
@@ -1,0 +1,69 @@
+/** @jsxImportSource react */
+/** @jsxRuntime automatic */
+
+import type { ReactElement } from "react";
+import satori from "satori";
+import sharp from "sharp";
+
+interface IconStyleOptions {
+  width?: number | string;
+  height?: number | string;
+}
+
+interface SatoriOptions {
+  width: number;
+  height: number;
+}
+
+const createIconElement = (options?: IconStyleOptions) => {
+  const { width = "100%", height = "100%" } = options ?? {};
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <div
+        style={{
+          width,
+          height,
+          borderRadius: "50%",
+          background:
+            "linear-gradient(to bottom right, #dbe7f0 0%, #527ce0 50%, #03077c 100%)",
+        }}
+      />
+    </div>
+  );
+};
+
+const generateSvg = async (element: ReactElement, options: SatoriOptions) => {
+  return satori(element, {
+    width: options.width,
+    height: options.height,
+    fonts: [],
+  });
+};
+
+const convertSvgToPng = async (svg: string) => {
+  return sharp(Buffer.from(svg)).png().toBuffer();
+};
+
+export const generateIcon = async (
+  satoriOptions: SatoriOptions,
+  iconStyleOptions?: IconStyleOptions,
+  format: "svg" | "png" = "svg",
+) => {
+  const element = createIconElement(iconStyleOptions);
+  const svg = await generateSvg(element, satoriOptions);
+
+  if (format === "png") {
+    return convertSvgToPng(svg);
+  }
+
+  return svg;
+};

--- a/src/pages/api/favicon/_util.ts
+++ b/src/pages/api/favicon/_util.ts
@@ -1,0 +1,37 @@
+import type { APIRoute } from "astro";
+
+export const createPngHandler = (
+  generator: () => Promise<ArrayBuffer | Buffer>,
+): APIRoute => {
+  return async () => {
+    if (import.meta.env.PROD) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const image = await generator();
+    return new Response(new Uint8Array(image), {
+      headers: {
+        "Content-Type": "image/png",
+        "Cache-Control": "public, max-age=31536000, immutable",
+      },
+    });
+  };
+};
+
+export const createSvgHandler = (
+  generator: () => Promise<string>,
+): APIRoute => {
+  return async () => {
+    if (import.meta.env.PROD) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    const svg = await generator();
+    return new Response(svg, {
+      headers: {
+        "Content-Type": "image/svg+xml",
+        "Cache-Control": "public, max-age=31536000, immutable",
+      },
+    });
+  };
+};

--- a/src/pages/api/favicon/apple-touch-icon.png.ts
+++ b/src/pages/api/favicon/apple-touch-icon.png.ts
@@ -1,0 +1,4 @@
+import { AppleTouchIconPng } from "#/components/seo/favicon/apple-touch-icon-png";
+import { createPngHandler } from "./_util";
+
+export const GET = createPngHandler(AppleTouchIconPng);

--- a/src/pages/api/favicon/icon-192.png.ts
+++ b/src/pages/api/favicon/icon-192.png.ts
@@ -1,0 +1,4 @@
+import { Icon192Png } from "#/components/seo/favicon/icon-192-png";
+import { createPngHandler } from "./_util";
+
+export const GET = createPngHandler(Icon192Png);

--- a/src/pages/api/favicon/icon-512.png.ts
+++ b/src/pages/api/favicon/icon-512.png.ts
@@ -1,0 +1,4 @@
+import { Icon512Png } from "#/components/seo/favicon/icon-512-png";
+import { createPngHandler } from "./_util";
+
+export const GET = createPngHandler(Icon512Png);

--- a/src/pages/api/favicon/icon-mask.png.ts
+++ b/src/pages/api/favicon/icon-mask.png.ts
@@ -1,0 +1,4 @@
+import { IconMaskPng } from "#/components/seo/favicon/icon-mask-png";
+import { createPngHandler } from "./_util";
+
+export const GET = createPngHandler(IconMaskPng);

--- a/src/pages/api/favicon/icon.svg.ts
+++ b/src/pages/api/favicon/icon.svg.ts
@@ -1,0 +1,4 @@
+import { IconSvg } from "#/components/seo/favicon/icon-svg";
+import { createSvgHandler } from "./_util";
+
+export const GET = createSvgHandler(IconSvg);


### PR DESCRIPTION
## Summary

Add a complete favicon generation system using Satori for SVG rendering and Sharp for PNG conversion. Implements a dynamic, customizable approach with support for multiple icon formats and platform requirements.

## Changes

- **Utilities**: Core favicon generation with blue gradient design (#dbe7f0 → #527ce0 → #03077c)
- **Components**: React wrappers for SVG and PNG variants (192, 512, Apple Touch, mask icons)
- **API Routes**: Development-only endpoints serving generated favicons with immutable cache headers

## Technical Details

- Uses Satori to generate React components as SVG
- Converts SVG to PNG with Sharp for raster formats
- Circular badge design with diagonal linear gradient
- Platform-specific sizing and padding (Apple Touch Icon with 40px padding)
- Cache-Control set to immutable for production deployment

## Testing

Favicon generation can be tested via:
- `/api/favicon/icon.svg` - SVG badge
- `/api/favicon/icon-192.png` - Small PNG
- `/api/favicon/icon-512.png` - Large PNG
- `/api/favicon/apple-touch-icon.png` - Apple device icon
- `/api/favicon/icon-mask.png` - Adaptive icon mask

Note: All routes return 404 in production builds.