### PR TITLE
[main] fix: reserve image layout box to prevent CLS

### DIFF
--- a/src/components/ui/image/image.astro
+++ b/src/components/ui/image/image.astro
@@ -22,6 +22,13 @@ const pictureProps = {
   onload: "this.closest('.blur-load')?.classList.add('image-loaded')",
   ...rest,
 } as Parameters<typeof Picture>[0];
+
+// Reserve layout box before image data loads (prevents CLS).
+const { src } = rest;
+const aspectRatio =
+  typeof src === "object" && src !== null && "width" in src
+    ? `${src.width} / ${src.height}`
+    : "auto";
 ---
 
 {title ? (
@@ -41,7 +48,7 @@ const pictureProps = {
   </div>
 )}
 
-<style define:vars={{ 'bg-image': `url(${blurryImage.src})` }}>
+<style define:vars={{ 'bg-image': `url(${blurryImage.src})`, 'aspect-ratio': aspectRatio }}>
   .image-rounded {
     border-radius: var(--radius-lg);
     user-select: none;
@@ -61,10 +68,13 @@ const pictureProps = {
 
   .blur-load-wrapper {
     overflow: hidden;
-    width: fit-content;
+    max-width: calc(50vh * (var(--aspect-ratio)));
+    aspect-ratio: var(--aspect-ratio);
   }
 
   .blur-load {
+    width: 100%;
+    height: 100%;
     background: var(--bg-image) center / cover no-repeat;
     filter: blur(36px);
     transition: filter 250ms ease-in-out;


### PR DESCRIPTION
- Compute aspect-ratio from source image dimensions to reserve layout space before load
- Apply aspect-ratio and max-width based on viewport height to the blur-load wrapper
- Expand .blur-load to fill the reserved wrapper box