### PR TITLE
[main] feat: auto-fetch Zenn posts into entry list

### DIFF
--- a/src/__tests__/lib/loaders/zenn.test.ts
+++ b/src/__tests__/lib/loaders/zenn.test.ts
@@ -1,0 +1,205 @@
+import type { LoaderContext } from "astro/loaders";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseZennFeed, zennLoader } from "#/lib/loaders/zenn";
+
+const buildItem = ({
+  title = "<![CDATA[テスト記事]]>",
+  link = "https://zenn.dev/kkhys/articles/test-article",
+  pubDate = "Sun, 31 May 2026 04:16:54 GMT",
+}: {
+  title?: string;
+  link?: string;
+  pubDate?: string;
+} = {}) =>
+  `<item><title>${title}</title><description><![CDATA[本文]]></description><link>${link}</link><guid isPermaLink="true">${link}</guid><pubDate>${pubDate}</pubDate></item>`;
+
+const buildFeed = (items: string[]) =>
+  `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>feed</title>${items.join(
+    "",
+  )}</channel></rss>`;
+
+describe("parseZennFeed", () => {
+  it("extracts title, url and publishedAt from a CDATA item", () => {
+    const items = parseZennFeed(buildFeed([buildItem()]));
+
+    expect(items).toEqual([
+      {
+        id: "test-article",
+        title: "テスト記事",
+        url: "https://zenn.dev/kkhys/articles/test-article",
+        publishedAt: new Date("Sun, 31 May 2026 04:16:54 GMT"),
+      },
+    ]);
+  });
+
+  it("parses multiple items", () => {
+    const feed = buildFeed([
+      buildItem({ link: "https://zenn.dev/kkhys/articles/a" }),
+      buildItem({ link: "https://zenn.dev/kkhys/articles/b" }),
+    ]);
+
+    expect(parseZennFeed(feed).map((item) => item.id)).toEqual(["a", "b"]);
+  });
+
+  it("decodes HTML entities in non-CDATA titles", () => {
+    const feed = buildFeed([buildItem({ title: "A &amp; B &lt;tag&gt;" })]);
+
+    expect(parseZennFeed(feed)[0]?.title).toBe("A & B <tag>");
+  });
+
+  it("skips items missing required fields", () => {
+    const incomplete = "<item><title>no link or date</title></item>";
+
+    expect(parseZennFeed(buildFeed([incomplete]))).toEqual([]);
+  });
+
+  it("skips items with an unparseable publication date", () => {
+    const feed = buildFeed([buildItem({ pubDate: "not a date" })]);
+
+    expect(parseZennFeed(feed)).toEqual([]);
+  });
+
+  it("returns an empty array for a feed without items", () => {
+    expect(parseZennFeed(buildFeed([]))).toEqual([]);
+  });
+});
+
+describe("zennLoader", () => {
+  const createContext = (metavalues: Record<string, string> = {}) => {
+    const metaStore = new Map<string, string>(Object.entries(metavalues));
+    return {
+      store: {
+        clear: vi.fn(),
+        set: vi.fn(),
+      },
+      meta: {
+        get: vi.fn((key: string) => metaStore.get(key)),
+        set: vi.fn((key: string, value: string) => {
+          metaStore.set(key, value);
+        }),
+        delete: vi.fn((key: string) => {
+          metaStore.delete(key);
+        }),
+        has: vi.fn((key: string) => metaStore.has(key)),
+      },
+      parseData: vi.fn(({ data }) => Promise.resolve(data)),
+      generateDigest: vi.fn(() => "digest"),
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    };
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const okResponse = (
+    body: string,
+    lastModified: string | null = "Sun, 31 May 2026 05:56:28 GMT",
+  ) => ({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(body),
+    headers: {
+      get: (key: string) => (key === "last-modified" ? lastModified : null),
+    },
+  });
+
+  it("clears the store and sets an entry per feed item on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(okResponse(buildFeed([buildItem()])))),
+    );
+
+    const context = createContext();
+    await zennLoader({ feedUrl: "https://zenn.dev/kkhys/feed" }).load(
+      context as unknown as LoaderContext,
+    );
+
+    expect(context.store.clear).toHaveBeenCalledOnce();
+    expect(context.store.set).toHaveBeenCalledWith({
+      id: "test-article",
+      data: {
+        title: "テスト記事",
+        url: "https://zenn.dev/kkhys/articles/test-article",
+        publishedAt: new Date("Sun, 31 May 2026 04:16:54 GMT"),
+      },
+      digest: "digest",
+    });
+  });
+
+  it("persists the Last-Modified header for conditional requests", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(okResponse(buildFeed([buildItem()])))),
+    );
+
+    const context = createContext();
+    await zennLoader({ feedUrl: "https://zenn.dev/kkhys/feed" }).load(
+      context as unknown as LoaderContext,
+    );
+
+    expect(context.meta.set).toHaveBeenCalledWith(
+      "last-modified",
+      "Sun, 31 May 2026 05:56:28 GMT",
+    );
+  });
+
+  it("sends If-Modified-Since and reuses cached entries on a 304 response", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ status: 304, ok: false }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const context = createContext({
+      "last-modified": "Sun, 31 May 2026 05:56:28 GMT",
+    });
+    await zennLoader({ feedUrl: "https://zenn.dev/kkhys/feed" }).load(
+      context as unknown as LoaderContext,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("https://zenn.dev/kkhys/feed", {
+      headers: { "If-Modified-Since": "Sun, 31 May 2026 05:56:28 GMT" },
+    });
+    expect(context.store.clear).not.toHaveBeenCalled();
+    expect(context.store.set).not.toHaveBeenCalled();
+  });
+
+  it("logs an error and keeps existing entries when the fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok: false,
+          status: 503,
+          statusText: "Service Unavailable",
+        }),
+      ),
+    );
+
+    const context = createContext();
+    await zennLoader({ feedUrl: "https://zenn.dev/kkhys/feed" }).load(
+      context as unknown as LoaderContext,
+    );
+
+    expect(context.logger.error).toHaveBeenCalledOnce();
+    expect(context.store.clear).not.toHaveBeenCalled();
+    expect(context.store.set).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning and keeps existing entries when the feed is empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(okResponse(buildFeed([])))),
+    );
+
+    const context = createContext();
+    await zennLoader({ feedUrl: "https://zenn.dev/kkhys/feed" }).load(
+      context as unknown as LoaderContext,
+    );
+
+    expect(context.logger.warn).toHaveBeenCalledOnce();
+    expect(context.store.clear).not.toHaveBeenCalled();
+  });
+});

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -17,4 +17,8 @@ export const me = {
   },
   twitter: "@kkhys_",
   memo: "https://memo.kkhys.me",
