### PR TITLE
[main] style: cap TOC max-height at 60vh

### DIFF
--- a/src/features/blog/components/ui/toc.astro
+++ b/src/features/blog/components/ui/toc.astro
@@ -32,7 +32,7 @@ const items = headings.filter(({ depth }) => depth === 2 || depth === 3);
     .toc {
       display: block;
       width: 220px;
-      max-height: calc(100vh - 260px);
+      max-height: 60vh;
       overflow-y: auto;
       overscroll-behavior: contain;
       scrollbar-width: thin;


### PR DESCRIPTION
## Summary
- Cap the blog post TOC `max-height` at `60vh` (was `calc(100vh - 260px)`)
- Keeps the TOC compact on tall viewports while preserving inner scrolling for long lists

## Test plan
- [x] Run `pnpm dev` and verify on `width >= 1280px` that the TOC stays within `60vh` and scrolls internally
- [x] Confirm short posts render a compact TOC and long posts scroll inside the TOC