### PR TITLE
[main] fix: refine reduced-motion and focus-ring accessibility

### DIFF
--- a/src/features/blog/components/ui/tag-cloud.astro
+++ b/src/features/blog/components/ui/tag-cloud.astro
@@ -60,8 +60,15 @@ const { tags, class: className, ...rest } = Astro.props;
     transform: scale(0.98);
   }
 
-  .tag:focus {
+  .tag:focus-visible {
     outline: none;
+    box-shadow: 0 0 0 3px oklch(from var(--c-ring) l c h / 50%);
+
+    /* box-shadow is stripped in Forced Colors Mode; restore a visible ring. */
+    @media (forced-colors: active) {
+      outline: 2px solid;
+      outline-offset: 2px;
+    }
   }
 
   .tag-emoji {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -294,6 +294,12 @@
     &:focus-visible {
       border-color: var(--c-ring);
       box-shadow: 0 0 0 3px oklch(from var(--c-ring) l c h / 50%);
+
+      /* box-shadow is stripped in Forced Colors Mode; restore a visible ring. */
+      @media (forced-colors: active) {
+        outline: 2px solid;
+        outline-offset: 2px;
+      }
     }
 
     & svg {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -365,13 +365,18 @@
 
 /* Honor the user's OS-level "reduce motion" setting (vestibular disorders,
    motion sensitivity). Kept unlayered so these !important rules reliably win
-   over any layered declaration. */
+   over any layered declaration.
+
+   We collapse interaction transitions and disable smooth scrolling, but
+   deliberately do NOT blanket-kill animation-duration. The only @keyframes
+   in this project are scroll-driven edge-fade masks (category nav, prose
+   tables): they are user-driven affordances, not time-based motion, and
+   forcing a tiny animation-duration risks breaking them. Any future
+   decorative/looping animation should opt into a reduced variant locally. */
 @media (prefers-reduced-motion: reduce) {
   *,
   ::before,
   ::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -4,8 +4,12 @@
 }
 
 .prose img {
-  max-height: 50vh;
+  max-height: 50dvh;
   width: auto;
+}
+
+.prose :is(p, li, blockquote) {
+  text-wrap: pretty;
 }
 
 .prose p,


### PR DESCRIPTION
- Switch tag focus styling from `:focus` to `:focus-visible` and add a visible ring via box-shadow
- Restore visible focus outlines in Forced Colors Mode where box-shadow is stripped
- Scope `prefers-reduced-motion` to transitions and scroll behavior, no longer blanket-killing scroll-driven edge-fade keyframe animations
- Apply `text-wrap: pretty` to prose paragraphs, list items, and blockquotes
- Use `dvh` instead of `vh` for prose media max-height