### PR TITLE
[main] style: narrow toc scrollbar to 3px

### DIFF
--- a/src/features/blog/components/ui/toc.astro
+++ b/src/features/blog/components/ui/toc.astro
@@ -35,7 +35,21 @@ const items = headings.filter(({ depth }) => depth === 2 || depth === 3);
       max-height: 60vh;
       overflow-y: auto;
       overscroll-behavior: contain;
-      scrollbar-width: thin;
+    }
+
+    .toc::-webkit-scrollbar {
+      width: 3px;
+    }
+
+    .toc::-webkit-scrollbar-thumb {
+      background: var(--c-sub);
+      border-radius: 2px;
+    }
+
+    @supports (-moz-appearance: none) {
+      .toc {
+        scrollbar-width: thin;
+      }
     }
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -195,6 +195,23 @@
       }
     }
 
+    & pre::-webkit-scrollbar {
+      width: 3px;
+      height: 3px;
+    }
+
+    & pre::-webkit-scrollbar-thumb {
+      background: var(--c-sub);
+      border-radius: 2px;
+    }
+
+    @supports (-moz-appearance: none) {
+      & pre {
+        scrollbar-color: var(--c-sub) transparent;
+        scrollbar-width: thin;
+      }
+    }
+
     & .copy {
       align-items: center !important;
     }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -189,6 +189,7 @@
   .expressive-code {
     & pre {
       max-height: 550px !important;
+      overscroll-behavior: contain;
 
       @media (width >= 640px) {
         max-height: 650px !important;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -86,13 +86,34 @@
   html {
     font-family: system-ui, sans-serif;
     scrollbar-gutter: stable both-edges;
-    scrollbar-color: light-dark(var(--uchu-gray-3), var(--uchu-yin-8))
-      transparent;
-    scrollbar-width: thin;
     background-color: var(--c-bg);
     color: var(--c-text);
     /*-webkit-font-smoothing: antialiased;*/
     /*-moz-osx-font-smoothing: grayscale;*/
+  }
+
+  /* Avoid standard scrollbar-* on :root in Chromium: it disables
+     ::-webkit-scrollbar for every scroller on the page. */
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: light-dark(var(--uchu-gray-3), var(--uchu-yin-8));
+    border-radius: 4px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  @supports (-moz-appearance: none) {
+    html {
+      scrollbar-color: light-dark(var(--uchu-gray-3), var(--uchu-yin-8))
+        transparent;
+      scrollbar-width: thin;
+    }
   }
 
   h1 {


### PR DESCRIPTION
- Override TOC scrollbar width to 3px via ::-webkit-scrollbar for Chromium/Safari
- Move page-level scrollbar styling off :root standard properties to ::-webkit-scrollbar-* to avoid Chromium disabling pseudo-elements when scrollbar-width is set on the document root
- Scope standard scrollbar-width/scrollbar-color to Firefox via @supports (-moz-appearance: none)