### PR TITLE
[main] refactor: adopt @scope for prose margin rule

### DIFF
--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -17,8 +17,10 @@
   line-height: 2;
 }
 
-.prose > *:not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  margin-block: 2rem;
+@scope (.prose) to (.not-prose) {
+  :scope > * {
+    margin-block: 2rem;
+  }
 }
 
 .prose p {


### PR DESCRIPTION
- Replace `:not(:where([class~="not-prose"]...))` exclusion with `@scope (.prose) to (.not-prose)` in prose.css
- Preserve original specificity (0,1,0) and matching behavior, so no visual change
- Rely on @scope reaching Baseline Newly Available with Firefox 146 in January 2026