### PR TITLE
[main] style: prevent toc scrollbar overlapping text

### DIFF
--- a/src/features/blog/components/ui/toc.astro
+++ b/src/features/blog/components/ui/toc.astro
@@ -33,6 +33,7 @@ const items = headings.filter(({ depth }) => depth === 2 || depth === 3);
       display: block;
       width: 220px;
       max-height: 60vh;
+      padding-right: 0.5rem;
       overflow-y: auto;
       overscroll-behavior: contain;
     }


### PR DESCRIPTION
- Add padding-right to .toc to prevent scrollbar from overlapping text