### PR TITLE
[main] fix: prevent category nav mask shadow on Firefox

### DIFF
--- a/src/features/blog/components/ui/category-navigation.astro
+++ b/src/features/blog/components/ui/category-navigation.astro
@@ -41,7 +41,11 @@ const pathname = Astro.url.pathname;
     -ms-overflow-style: none;
     scrollbar-width: none;
 
-    animation: scroll-mask linear both;
+    /* No `both` fill: with it, Firefox keeps applying a keyframe mask even when
+       the nav doesn't overflow (timeline inactive), clipping the leftmost pill
+       and making it look shadowed. Firefox also needs an explicit duration for
+       scroll-driven animations; the scroll timeline still drives progress. */
+    animation: scroll-mask 1ms linear;
     animation-timeline: --category-scroll;
   }
 


### PR DESCRIPTION
- Remove `both` fill mode from the category nav scroll-mask animation so Firefox no longer applies the keyframe mask when the nav does not overflow
- Add an explicit `1ms` duration to the scroll-driven animation, which Firefox requires while the scroll timeline still drives progress
- Fix the leftmost category pill appearing clipped and shadowed on Firefox