### PR TITLE
[main] feat: highlight active toc entry on scroll

### DIFF
--- a/src/__tests__/features/blog/utils/toc-active.test.ts
+++ b/src/__tests__/features/blog/utils/toc-active.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { pickActiveId } from "#/features/blog/utils/toc-active";
+
+describe("pickActiveId", () => {
+  const ordered = ["intro", "usage", "api", "faq"];
+
+  it("returns the only visible heading", () => {
+    expect(pickActiveId(ordered, new Set(["usage"]), null)).toBe("usage");
+  });
+
+  it("returns the topmost visible heading in document order", () => {
+    expect(pickActiveId(ordered, new Set(["faq", "usage"]), "intro")).toBe(
+      "usage",
+    );
+  });
+
+  it("keeps the previous id when nothing is visible", () => {
+    expect(pickActiveId(ordered, new Set(), "usage")).toBe("usage");
+  });
+
+  it("returns null when nothing is visible and there is no previous id", () => {
+    expect(pickActiveId(ordered, new Set(), null)).toBeNull();
+  });
+
+  it("ignores visible ids that are not part of the toc", () => {
+    expect(pickActiveId(ordered, new Set(["unknown"]), "api")).toBe("api");
+  });
+});

--- a/src/features/blog/components/ui/toc.astro
+++ b/src/features/blog/components/ui/toc.astro
@@ -72,9 +72,55 @@ const items = headings.filter(({ depth }) => depth === 2 || depth === 3);
     line-height: 1.25;
     color: var(--c-sub);
     text-decoration: none;
+    transition: color 0.2s;
   }
 
-  .toc-link:hover {
+  .toc-link:hover,
+  .toc-link--active {
     color: var(--c-text);
   }
 </style>
+
+<script>
+  import { pickActiveId } from "#/features/blog/utils/toc-active";
+
+  const ACTIVE_CLASS = "toc-link--active";
+
+  const toc = document.querySelector(".toc");
+  if (toc) {
+    const links = [...toc.querySelectorAll<HTMLAnchorElement>(".toc-link")];
+    const linkById = new Map(
+      links.map((link) => [decodeURIComponent(link.hash.slice(1)), link]),
+    );
+    const headings = [
+      ...document.querySelectorAll<HTMLElement>(".prose :is(h2, h3)[id]"),
+    ].filter((heading) => linkById.has(heading.id));
+    const orderedIds = headings.map((heading) => heading.id);
+    const visibleIds = new Set<string>();
+    let activeId: string | null = null;
+
+    const setActive = (id: string | null) => {
+      if (id === activeId) return;
+      activeId = id;
+      const activeLink = id ? linkById.get(id) : undefined;
+      for (const link of links) {
+        link.classList.toggle(ACTIVE_CLASS, link === activeLink);
+      }
+      activeLink?.scrollIntoView({ block: "nearest" });
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) visibleIds.add(entry.target.id);
+          else visibleIds.delete(entry.target.id);
+        }
+        setActive(pickActiveId(orderedIds, visibleIds, activeId));
+      },
+      // Treat the top 20% of the viewport as the "current section" band.
+      { rootMargin: "0px 0px -80% 0px" },
+    );
+
+    for (const heading of headings) observer.observe(heading);
+  }
+</script>

--- a/src/features/blog/utils/toc-active.ts
+++ b/src/features/blog/utils/toc-active.ts
@@ -1,0 +1,16 @@
+/**
+ * Pick the table-of-contents entry that should be marked active.
+ *
+ * The active entry is the first heading (in document order) currently within
+ * the observer's detection band. When no heading is in the band — e.g. while
+ * scrolling through the gap between two headings — the previously active id is
+ * kept so the highlight does not flicker off.
+ */
+export const pickActiveId = (
+  orderedIds: readonly string[],
+  visibleIds: ReadonlySet<string>,
+  previousId: string | null,
+): string | null => {
+  const current = orderedIds.find((id) => visibleIds.has(id));
+  return current ?? previousId;
+};


### PR DESCRIPTION
- Add `pickActiveId` helper to resolve the active toc entry from visible headings in document order
- Track heading visibility via IntersectionObserver in toc.astro and toggle a `toc-link--active` class
- Keep the previous active id when no heading is in the detection band to avoid highlight flicker
- Style the active toc link to match the hover color
- Add unit tests covering the active-id selection logic