### PR TITLE
[main] style: darken prose text color for readability

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,7 +20,7 @@
 
     --c-bg: light-dark(var(--uchu-yang), var(--uchu-yin));
     --c-text: light-dark(var(--uchu-yin), var(--uchu-gray-1));
-    --c-prose-text: light-dark(var(--uchu-yin-7), var(--uchu-gray-4));
+    --c-prose-text: light-dark(var(--uchu-yin-8), var(--uchu-gray-2));
     --c-sub: light-dark(var(--uchu-yin-6), var(--uchu-yin-4));
 
     --c-primary: light-dark(var(--uchu-yin-8), var(--uchu-gray-3));


### PR DESCRIPTION
- Darken --c-prose-text from yin-7/gray-4 to yin-8/gray-2 so body text reads closer to the pre-891569ea appearance
- Preserve the heading vs body contrast hierarchy by keeping --c-prose-text distinct from --c-text