### PR TITLE
[main] style: constrain image display dimensions in prose

### DIFF
--- a/src/components/ui/image/image.astro
+++ b/src/components/ui/image/image.astro
@@ -61,6 +61,7 @@ const pictureProps = {
 
   .blur-load-wrapper {
     overflow: hidden;
+    width: fit-content;
   }
 
   .blur-load {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -3,6 +3,11 @@
   color: var(--c-prose-text);
 }
 
+.prose img {
+  max-height: 50vh;
+  width: auto;
+}
+
 .prose p,
 .prose ul,
 .prose ol,


### PR DESCRIPTION
- Add \`max-height: 50vh\` and \`width: auto\` to \`.prose img\` to prevent oversized images in blog posts
- Add \`width: fit-content\` to \`.blur-load-wrapper\` to keep image wrapper from stretching full width
- Update me-content submodule to include blog post addendum with a new image