### PR TITLE
[main] chore: disable noImportantStyles rule in global.css

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -30,7 +30,11 @@
     {
       "includes": ["src/styles/global.css"],
       "linter": {
-        "enabled": false
+        "rules": {
+          "complexity": {
+            "noImportantStyles": "off"
+          }
+        }
       }
     }
   ]


### PR DESCRIPTION
- Disable noImportantStyles rule specifically in global.css
- Allow !important in Expressive Code style overrides
- Maintain other linting rules to ensure code quality