### PR TITLE
[main] fix: center copy button icon in code blocks

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -170,12 +170,17 @@
       max-height: 650px !important;
     }
 
+    & .copy {
+      align-items: center !important;
+    }
+
     & .copy button {
       border-radius: var(--radius-md) !important;
 
       &::after {
         mask-size: 0.8rem;
-        margin: 0.6rem !important;
+        mask-position: center;
+        margin: 0 !important;
       }
     }
   }


### PR DESCRIPTION
- Add vertical centering to the copy button container in code blocks
- Reset margin and center mask position on the copy icon pseudo-element