### PR TITLE
[main] fix: restore scroll-margin-top on h2/h3 headings

### DIFF
--- a/src/features/blog/components/ui/blocks/heading.astro
+++ b/src/features/blog/components/ui/blocks/heading.astro
@@ -7,10 +7,15 @@ interface Props extends HTMLAttributes<"h2"> {
   id: string;
 }
 
-const { as: Tag, id, ...rest } = Astro.props;
+const { as: Tag, id, class: className, ...rest } = Astro.props;
+const classes = new Set([
+  "heading",
+  "budoux",
+  ...(className?.split(/\s+/).filter(Boolean) ?? []),
+]);
 ---
 
-<Tag id={id} class="heading budoux" {...rest}>
+<Tag id={id} class={[...classes].join(" ")} {...rest}>
   <a href={`#${id}`} class="heading-link"><div class="anchor-wrapper"><div class="anchor-box"><LinkIcon class="anchor-icon" /></div></div><slot /></a>
 </Tag>
 


### PR DESCRIPTION
- Preserve the `heading` class on h2/h3 anchors by destructuring `class` from props and merging with a Set
- Restore `scroll-margin-top: 3rem` so anchor clicks no longer scroll the heading flush to the viewport top
- Deduplicate the `budoux` token that rehype-budoux injects through MDX props