### PR TITLE
[main] chore: add minimumReleaseAge to delay dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
   "assignees": ["kkhys"],
   "labels": ["type: bump-version"],
   "assignAutomerge": true,
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "groupName": "DevDependencies",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 4320
+
 ignoredBuiltDependencies:
   - workerd
 


### PR DESCRIPTION
- Add `minimumReleaseAge: "3 days"` to Renovate config to avoid adopting freshly released packages
- Add `minimumReleaseAge: 4320` to pnpm-workspace.yaml for consistent release age enforcement