+  zenn: {
+    url: "https://zenn.dev/kkhys",
+    feed: "https://zenn.dev/kkhys/feed",
+  },
 } as const;

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,9 +1,11 @@
 import { defineCollection } from "astro:content";
 import { file, glob } from "astro/loaders";
 import { z } from "astro/zod";
+import { me } from "#/config/site";
 import { categoryTitles } from "#/features/blog/config/category";
 import { externalSites } from "#/features/blog/config/external-site";
 import { allTagTitles } from "#/features/blog/config/tag";
+import { zennLoader } from "#/lib/loaders/zenn";
 
 const blog = defineCollection({
   loader: glob({ pattern: "**/*.mdx", base: "./me-content/blog" }),
@@ -56,4 +58,19 @@ const externalPost = defineCollection({
   }),
 });
 
-export const collections = { blog, pages, bucketList, externalPost };
+const zennPost = defineCollection({
+  loader: zennLoader({ feedUrl: me.zenn.feed }),
+  // Zenn posts are auto-fetched from the RSS feed, which carries no category or
+  // tags, so siteName is fixed to "Zenn" and category to "Tech". To override a
+  // specific article's category/tags, add a manual entry with the same URL to
+  // the externalPost collection (it takes precedence in getPublicListEntries).
+  schema: z.object({
+    title: z.string(),
+    url: z.url(),
+    publishedAt: z.date(),
+    siteName: z.literal("Zenn").default("Zenn"),
+    category: z.literal("Tech").default("Tech"),
+  }),
+});
+
+export const collections = { blog, pages, bucketList, externalPost, zennPost };

--- a/src/features/blog/utils/entry.ts
+++ b/src/features/blog/utils/entry.ts
@@ -58,29 +58,40 @@ export const toListEntries = (
     publishedAt: entry.data.publishedAt,
   }));
 
