### PR TITLE
[main] chore: group Expressive Code packages in Renovate with automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,11 @@
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "groupName": "Expressive Code",
+      "matchPackageNames": ["astro-expressive-code", "@expressive-code/**"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
- Add a Renovate package rule grouping astro-expressive-code and @expressive-code/** under "Expressive Code"
- Enable automerge for the grouped Expressive Code updates