### PR TITLE
[main] style: reduce code block max-height on mobile

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -167,7 +167,11 @@
 
   .expressive-code {
     & pre {
-      max-height: 650px !important;
+      max-height: 550px !important;
+
+      @media (width >= 640px) {
+        max-height: 650px !important;
+      }
     }
 
     & .copy {


### PR DESCRIPTION
- Apply 550px max-height to code blocks on viewports under 640px
- Keep existing 650px max-height from the sm breakpoint up