-const toExternalListEntries = (
-  externalEntries: CollectionEntry<"externalPost">[],
-): ListEntry[] =>
-  externalEntries.map((entry) => ({
-    type: "external",
-    title: entry.data.title,
-    url: entry.data.url,
-    siteName: entry.data.siteName as ExternalSite,
-    category: entry.data.category,
-    tags: entry.data.tags,
-    publishedAt: entry.data.publishedAt,
-  }));
+const toExternalEntry = (data: {
+  title: string;
+  url: string;
+  siteName: string;
+  category: string;
+  tags?: string[] | undefined;
+  publishedAt: Date;
+}): ExternalEntry => ({
+  type: "external",
+  title: data.title,
+  url: data.url,
+  siteName: data.siteName as ExternalSite,
+  category: data.category,
+  tags: data.tags,
+  publishedAt: data.publishedAt,
+});
 
 export const getPublicListEntries = async (
   sort: "asc" | "desc" = "desc",
 ): Promise<ListEntry[]> => {
   const blogEntries = await getPublicBlogEntries(sort);
   const externalEntries = await getCollection("externalPost");
+  const zennEntries = await getCollection("zennPost");
 
   const internal = toListEntries(blogEntries);
-  const external = toExternalListEntries(externalEntries);
+  const external = externalEntries.map((entry) => toExternalEntry(entry.data));
+  const zenn = zennEntries.map((entry) => toExternalEntry(entry.data));
 
-  return [...internal, ...external].sort((a, b) => {
+  // Manually curated external posts take precedence over auto-fetched Zenn
+  // posts sharing the same URL, allowing per-article category/tag overrides.
+  const manualUrls = new Set(external.map((entry) => entry.url));
+  const dedupedZenn = zenn.filter((entry) => !manualUrls.has(entry.url));
+
+  return [...internal, ...external, ...dedupedZenn].sort((a, b) => {
     const dateA = a.publishedAt.getTime();
     const dateB = b.publishedAt.getTime();
     return sort === "asc" ? dateA - dateB : dateB - dateA;

--- a/src/lib/loaders/zenn.ts
+++ b/src/lib/loaders/zenn.ts
@@ -1,0 +1,132 @@
+import type { Loader } from "astro/loaders";
+
+export type ZennFeedItem = {
+  id: string;
+  title: string;
+  url: string;
+  publishedAt: Date;
+};
+
+const stripCdata = (value: string): string =>
+  value.replace(/^<!\[CDATA\[([\s\S]*?)\]\]>$/, "$1");
+
+const decodeEntities = (value: string): string =>
+  value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#0*39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+
+const getTagText = (block: string, tag: string): string | undefined => {
+  const match = block.match(
+    new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</${tag}>`),
+  );
+  const raw = match?.[1];
+  if (raw === undefined) return undefined;
+  return decodeEntities(stripCdata(raw.trim()).trim());
+};
+
+const toSlug = (url: string): string | undefined =>
+  url.split("/").filter(Boolean).pop();
+
+/**
+ * Parses a Zenn RSS feed into a list of posts. Only the fields needed for the
+ * external-post listing (title, link, pubDate) are extracted; everything else
+ * in the feed is ignored.
+ */
+export const parseZennFeed = (xml: string): ZennFeedItem[] => {
+  const blocks = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)].map(
+    (match) => match[1] ?? "",
+  );
+
+  return blocks.flatMap((block) => {
+    const title = getTagText(block, "title");
+    const url = getTagText(block, "link");
+    const pubDate = getTagText(block, "pubDate");
+
+    if (!title || !url || !pubDate) return [];
+
+    const id = toSlug(url);
+    if (!id) return [];
+
+    const publishedAt = new Date(pubDate);
+    if (Number.isNaN(publishedAt.getTime())) return [];
+
+    return [{ id, title, url, publishedAt }];
+  });
+};
+
+const LAST_MODIFIED_META_KEY = "last-modified";
+
+/**
+ * Content layer loader that fetches a Zenn RSS feed at build time and exposes
+ * each article as an entry.
+ *
+ * The previous `Last-Modified` value is persisted in the loader `meta` store
+ * (which survives across builds alongside the data store), so subsequent loads
+ * send a conditional `If-Modified-Since` request. When the feed is unchanged
+ * the server returns 304 and the cached entries are reused without re-parsing.
+ *
+ * Network or parse failures are logged and leave any previously loaded entries
+ * untouched rather than failing the build.
+ */
+export const zennLoader = ({ feedUrl }: { feedUrl: string }): Loader => ({
+  name: "zenn-loader",
+  load: async ({ store, meta, parseData, generateDigest, logger }) => {
+    const lastModified = meta.get(LAST_MODIFIED_META_KEY);
+
+    let xml: string;
+    let nextLastModified: string | null;
+    try {
+      const response = await fetch(feedUrl, {
+        headers: lastModified ? { "If-Modified-Since": lastModified } : {},
+      });
+
+      if (response.status === 304) {
+        logger.info(
+          `Zenn feed not modified since ${lastModified}; reusing cached entries.`,
+        );
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`);
+      }
+
+      xml = await response.text();
+      nextLastModified = response.headers.get("last-modified");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(
+        `Failed to fetch Zenn feed from ${feedUrl}: ${message}. Keeping previously loaded entries.`,
+      );
+      return;
+    }
+
+    const items = parseZennFeed(xml);
+
+    if (items.length === 0) {
+      logger.warn(
+        `Zenn feed at ${feedUrl} contained no items. Keeping previously loaded entries.`,
+      );
+      return;
+    }
+
+    store.clear();
+
+    for (const { id, title, url, publishedAt } of items) {
+      const data = await parseData({ id, data: { title, url, publishedAt } });
+      store.set({ id, data, digest: generateDigest(data) });
+    }
+
+    if (nextLastModified) {
+      meta.set(LAST_MODIFIED_META_KEY, nextLastModified);
+    } else {
+      meta.delete(LAST_MODIFIED_META_KEY);
+    }
+
+    logger.info(`Loaded ${items.length} Zenn post(s) from ${feedUrl}.`);
+  },
+});


### PR DESCRIPTION
- Add zennLoader that fetches and parses the Zenn RSS feed into a zennPost content collection
- Add the zennPost collection to content.config.ts with siteName fixed to "Zenn" and category to "Tech"
- Merge auto-fetched Zenn posts into the public list entries, deduping against manually curated externalPost entries by URL so manual entries take precedence
- Extract toExternalEntry helper shared by external and Zenn entries
- Add me.zenn config (URL and feed) to site.ts
- Add unit tests for the Zenn loader