### PR TITLE
[main] feat: add Web API tag

### DIFF
--- a/src/features/blog/config/tag.ts
+++ b/src/features/blog/config/tag.ts
@@ -182,6 +182,12 @@ export const tags = [
     emoji: "🧩",
   },
   {
+    title: "Web API",
+    label: "Web API",
+    slug: "web-api",
+    emoji: "🌐",
+  },
+  {
     title: "Chocolate",
     label: "チョコレート",
     slug: "chocolate",


### PR DESCRIPTION
- Add Web API tag to blog configuration
- Enable categorization of Web API-related blog posts
- Tag: "Web API" (slug: web-api, emoji: 🌐)