### PR TITLE
[main] chore: increase blog list page size to 20

### DIFF
--- a/src/config/constant.ts
+++ b/src/config/constant.ts
@@ -1,2 +1,2 @@
-export const countPerPage = 10;
+export const countPerPage = 20;
 export const relatedEntriesCount = 5;


### PR DESCRIPTION
- Increase blog list page size from 10 to 20 in src/config/constant.ts
- Halve the blog list page count (~76 entries now span 4 pages instead of 8)
- Apply the larger page size to the blog index, category, and tag listings