### PR TITLE
[main] feat: show site name above breadcrumb trail

### DIFF
--- a/src/components/ui/breadcrumb.astro
+++ b/src/components/ui/breadcrumb.astro
@@ -1,5 +1,6 @@
 ---
 import ArrowLeftIcon from "#/components/icons/arrow-left.svg";
+import { siteConfig } from "#/config/site";
 
 interface BreadcrumbSegment {
   label: string;
@@ -8,30 +9,21 @@ interface BreadcrumbSegment {
 }
 
 interface Props {
-  segments: [BreadcrumbSegment, ...BreadcrumbSegment[]];
+  segments?: BreadcrumbSegment[] | undefined;
   class?: string | null | undefined;
 }
 
-const { segments, class: className } = Astro.props;
-const first = segments[0];
-const isSimple = segments.length === 1;
+const { segments = [], class: className } = Astro.props;
+const hasTrail = segments.length > 0;
 ---
 
-<div class:list={["breadcrumb", className]}>
-  {isSimple ? (
-    <a href={first.href} class="breadcrumb-link">
-      <ArrowLeftIcon class="breadcrumb-icon" />
-      {first.label}
-    </a>
-  ) : (
+<nav class:list={["breadcrumb", className]} aria-label="Breadcrumb">
+  <a href="/" class="breadcrumb-site-name">{siteConfig.title}</a>
+  {hasTrail && (
     <span class="breadcrumb-inner">
-      <a href={first.href} class="breadcrumb-link">
-        <ArrowLeftIcon class="breadcrumb-icon" />
-        {first.label}
-      </a>
-      {segments.slice(1).map((segment) => (
+      {segments.map((segment, index) => (
         <>
-          <span class="breadcrumb-sep">/</span>
+          {index > 0 && <span class="breadcrumb-sep">/</span>}
           {segment.isCurrent ? (
             <b class="breadcrumb-current">
               <a href={segment.href} class="breadcrumb-current-link">
@@ -40,6 +32,7 @@ const isSimple = segments.length === 1;
             </b>
           ) : (
             <a href={segment.href} class="breadcrumb-link">
+              {index === 0 && <ArrowLeftIcon class="breadcrumb-icon" />}
               {segment.label}
             </a>
           )}
@@ -47,7 +40,7 @@ const isSimple = segments.length === 1;
       ))}
     </span>
   )}
-</div>
+</nav>
 
 <style>
   .breadcrumb {
@@ -61,6 +54,20 @@ const isSimple = segments.length === 1;
       top: 2rem;
       left: 2rem;
     }
+  }
+
+  .breadcrumb-site-name {
+    display: block;
+    margin-bottom: 0.25rem;
+    color: var(--c-text);
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-medium);
+    font-feature-settings: "palt";
+    text-decoration: none;
+  }
+
+  .breadcrumb-site-name:hover {
+    text-decoration: underline;
   }
 
   .breadcrumb-inner {

--- a/src/layouts/page-layout.astro
+++ b/src/layouts/page-layout.astro
@@ -21,7 +21,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     slot='seo'
   />
   <slot name='head' slot='head'/>
-  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
+  <Breadcrumb />
   <h1 class="page-title">{title}</h1>
   <section class="prose page-body">
     <slot />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -10,7 +10,7 @@ import BaseLayout from "#/layouts/base-layout.astro";
       noindex
       slot='seo'
   />
-  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
+  <Breadcrumb />
   <h1 class="page-title">
     ページが見つかりませんでした
   </h1>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -26,7 +26,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     image={seoImage}
     slot='seo'
   />
-  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
+  <Breadcrumb />
   <h1 class="page-title">
     About
   </h1>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -32,7 +32,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     image={seoImage}
     slot='seo'
   />
-  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
+  <Breadcrumb />
   <section>
     <h1 class="page-title">Blog</h1>
     <CategoryNavigation class="blog-nav" />

--- a/src/pages/blog/categories/[category]/[...page].astro
+++ b/src/pages/blog/categories/[category]/[...page].astro
@@ -49,7 +49,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     image={seoImage}
     slot='seo'
   />
-  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
+  <Breadcrumb />
   <section>
     <h1 class="page-title">Blog</h1>
     <CategoryNavigation class="blog-nav" />

--- a/src/pages/bucket-list.astro
+++ b/src/pages/bucket-list.astro
@@ -61,7 +61,7 @@ const seoImage = `${BASE_URL}/api/og/default.png`;
     image={seoImage}
     slot='seo'
   />
-  <Breadcrumb segments={[{ label: "Home", href: "/" }]} />
+  <Breadcrumb />
   <h1 class="page-title">
     バケットリスト
   </h1>


### PR DESCRIPTION
- Add the site name (Keisuke Hayashi) as a home link above the breadcrumb at the same font size
- Remove the redundant "Home" segment from all pages now that the site name serves as the home anchor
- Wrap the breadcrumb in a <nav aria-label="Breadcrumb"> landmark for accessibility
- Make the segments prop optional so home-level pages render only the site name