### PR TITLE
[main] chore: add tests and quality enforcement hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,8 +5,18 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm lint:fix > /dev/null 2>&1; OUTPUT=$(pnpm lint 2>&1); RC=$?; if [ $RC -ne 0 ]; then echo \"$OUTPUT\"; exit 1; fi",
+            "command": "pnpm run lint:fix > /dev/null 2>&1; OUTPUT=$(pnpm run lint 2>&1); RC=$?; if [ $RC -ne 0 ]; then echo \"$OUTPUT\" >&2; exit 1; fi",
             "statusMessage": "Running Biome lint & format..."
+          },
+          {
+            "type": "command",
+            "command": "OUTPUT=$(pnpm run check 2>&1); RC=$?; if [ $RC -ne 0 ]; then echo \"$OUTPUT\" >&2; exit 1; fi",
+            "statusMessage": "Running type check..."
+          },
+          {
+            "type": "command",
+            "command": "OUTPUT=$(pnpm run coverage 2>&1); RC=$?; if [ $RC -ne 0 ]; then echo \"$OUTPUT\" >&2; exit 1; fi; CLEAN=$(echo \"$OUTPUT\" | perl -pe 's/\\e\\[\\d+(?:;\\d+)*m//g'); if echo \"$CLEAN\" | awk -F'|' '/\\|/ && !/^-/ && !/File/ && !/All files/ { gsub(/[[:space:]]/,\"\",$2); gsub(/[[:space:]]/,\"\",$4); gsub(/[[:space:]]/,\"\",$5); if(($2!=\"\" && $2+0!=100) || ($4!=\"\" && $4+0!=100) || ($5!=\"\" && $5+0!=100)) { found=1 } } END { exit !found }'; then echo \"Coverage is not 100%. Fix the uncovered lines:\" >&2; echo \"$CLEAN\" | grep '|' >&2; exit 1; fi",
+            "statusMessage": "Checking test coverage is 100%..."
           }
         ]
       }

--- a/src/__tests__/features/blog/utils/entry.test.ts
+++ b/src/__tests__/features/blog/utils/entry.test.ts
@@ -93,6 +93,8 @@ describe("getRelatedPosts", () => {
     // Run multiple times to account for randomness within same score
     const tagScores = new Map<string, number>();
 
+    const tracked = ["a", "c", "d", "g"];
+
     for (let i = 0; i < 50; i++) {
       const results = await getRelatedPosts({
         id: "current",
@@ -103,6 +105,14 @@ describe("getRelatedPosts", () => {
       for (const [rank, result] of results.entries()) {
         const prev = tagScores.get(result.id) ?? 0;
         tagScores.set(result.id, prev + rank);
+      }
+
+      // Penalize posts not in results with worst rank
+      for (const id of tracked) {
+        if (!results.some((r) => r.id === id)) {
+          const prev = tagScores.get(id) ?? 0;
+          tagScores.set(id, prev + results.length);
+        }
       }
     }
 

--- a/src/__tests__/lib/api/memo.test.ts
+++ b/src/__tests__/lib/api/memo.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MemoPost } from "#/lib/api/memo";
+
+const samplePost: MemoPost = {
+  id: "ABC123",
+  body: "Hello world",
+  createdAt: "2025-01-01T00:00:00Z",
+  author: {
+    name: "Keisuke Hayashi",
+    username: "kkhys",
+    avatar: "https://memo.kkhys.me/avatar.jpg",
+  },
+  tag: null,
+  images: [],
+};
+
+describe("getMemoPost", () => {
+  let getMemoPost: (id: string) => Promise<MemoPost | null>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.stubGlobal("fetch", vi.fn());
+    vi.doMock("astro:env/client", () => ({ NODE_ENV: "production" }));
+    // Ensure CI env is unset so production path is taken
+    delete process.env.CI;
+    const mod = await import("#/lib/api/memo");
+    getMemoPost = mod.getMemoPost;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns post data from successful response", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(samplePost),
+    } as Response);
+
+    const result = await getMemoPost("ABC123");
+    expect(result).toEqual(samplePost);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://memo.kkhys.me/api/posts/ABC123.json",
+      { signal: expect.any(AbortSignal) },
+    );
+  });
+
+  it("returns null when response is not ok", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+    } as Response);
+
+    const result = await getMemoPost("NOTFOUND");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when fetch throws", async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("Network error"));
+
+    const result = await getMemoPost("ERR");
+    expect(result).toBeNull();
+  });
+
+  it("returns stub data in non-production environment", async () => {
+    vi.resetModules();
+    vi.doMock("astro:env/client", () => ({ NODE_ENV: "development" }));
+    const mod = await import("#/lib/api/memo");
+
+    const result = await mod.getMemoPost("DEV123");
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe("DEV123");
+    expect(result?.body).toBe("サンプルメモ投稿");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns stub data when CI env is set", async () => {
+    vi.resetModules();
+    vi.doMock("astro:env/client", () => ({ NODE_ENV: "production" }));
+    process.env.CI = "true";
+    const mod = await import("#/lib/api/memo");
+
+    const result = await mod.getMemoPost("CI123");
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe("CI123");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("caches results for the same id", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(samplePost),
+    } as Response);
+
+    const first = await getMemoPost("ABC123");
+    const second = await getMemoPost("ABC123");
+    expect(first).toEqual(second);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("extractMemoId", () => {
+  let extractMemoId: (url: string) => string | null;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock("astro:env/client", () => ({ NODE_ENV: "production" }));
+    const mod = await import("#/lib/api/memo");
+    extractMemoId = mod.extractMemoId;
+  });
+
+  it("extracts id from valid memo URL", () => {
+    expect(extractMemoId("https://memo.kkhys.me/post/ABC123")).toBe("ABC123");
+  });
+
+  it("extracts id from posts path", () => {
+    expect(extractMemoId("https://memo.kkhys.me/posts/XYZ789")).toBe("XYZ789");
+  });
+
+  it("handles http protocol", () => {
+    expect(extractMemoId("http://memo.kkhys.me/post/ABC123")).toBe("ABC123");
+  });
+
+  it("returns null for invalid URL", () => {
+    expect(extractMemoId("https://example.com/post/123")).toBeNull();
+  });
+
+  it("returns null for URL with trailing slash", () => {
+    expect(extractMemoId("https://memo.kkhys.me/post/ABC123/")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractMemoId("")).toBeNull();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "import.meta.env.SITE": JSON.stringify("https://example.com"),
   },
   test: {
+    exclude: ["node_modules", ".direnv"],
     coverage: {
       include: ["src/utils/*.ts", "src/lib/*.ts", "src/lib/api/*.ts"],
       exclude: [


### PR DESCRIPTION
- Add unit tests for getMemoPost and extractMemoId in memo API client
- Improve getRelatedPosts test by penalizing untracked posts for better coverage
- Exclude .direnv from vitest module resolution
- Add type check and 100% coverage verification to Stop hook
- Fix pnpm → pnpm run and redirect lint errors to stderr in Stop hook