### PR TITLE
[main] style: make link card responsive on mobile

### DIFF
--- a/src/features/blog/components/ui/blocks/link-card.astro
+++ b/src/features/blog/components/ui/blocks/link-card.astro
@@ -40,8 +40,10 @@ const { title, description, image } = await getMetadata(props.href);
           <Image
               src={image.src}
               alt={`${title}のカバー画像`}
-              width={460}
-              height={240}
+              width={1200}
+              height={630}
+              widths={[230, 460, 690, 920, 1200]}
+              sizes="(max-width: 639.98px) 100vw, 230px"
               format="avif"
               class="link-card-img"
           />
@@ -63,11 +65,12 @@ const { title, description, image } = await getMetadata(props.href);
     transform: scale(0.99);
   }
 
+  /* Mobile: stack vertically with the image on top (image is the last child,
+     so column-reverse lifts it above the text). */
   .link-card-inner {
     display: flex;
-    height: 120px;
+    flex-direction: column-reverse;
     width: 100%;
-    align-items: center;
     color: inherit;
     text-decoration: none;
     box-shadow: var(--shadow-sm);
@@ -80,7 +83,7 @@ const { title, description, image } = await getMetadata(props.href);
 
   .link-card-content {
     min-width: 0;
-    flex: 1;
+    width: 100%;
     padding: 0.5rem 1rem;
   }
 
@@ -128,21 +131,34 @@ const { title, description, image } = await getMetadata(props.href);
     font-size: var(--fs-xs);
   }
 
+  /* Mobile: full-width banner on top, kept at the standard OG ratio. */
   .link-card-image {
-    width: 120px;
-    height: 120px;
-    max-width: 230px;
-  }
-
-  @media (width >= 640px) {
-    .link-card-image {
-      width: auto;
-    }
+    width: 100%;
+    aspect-ratio: 40 / 21;
   }
 
   .link-card-img {
     width: 100%;
     height: 100%;
     object-fit: cover;
+  }
+
+  /* Desktop: horizontal row with the image beside the text, same ratio. */
+  @media (width >= 640px) {
+    .link-card-inner {
+      flex-direction: row;
+      height: 120px;
+      align-items: center;
+    }
+
+    .link-card-content {
+      flex: 1;
+      width: auto;
+    }
+
+    .link-card-image {
+      width: auto;
+      height: 100%;
+    }
   }
 </style>


### PR DESCRIPTION
- Stack link card vertically on mobile with a full-width banner image on top via flex column-reverse
- Switch image to OG aspect ratio (1200x630) with responsive widths and sizes attributes
- Keep horizontal layout with side image on desktop (width >= 640px)
- Use aspect-ratio 40/21 to preserve the standard OG image proportions