### PR TITLE
[main] fix: drop og:images that serve non-image content

### DIFF
--- a/src/__tests__/lib/api/metadata.test.ts
+++ b/src/__tests__/lib/api/metadata.test.ts
@@ -69,9 +69,27 @@ describe("getMetadata", () => {
   describe("production environment", () => {
     let mockFetchSiteMetadata: ReturnType<typeof vi.fn>;
 
+    // PNG magic number, padded so the byte sniffer reads a full chunk.
+    const PNG_BYTES = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]);
+
+    const mockImageResponse = (bytes: Uint8Array) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(bytes as unknown as BodyInit, {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          }),
+        ),
+      );
+    };
+
     beforeEach(async () => {
       vi.resetModules();
       vi.stubEnv("CI", "");
+      mockImageResponse(PNG_BYTES);
       mockFetchSiteMetadata = vi.fn().mockResolvedValue({
         title: "Example",
         description: "Example description",
@@ -89,6 +107,7 @@ describe("getMetadata", () => {
     });
 
     afterEach(() => {
+      vi.unstubAllGlobals();
       vi.unstubAllEnvs();
       vi.resetModules();
     });
@@ -144,7 +163,7 @@ describe("getMetadata", () => {
       expect(result.image).toBeUndefined();
     });
 
-    it("keeps non-SVG og:image untouched", async () => {
+    it("keeps a non-SVG og:image whose bytes are a real raster image", async () => {
       mockFetchSiteMetadata.mockResolvedValueOnce({
         title: "PNG site",
         description: "desc",
@@ -158,6 +177,45 @@ describe("getMetadata", () => {
         width: "1",
         height: "1",
       });
+    });
+
+    it("drops an og:image that serves HTML despite an image content-type", async () => {
+      // Vercel's docs-og endpoint advertises image/png but returns an HTML
+      // bot-protection page to non-browser clients, which crashes sharp.
+      mockImageResponse(new TextEncoder().encode("<!DOCTYPE html><html>"));
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "Fake image site",
+        description: "desc",
+        image: {
+          src: "https://vercel.com/api/docs-og?title=Deploy%20Hooks",
+          width: "1200",
+          height: "630",
+        },
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://fake-image-example.com");
+      expect(result.image).toBeUndefined();
+    });
+
+    it("drops an og:image when fetching its bytes fails", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new Error("Network error")),
+      );
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "Unreachable image site",
+        description: "desc",
+        image: {
+          src: "https://example.com/unreachable.png",
+          width: "1",
+          height: "1",
+        },
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://unreachable-image-example.com");
+      expect(result.image).toBeUndefined();
     });
   });
 });

--- a/src/lib/api/metadata.ts
+++ b/src/lib/api/metadata.ts
@@ -11,10 +11,68 @@ const isSvgSrc = (src: string): boolean => {
   return pathname.toLowerCase().endsWith(".svg");
 };
 
-const stripSvgImage = (metadata: Metadata): Metadata =>
-  metadata.image && isSvgSrc(metadata.image.src)
-    ? { ...metadata, image: undefined }
-    : metadata;
+// Some og:image endpoints advertise `content-type: image/png` but actually serve
+// HTML (e.g. a bot-protection challenge page) to non-browser clients. sharp then
+// fails with "Could not process image metadata" and crashes the whole build, so
+// we sniff the leading bytes and only keep images sharp can actually decode.
+const matchesAt = (
+  bytes: Uint8Array,
+  offset: number,
+  signature: readonly number[],
+): boolean => signature.every((byte, index) => bytes[offset + index] === byte);
+
+const isRasterImage = (bytes: Uint8Array): boolean => {
+  // PNG
+  if (matchesAt(bytes, 0, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return true;
+  }
+  // JPEG
+  if (matchesAt(bytes, 0, [0xff, 0xd8, 0xff])) return true;
+  // GIF ("GIF8")
+  if (matchesAt(bytes, 0, [0x47, 0x49, 0x46, 0x38])) return true;
+  // WebP ("RIFF"...."WEBP")
+  if (
+    matchesAt(bytes, 0, [0x52, 0x49, 0x46, 0x46]) &&
+    matchesAt(bytes, 8, [0x57, 0x45, 0x42, 0x50])
+  ) {
+    return true;
+  }
+  // AVIF / HEIF (ISOBMFF "ftyp" box)
+  if (matchesAt(bytes, 4, [0x66, 0x74, 0x79, 0x70])) return true;
+  return false;
+};
+
+const isProcessableImage = async (src: string): Promise<boolean> => {
+  try {
+    const response = await fetch(src, { headers: { accept: "image/*" } });
+    if (!response.ok || !response.body) return false;
+
+    const reader = response.body.getReader();
+    const bytes: number[] = [];
+    while (bytes.length < 16) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) bytes.push(...value);
+    }
+    await reader.cancel();
+
+    return isRasterImage(new Uint8Array(bytes));
+  } catch {
+    return false;
+  }
+};
+
+const dropUnprocessableImage = async (
+  metadata: Metadata,
+): Promise<Metadata> => {
+  const src = metadata.image?.src;
+  if (!src || isSvgSrc(src)) {
+    return src ? { ...metadata, image: undefined } : metadata;
+  }
+  return (await isProcessableImage(src))
+    ? metadata
+    : { ...metadata, image: undefined };
+};
 
 export const getMetadata = (url: string) =>
   cache(url, async () => {
@@ -34,7 +92,7 @@ export const getMetadata = (url: string) =>
         "accept-language": "ja,en-US;q=0.7,en;q=0.3",
       },
     })
-      .then(stripSvgImage)
+      .then(dropUnprocessableImage)
       .catch(() => ({
         title: "Not Found",
         description: "Page not found",


### PR DESCRIPTION
- Sniff og:image leading bytes and keep only PNG/JPEG/GIF/WebP that sharp can actually decode
- Drop og:images that advertise an image content-type but serve HTML (e.g. bot-protection pages) to prevent build crashes
- Drop og:images when fetching their bytes fails
- Replace stripSvgImage with dropUnprocessableImage in the metadata pipeline
- Add tests covering raster images, HTML-masquerading images, and fetch failures