### PR TITLE
[main] fix: switch umami endpoint to stable project domain

### DIFF
--- a/src/layouts/base-layout.astro
+++ b/src/layouts/base-layout.astro
@@ -23,11 +23,11 @@ const { class: className } = Astro.props;
 
   {import.meta.env.PROD && (
     <>
-      <link rel='preconnect' href='https://umami-oy31vfaew-kkhys-team.vercel.app' crossorigin />
+      <link rel='preconnect' href='https://umami-theta-mauve.vercel.app' crossorigin />
       <script
         is:inline
         defer
-        src='https://umami-oy31vfaew-kkhys-team.vercel.app/script.js'
+        src='https://umami-theta-mauve.vercel.app/script.js'
         data-website-id='80a06017-d3fc-4362-ae8a-d5de251c3ef5'
         data-domains='kkhys.me'
         data-exclude-search='true'


### PR DESCRIPTION
- Switch umami preconnect host to the stable project domain
- Update umami tracking script src to the stable project domain to avoid 401 SSO page on the deployment-specific Vercel URL