### PR TITLE
[main] style: move breadcrumb to top-left on desktop

### DIFF
--- a/src/components/ui/breadcrumb.astro
+++ b/src/components/ui/breadcrumb.astro
@@ -57,8 +57,9 @@ const isSimple = segments.length === 1;
   @media (width >= 1280px) {
     .breadcrumb {
       position: fixed;
-      top: 0;
-      transform: translateY(170px) translateX(-260px);
+      /* Pin to the very top-left of the viewport. */
+      top: 2rem;
+      left: 2rem;
     }
   }
 

--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -80,11 +80,11 @@ const currentDate = new Date();
   />
   <slot name='head' slot='head' />
   <section>
+    <Breadcrumb segments={[
+      { label: "Blog", href: "/blog" },
+      { label: categoryObject.label, href: `/blog/categories/${categorySlug}`, isCurrent: true },
+    ]} />
     <div class="sidebar">
-      <Breadcrumb segments={[
-        { label: "Blog", href: "/blog" },
-        { label: categoryObject.label, href: `/blog/categories/${categorySlug}`, isCurrent: true },
-      ]} />
       <Toc headings={headings} />
     </div>
     <div class:list={[status === 'draft' && 'draft-header']}>
@@ -144,14 +144,11 @@ const currentDate = new Date();
     .sidebar {
       position: fixed;
       top: 0;
-      transform: translateY(170px) translateX(-260px);
+      /* Keep the ToC where it was: 170px (original sidebar offset) + 56px
+         (the breadcrumb block that has since moved to the top) holds it in place. */
+      left: 2rem;
+      transform: translateY(226px);
       width: fit-content;
-    }
-
-    .sidebar :global(.breadcrumb) {
-      position: static;
-      transform: none;
-      margin-bottom: 32px;
     }
   }
 


### PR DESCRIPTION
- Pin the breadcrumb to the top-left of the viewport on desktop (fixed top: 2rem / left: 2rem) instead of transform-offsetting it inside the sidebar
- Move the breadcrumb out of the sidebar block in the blog layout so it stands alone
- Reposition the ToC to hold its original placement now that the breadcrumb has moved out
- Drop the now-unused sidebar breadcrumb override styles