### PR TITLE
[main] fix: remove stray whitespace inside link tags

### DIFF
--- a/src/features/blog/components/link-handler.astro
+++ b/src/features/blog/components/link-handler.astro
@@ -22,14 +22,9 @@ const isMemoLink = isLinkCard && !!extractMemoId(href);
     <LinkCard href={href} {...rest} />
   ) : (
     href.startsWith('http') ? (
-      <a href={href} target="_blank" rel="noreferrer" class="external-link" {...rest}>
-        <slot />
-        <MoveUpRightIcon class="external-icon" />
-      </a>
+      <a href={href} target="_blank" rel="noreferrer" class="external-link" {...rest}><slot /><MoveUpRightIcon class="external-icon" /></a>
     ) : (
-      <a href={href} {...rest}>
-        <slot />
-      </a>
+      <a href={href} {...rest}><slot /></a>
     )
   )
 }

--- a/src/features/blog/components/ui/blocks/heading.astro
+++ b/src/features/blog/components/ui/blocks/heading.astro
@@ -11,14 +11,7 @@ const { as: Tag, id, ...rest } = Astro.props;
 ---
 
 <Tag id={id} class="heading budoux" {...rest}>
-  <a href={`#${id}`} class="heading-link">
-    <div class="anchor-wrapper">
-      <div class="anchor-box">
-        <LinkIcon class="anchor-icon" />
-      </div>
-    </div>
-    <slot />
-  </a>
+  <a href={`#${id}`} class="heading-link"><div class="anchor-wrapper"><div class="anchor-box"><LinkIcon class="anchor-icon" /></div></div><slot /></a>
 </Tag>
 
 <style>


### PR DESCRIPTION
- Inline `<slot />` in link-handler.astro so JSX newlines no longer become text nodes inside `<a>`
- Inline anchor wrapper and `<slot />` in heading.astro to eliminate the same spurious whitespace
- Restore expected rendering of inline links (e.g. `<a>プログラミング</a>` instead of `<a> プログラミング </a>`)