### PR TITLE
[main] feat: respect prefers-reduced-motion

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,6 +33,9 @@
         "rules": {
           "complexity": {
             "noImportantStyles": "off"
+          },
+          "style": {
+            "noDescendingSpecificity": "off"
           }
         }
       }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -354,3 +354,19 @@
     border: 0;
   }
 }
+
+/* ===== Reduced Motion ===== */
+
+/* Honor the user's OS-level "reduce motion" setting (vestibular disorders,
+   motion sensitivity). Kept unlayered so these !important rules reliably win
+   over any layered declaration. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
- Add a global prefers-reduced-motion reset that disables animations, transitions, and smooth scrolling for users who enable the OS-level "reduce motion" setting
- Keep the reset unlayered so its !important declarations reliably win over layered styles
- Disable noDescendingSpecificity for global.css, since the universal reduced-motion reset is inherently low-specificity (matching the existing noImportantStyles carve-out)