### PR TITLE
[main] fix: exclude svg og:image sources from link cards

### DIFF
--- a/src/__tests__/lib/api/metadata.test.ts
+++ b/src/__tests__/lib/api/metadata.test.ts
@@ -75,7 +75,7 @@ describe("getMetadata", () => {
       mockFetchSiteMetadata = vi.fn().mockResolvedValue({
         title: "Example",
         description: "Example description",
-        image: "https://example.com/og.png",
+        image: { src: "https://example.com/og.png", width: "1", height: "1" },
         icon: "https://example.com/favicon.ico",
       });
       vi.doMock("astro:env/client", () => ({
@@ -114,6 +114,50 @@ describe("getMetadata", () => {
       const result = await getMetadata("https://error-example.com");
       expect(result.title).toBe("Not Found");
       expect(result.description).toBe("Page not found");
+    });
+
+    it("strips SVG og:image so Astro's sharp service won't reject the build", async () => {
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "SVG site",
+        description: "desc",
+        image: { src: "https://example.com/og.svg", width: "1", height: "1" },
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://svg-example.com");
+      expect(result.image).toBeUndefined();
+    });
+
+    it("strips SVG og:image even when the URL has query params", async () => {
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "SVG site",
+        description: "desc",
+        image: {
+          src: "https://example.com/og.svg?v=2#frag",
+          width: "1",
+          height: "1",
+        },
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://svg-query-example.com");
+      expect(result.image).toBeUndefined();
+    });
+
+    it("keeps non-SVG og:image untouched", async () => {
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "PNG site",
+        description: "desc",
+        image: { src: "https://example.com/og.png", width: "1", height: "1" },
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://png-example.com");
+      expect(result.image).toEqual({
+        src: "https://example.com/og.png",
+        width: "1",
+        height: "1",
+      });
     });
   });
 });

--- a/src/lib/api/metadata.ts
+++ b/src/lib/api/metadata.ts
@@ -4,6 +4,18 @@ import { createResolvedCache } from "#/lib/api/cache";
 
 const cache = createResolvedCache<Metadata>();
 
+// Astro's sharp service refuses SVG inputs unless `image.dangerouslyProcessSVG`
+// is enabled, so drop SVG og:images here to keep `<Image>` from crashing the build.
+const isSvgSrc = (src: string): boolean => {
+  const pathname = src.split(/[?#]/, 1)[0] ?? src;
+  return pathname.toLowerCase().endsWith(".svg");
+};
+
+const stripSvgImage = (metadata: Metadata): Metadata =>
+  metadata.image && isSvgSrc(metadata.image.src)
+    ? { ...metadata, image: undefined }
+    : metadata;
+
 export const getMetadata = (url: string) =>
   cache(url, async () => {
     if (NODE_ENV !== "production" || process.env.CI) {
@@ -21,10 +33,12 @@ export const getMetadata = (url: string) =>
         accept: "text/html",
         "accept-language": "ja,en-US;q=0.7,en;q=0.3",
       },
-    }).catch(() => ({
-      title: "Not Found",
-      description: "Page not found",
-      image: undefined,
-      icon: undefined,
-    }));
+    })
+      .then(stripSvgImage)
+      .catch(() => ({
+        title: "Not Found",
+        description: "Page not found",
+        image: undefined,
+        icon: undefined,
+      }));
   });


### PR DESCRIPTION
- Skip remote og:image sources whose URL ends with .svg (incl. query/hash) in `getMetadata`
- Prevent `astro build` from crashing with `UnsupportedImageFormat` when a link-card references a site that ships an SVG og:image (e.g. mermaid.js.org)
- Add unit tests covering SVG stripping, SVG with query string, and non-SVG passthrough
- Fix existing mock so `image` matches `ImageInfo` shape from `fetch-site-metadata`