### PR TITLE
[main] fix: clip blur halo in link card image

### DIFF
--- a/src/features/blog/components/ui/blocks/link-card.astro
+++ b/src/features/blog/components/ui/blocks/link-card.astro
@@ -143,10 +143,13 @@ const blurryImage = image
     font-size: var(--fs-xs);
   }
 
-  /* Mobile: full-width banner on top, kept at the standard OG ratio. */
+  /* Mobile: full-width banner on top, kept at the standard OG ratio.
+     overflow: hidden clips the blur halo so it doesn't bleed past the image
+     box into the adjacent text on the desktop horizontal layout. */
   .link-card-image {
     width: 100%;
     aspect-ratio: 40 / 21;
+    overflow: hidden;
   }
 
   .link-card-blur-load {


### PR DESCRIPTION
- Add overflow: hidden to the link card image container to clip the blur halo
- Prevent the blur(36px) filter from bleeding into adjacent text on the desktop horizontal layout