### PR TITLE
[main] feat: add table of contents to post pages

### DIFF
--- a/src/features/blog/components/ui/toc.astro
+++ b/src/features/blog/components/ui/toc.astro
@@ -1,0 +1,65 @@
+---
+import type { MarkdownHeading } from "astro";
+
+interface Props {
+  headings: MarkdownHeading[];
+}
+
+const MIN_ITEMS = 3;
+
+const { headings } = Astro.props;
+const items = headings.filter(({ depth }) => depth === 2 || depth === 3);
+---
+
+{items.length >= MIN_ITEMS && (
+  <nav class="toc" aria-label="目次">
+    <ul class="toc-list">
+      {items.map(({ depth, slug, text }) => (
+        <li class:list={["toc-item", `toc-item--depth-${depth}`]}>
+          <a href={`#${slug}`} class="toc-link palt">{text}</a>
+        </li>
+      ))}
+    </ul>
+  </nav>
+)}
+
+<style>
+  .toc {
+    display: none;
+  }
+
+  @media (width >= 1280px) {
+    .toc {
+      display: block;
+      width: 220px;
+      max-height: calc(100vh - 260px);
+      overflow-y: auto;
+      overscroll-behavior: contain;
+      scrollbar-width: thin;
+    }
+  }
+
+  .toc-list {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .toc-item--depth-3 {
+    padding-left: 1.25rem;
+  }
+
+  .toc-link {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    font-size: var(--fs-xs);
+    line-height: 1.25;
+    color: var(--c-sub);
+    text-decoration: none;
+  }
+
+  .toc-link:hover {
+    color: var(--c-text);
+  }
+</style>

--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -1,5 +1,6 @@
 ---
 import type { InferEntrySchema } from "astro:content";
+import type { MarkdownHeading } from "astro";
 import { emojiSvg } from "#/components/emoji-svg";
 import SEO from "#/components/seo/seo.astro";
 import Breadcrumb from "#/components/ui/breadcrumb.astro";
@@ -8,6 +9,7 @@ import Separator from "#/components/ui/separator.astro";
 import { me } from "#/config/site";
 import EntryList from "#/features/blog/components/ui/entry-list.astro";
 import TagCloud from "#/features/blog/components/ui/tag-cloud.astro";
+import Toc from "#/features/blog/components/ui/toc.astro";
 import { getCategoryBySlug } from "#/features/blog/config/category";
 import { tags as allTags } from "#/features/blog/config/tag";
 import { getRelatedPosts, toListEntries } from "#/features/blog/utils/entry";
@@ -17,6 +19,7 @@ import { BASE_URL } from "#/utils/base-url";
 interface Props extends InferEntrySchema<"blog"> {
   id: string;
   description: string;
+  headings: MarkdownHeading[];
 }
 
 const {
@@ -30,6 +33,7 @@ const {
   updatedAt,
   description,
   status,
+  headings,
 } = Astro.props;
 
 const categorySlug = category.toLowerCase();
@@ -73,10 +77,13 @@ const currentDate = new Date();
   />
   <slot name='head' slot='head' />
   <section>
-    <Breadcrumb segments={[
-      { label: "Blog", href: "/blog" },
-      { label: categoryObject.label, href: `/blog/categories/${categorySlug}`, isCurrent: true },
-    ]} />
+    <div class="sidebar">
+      <Breadcrumb segments={[
+        { label: "Blog", href: "/blog" },
+        { label: categoryObject.label, href: `/blog/categories/${categorySlug}`, isCurrent: true },
+      ]} />
+      <Toc headings={headings} />
+    </div>
     <div class:list={[status === 'draft' && 'draft-header']}>
       <EmojiEyeCatch emoji={emoji} />
       {status === "draft" && (
@@ -108,6 +115,21 @@ const currentDate = new Date();
 </BaseLayout>
 
 <style>
+  @media (width >= 1280px) {
+    .sidebar {
+      position: fixed;
+      top: 0;
+      transform: translateY(170px) translateX(-260px);
+      width: fit-content;
+    }
+
+    .sidebar :global(.breadcrumb) {
+      position: static;
+      transform: none;
+      margin-bottom: 32px;
+    }
+  }
+
   .draft-header {
     display: flex;
     justify-content: space-between;
@@ -121,6 +143,7 @@ const currentDate = new Date();
 
   .post-title {
     margin-top: 1rem;
+    font-size: var(--fs-sm);
     font-weight: var(--fw-medium);
   }
 

--- a/src/pages/blog/posts/[id].astro
+++ b/src/pages/blog/posts/[id].astro
@@ -25,7 +25,7 @@ export const getStaticPaths = (async () =>
   })) satisfies GetStaticPaths;
 
 const { entry, description } = Astro.props;
-const { Content } = await render(entry);
+const { Content, headings } = await render(entry);
 const publishedAtString = convertDateToString(entry.data.publishedAt);
 
 const contentPath = entry.filePath?.replace("me-content/", "");
@@ -87,7 +87,7 @@ const jsonLd = {
 };
 ---
 
-<BlogLayout id={entry.id} publishedAtString={publishedAtString} description={description} {...entry.data}>
+<BlogLayout id={entry.id} publishedAtString={publishedAtString} description={description} headings={headings} {...entry.data}>
   <script
       is:inline
       type='application/ld+json'


### PR DESCRIPTION
- Add Toc component that lists h2/h3 headings with anchor links
- Render TOC alongside breadcrumb in a fixed sidebar on screens >= 1280px
- Pass rendered headings from post page through BlogLayout to the new component
- Hide TOC when fewer than 3 qualifying headings exist