### PR TITLE
[main] fix: align inline external link baseline cross-browser

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,15 +64,15 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
   }
 
   .external-link {
-    display: inline-flex;
-    align-items: center;
+    white-space: nowrap;
   }
 
   .external-icon {
+    display: inline-block;
     margin-inline: 0.25rem;
-    margin-top: 0.125rem;
     width: 0.75rem;
     height: 0.75rem;
+    vertical-align: -0.05em;
   }
 
   .home-link:visited {


### PR DESCRIPTION
- Replace inline-flex layout on home links with white-space: nowrap to keep text on the natural baseline
- Render the external-link icon as inline-block aligned via vertical-align instead of flex centering
- Drop the manual margin-top offset on the icon now that baseline alignment handles vertical positioning