### PR TITLE
[main] chore: update umami analytics endpoint

### DIFF
--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -23,12 +23,12 @@ const { class: className } = Astro.props;
 
   {import.meta.env.PROD && (
     <>
-      <link rel='preconnect' href='https://cloud.umami.is' crossorigin />
+      <link rel='preconnect' href='https://umami-oy31vfaew-kkhys-team.vercel.app' crossorigin />
       <script
         is:inline
         defer
-        src='https://cloud.umami.is/script.js'
-        data-website-id='51a14042-a40a-4ea2-a0e0-32a0146e7bc0'
+        src='https://umami-oy31vfaew-kkhys-team.vercel.app/script.js'
+        data-website-id='80a06017-d3fc-4362-ae8a-d5de251c3ef5'
         data-domains='kkhys.me'
         data-exclude-search='true'
       />


### PR DESCRIPTION
- Migrate umami tracking from cloud.umami.is to the self-hosted Vercel deployment
- Update the umami website id to match the new deployment