### PR TITLE
[main] build: migrate markdown config to unified() processor

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,3 +1,4 @@
+import { unified } from "@astrojs/markdown-remark";
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
@@ -31,25 +32,27 @@ export default defineConfig({
   },
   markdown: {
     syntaxHighlight: false,
-    smartypants: false,
-    remarkPlugins: [
-      remarkUnwrapImages,
-      remarkYoutubeBlock,
-      remarkLinkCard,
-      remarkFootnoteTitle,
-      remarkBlockQuoteAlert,
-    ],
-    remarkRehype: {
-      footnoteLabel: " ",
-      footnoteBackLabel: "戻る",
-      footnoteLabelTagName: "hr",
-    },
-    rehypePlugins: [
-      rehypeSlug,
-      rehypeSlugWithCustomId,
-      rehypeMermaidCached,
-      rehypeBudoux,
-    ],
+    processor: unified({
+      smartypants: false,
+      remarkPlugins: [
+        remarkUnwrapImages,
+        remarkYoutubeBlock,
+        remarkLinkCard,
+        remarkFootnoteTitle,
+        remarkBlockQuoteAlert,
+      ],
+      remarkRehype: {
+        footnoteLabel: " ",
+        footnoteBackLabel: "戻る",
+        footnoteLabelTagName: "hr",
+      },
+      rehypePlugins: [
+        rehypeSlug,
+        rehypeSlugWithCustomId,
+        rehypeMermaidCached,
+        rehypeBudoux,
+      ],
+    }),
   },
   image: {
     remotePatterns: [{ protocol: "https" }],

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "sharp": "0.35.2"
   },
   "devDependencies": {
+    "@astrojs/markdown-remark": "7.2.0",
     "@biomejs/biome": "2.5.0",
     "@expressive-code/plugin-line-numbers": "0.43.1",
     "@types/bun": "1.3.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
         specifier: 0.35.2
         version: 0.35.2
     devDependencies:
+      '@astrojs/markdown-remark':
+        specifier: 7.2.0
+        version: 7.2.0
       '@biomejs/biome':
         specifier: 2.5.0
         version: 2.5.0


### PR DESCRIPTION
- Wrap remark/rehype plugin config in the unified() processor from @astrojs/markdown-remark
- Add @astrojs/markdown-remark as an explicit dependency
- Sync pnpm-lock.yaml for the new dependency