### PR TITLE
[main] style: unify keyboard focus rings across the site

### DIFF
--- a/src/features/blog/components/ui/blocks/memo-card.astro
+++ b/src/features/blog/components/ui/blocks/memo-card.astro
@@ -169,6 +169,13 @@ const blurryImages = hasImages
     background-color: oklch(from var(--c-surface) l c h / 50%);
   }
 
+  /* The card clips its content (overflow: hidden), so an outer ring would be
+     invisible; draw it inset against the card edge. */
+  .memo-card-link:focus-visible {
+    outline: var(--ring-width) solid var(--ring);
+    outline-offset: calc(-1 * var(--ring-width));
+  }
+
   .memo-header {
     display: flex;
     align-items: flex-start;

--- a/src/features/blog/components/ui/category-navigation.astro
+++ b/src/features/blog/components/ui/category-navigation.astro
@@ -84,6 +84,13 @@ const pathname = Astro.url.pathname;
     color: var(--c-primary);
   }
 
+  /* The scroller clips overflow (and applies an edge-fade mask), so draw the
+     ring inset to keep it fully visible. */
+  .cat-link:focus-visible {
+    outline: var(--ring-width) solid var(--ring);
+    outline-offset: calc(-1 * var(--ring-width));
+  }
+
   .cat-link--active {
     background-color: var(--c-primary);
     color: var(--c-primary-text);

--- a/src/features/blog/components/ui/entry-list.astro
+++ b/src/features/blog/components/ui/entry-list.astro
@@ -107,6 +107,13 @@ const { entries, class: className, showDate = false, ...rest } = Astro.props;
     background-color: oklch(from var(--c-surface) l c h / 50%);
   }
 
+  /* Full-bleed rows: an outer ring would overlap the sibling separators, so
+     draw it inset. */
+  .entry-item:focus-visible {
+    outline: var(--ring-width) solid var(--ring);
+    outline-offset: calc(-1 * var(--ring-width));
+  }
+
   .entry-left {
     display: flex;
     align-items: center;

--- a/src/features/blog/components/ui/pagination.astro
+++ b/src/features/blog/components/ui/pagination.astro
@@ -191,17 +191,24 @@ const menuId = `page-menu-${currentPage}-${lastPage}`;
     rotate: 180deg;
   }
 
-  /* Inset focus ring so the pill's rounded edges don't clip it. */
+  /* Round the end segments' outer corners to match the pill so a per-segment
+     inset ring follows the rounded ends instead of cutting a square corner. */
+  .pager > .pager-arrow:first-child {
+    border-start-start-radius: var(--radius-full);
+    border-end-start-radius: var(--radius-full);
+  }
+
+  .pager > .pager-current + .pager-arrow {
+    border-start-end-radius: var(--radius-full);
+    border-end-end-radius: var(--radius-full);
+  }
+
+  /* Inset focus ring per segment: drawn inside the segment so the pill's
+     overflow clip never trims it, and it follows the rounded ends above. */
   .pager-arrow:focus-visible,
   .pager-current:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 2px oklch(from var(--c-ring) l c h / 55%);
-
-    /* box-shadow is stripped in Forced Colors Mode; restore a visible ring. */
-    @media (forced-colors: active) {
-      outline: 2px solid;
-      outline-offset: -2px;
-    }
+    outline: var(--ring-width) solid var(--ring);
+    outline-offset: calc(-1 * var(--ring-width));
   }
 
   /* Page picker popover, anchored above the center segment. */
@@ -319,8 +326,8 @@ const menuId = `page-menu-${currentPage}-${lastPage}`;
   }
 
   .page-menu-item:focus-visible {
-    outline: none;
-    box-shadow: inset 0 0 0 2px oklch(from var(--c-ring) l c h / 55%);
+    outline: var(--ring-width) solid var(--ring);
+    outline-offset: calc(-1 * var(--ring-width));
   }
 
   /* The current page is "you are here": filled, non-interactive, no pointer. */

--- a/src/features/blog/components/ui/tag-cloud.astro
+++ b/src/features/blog/components/ui/tag-cloud.astro
@@ -61,14 +61,8 @@ const { tags, class: className, ...rest } = Astro.props;
   }
 
   .tag:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 3px oklch(from var(--c-ring) l c h / 50%);
-
-    /* box-shadow is stripped in Forced Colors Mode; restore a visible ring. */
-    @media (forced-colors: active) {
-      outline: 2px solid;
-      outline-offset: 2px;
-    }
+    outline: var(--ring-width) solid var(--ring);
+    outline-offset: var(--ring-offset);
   }
 
   .tag-emoji {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -72,6 +72,13 @@
     --fw-medium: 500;
 
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+
+    /* Unified focus ring. Outline (not box-shadow) so it follows
+       border-radius, never shifts layout, and survives Forced Colors Mode
+       where box-shadow rings are stripped. */
+    --ring: oklch(from var(--c-ring) l c h / 55%);
+    --ring-width: 2px;
+    --ring-offset: 2px;
   }
 }
 
@@ -80,7 +87,15 @@
 @layer base {
   * {
     border-color: var(--c-border);
-    outline-color: oklch(from var(--c-ring) l c h / 50%);
+  }
+
+  /* Site-wide keyboard focus ring. Every focusable element gets the same
+     calm, theme-aware outline by default. Elements inside clipping
+     containers (full-bleed rows, bordered cards, masked scrollers) draw the
+     identical ring inset via a negative outline-offset. */
+  :focus-visible {
+    outline: var(--ring-width) solid var(--ring);
+    outline-offset: var(--ring-offset);
   }
 
   html {
@@ -292,14 +307,8 @@
     }
 
     &:focus-visible {
-      border-color: var(--c-ring);
-      box-shadow: 0 0 0 3px oklch(from var(--c-ring) l c h / 50%);
-
-      /* box-shadow is stripped in Forced Colors Mode; restore a visible ring. */
-      @media (forced-colors: active) {
-        outline: 2px solid;
-        outline-offset: 2px;
-      }
+      outline: var(--ring-width) solid var(--ring);
+      outline-offset: var(--ring-offset);
     }
 
     & svg {


### PR DESCRIPTION
- Add shared `--ring`, `--ring-width`, and `--ring-offset` design tokens in global.css
- Apply a site-wide `:focus-visible` outline so every focusable element shares the same theme-aware ring
- Replace box-shadow focus rings with outline so rings follow border-radius, avoid layout shift, and survive Forced Colors Mode
- Draw inset focus rings for elements inside clipping containers (memo cards, category nav, full-bleed entry rows)
- Round the pagination end segments so per-segment inset rings follow the pill's rounded ends