### PR TITLE
[main] style: colorize emoji eye-catch with fluent fallback

### DIFF
--- a/src/__tests__/lib/api/emoji.test.ts
+++ b/src/__tests__/lib/api/emoji.test.ts
@@ -35,6 +35,37 @@ describe("getIconCode", () => {
   });
 });
 
+describe("getFirstGrapheme", () => {
+  let getFirstGrapheme: (value: string) => string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const mod = await import("#/lib/api/emoji");
+    getFirstGrapheme = mod.getFirstGrapheme;
+  });
+
+  it("returns the first grapheme of a simple string", () => {
+    expect(getFirstGrapheme("😀x")).toBe("😀");
+  });
+
+  it("keeps a regional indicator (flag) pair intact", () => {
+    // U+1F1EA U+1F1EA (Estonia flag)
+    const flag = "🇪🇪";
+    expect(getFirstGrapheme(flag)).toBe(flag);
+  });
+
+  it("keeps a ZWJ sequence intact", () => {
+    // Family emoji: U+1F468 U+200D U+1F469 U+200D U+1F467
+    const zwj = String.fromCharCode(8205);
+    const family = `👨${zwj}👩${zwj}👧`;
+    expect(getFirstGrapheme(`${family}😀`)).toBe(family);
+  });
+
+  it("returns an empty string for an empty input", () => {
+    expect(getFirstGrapheme("")).toBe("");
+  });
+});
+
 describe("loadEmoji", () => {
   type EmojiType =
     | "twemoji"
@@ -50,6 +81,7 @@ describe("loadEmoji", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({
+        ok: true,
         text: () => Promise.resolve("<svg>mock</svg>"),
       }),
     );
@@ -112,5 +144,19 @@ describe("loadEmoji", () => {
     expect(fetch).toHaveBeenCalledWith(
       "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/svg/1f600.svg",
     );
+  });
+
+  it("returns undefined when the response is not ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        text: () => Promise.resolve("Not Found"),
+      }),
+    );
+    const { loadEmoji: load } = await import("#/lib/api/emoji");
+
+    const result = await load("fluent", "1f1ea-1f1ea");
+    expect(result).toBeUndefined();
   });
 });

--- a/src/components/emoji-svg.tsx
+++ b/src/components/emoji-svg.tsx
@@ -2,7 +2,7 @@
 /** @jsxRuntime automatic */
 
 import satori from "satori";
-import { getIconCode, loadEmoji } from "#/lib/api/emoji";
+import { getFirstGrapheme, getIconCode, loadEmoji } from "#/lib/api/emoji";
 import { loadFont } from "#/utils/font-loader";
 
 export const emojiSvg = async ({
@@ -12,7 +12,7 @@ export const emojiSvg = async ({
   emoji: string;
   isColored?: boolean;
 }) => {
-  const firstEmoji = Array.from(emoji)[0];
+  const firstEmoji = getFirstGrapheme(emoji);
 
   const selectedFont = isColored
     ? await loadFont("./src/assets/Inter-Medium.ttf")
@@ -46,7 +46,12 @@ export const emojiSvg = async ({
       ],
       loadAdditionalAsset: async (code: string, segment: string) => {
         if (isColored && code === "emoji") {
-          const result = await loadEmoji("fluent", getIconCode(segment));
+          const iconCode = getIconCode(segment);
+          // Prefer fluent, but fall back to twemoji for emojis fluent omits
+          // (notably country/region flags).
+          const result =
+            (await loadEmoji("fluent", iconCode)) ??
+            (await loadEmoji("twemoji", iconCode));
           if (!result) {
             throw new Error(`Failed to load emoji for segment: ${segment}`);
           }

--- a/src/features/blog/components/ui/entry-list.astro
+++ b/src/features/blog/components/ui/entry-list.astro
@@ -54,7 +54,7 @@ const { entries, class: className, showDate = false, ...rest } = Astro.props;
       return (
         <a href={`/blog/posts/${entry.id}`} class="entry-item">
           <div class="entry-left">
-            <EmojiEyeCatch emoji={entry.emoji} size="sm" class="entry-emoji" />
+            <EmojiEyeCatch emoji={entry.emoji} size="sm" isColored class="entry-emoji" />
             <Budoux>
               <p class="palt">{entry.title}</p>
             </Budoux>

--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -88,7 +88,7 @@ const currentDate = new Date();
       <Toc headings={headings} />
     </div>
     <div class:list={[status === 'draft' && 'draft-header']}>
-      <EmojiEyeCatch emoji={emoji} />
+      <EmojiEyeCatch emoji={emoji} isColored />
       {status === "draft" && (
           <span class="draft-badge">Draft</span>
       )}

--- a/src/lib/api/emoji.ts
+++ b/src/lib/api/emoji.ts
@@ -36,9 +36,18 @@ export const getIconCode = (char: string) => {
   return toCodePoint(!char.includes(U200D) ? char.replace(UFE0Fg, "") : char);
 };
 
+// Return the first grapheme cluster, not the first code point. Flags (Regional
+// Indicator pairs) and ZWJ sequences span multiple code points, so naive
+// indexing would split them and yield a broken fragment.
+export const getFirstGrapheme = (value: string) => {
+  const segmenter = new Intl.Segmenter();
+  const [first] = segmenter.segment(value);
+  return first?.segment ?? value;
+};
+
 import { createCache } from "#/lib/api/cache";
 
-const cache = createCache<string>();
+const cache = createCache<string | undefined>();
 
 export const loadEmoji = (type: keyof typeof apis, code: string) => {
   const key = `${type}:${code}`;
@@ -46,13 +55,13 @@ export const loadEmoji = (type: keyof typeof apis, code: string) => {
   return cache(key, async () => {
     const resolvedType = type && apis[type] ? type : "twemoji";
     const api = apis[resolvedType];
+    const url =
+      typeof api === "function" ? api(code) : `${api}${code.toUpperCase()}.svg`;
 
-    if (typeof api === "function") {
-      const r = await fetch(api(code));
-      return r.text();
-    }
-
-    const r = await fetch(`${api}${code.toUpperCase()}.svg`);
+    const r = await fetch(url);
+    // A set may not provide every emoji (e.g. fluent omits country flags).
+    // Return undefined so callers can fall back to another set.
+    if (!r.ok) return undefined;
     return r.text();
   });
 };


### PR DESCRIPTION
- Colorize emoji eye-catch in blog layout and entry list via the `isColored` prop
- Add `getFirstGrapheme` to take the first grapheme cluster instead of the first code point, keeping flags and ZWJ sequences intact
- Fall back from fluent to twemoji for emojis fluent omits (notably country/region flags)
- Return undefined from `loadEmoji` on non-ok responses so callers can fall back to another set
- Add unit tests for `getFirstGrapheme` and the not-ok response path