### PR TITLE
[main] style: refine created/updated date popover layout

### DIFF
--- a/src/layouts/blog-layout.astro
+++ b/src/layouts/blog-layout.astro
@@ -234,22 +234,21 @@ const currentDate = new Date();
     margin: 0;
     display: grid;
     grid-template-columns: auto auto;
-    column-gap: 0.75rem;
-    row-gap: 0.25rem;
+    column-gap: 1.5rem;
+    row-gap: 0.375rem;
     align-items: baseline;
   }
 
   .post-updated-at__label {
     margin: 0;
-    font-size: var(--fs-2xs);
+    font-size: var(--fs-xs);
     font-weight: var(--fw-normal);
     color: var(--c-sub);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
   }
 
   .post-updated-at__date {
     margin: 0;
+    justify-self: end;
     font-size: var(--fs-sm);
     font-variant-numeric: tabular-nums;
     color: var(--c-text);


### PR DESCRIPTION
- Drop the uppercase label treatment and letter-spacing on the created/updated labels
- Right-align the dates with tabular figures so created and updated digits line up
- Widen the column and row gaps so the popover reads as a tidy two-column list