### PR TITLE
[main] refactor: enable oxlint regex and code-point rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -16,8 +16,6 @@
     "import/no-unassigned-import": "off",
     // Sequential awaits are intentional (ordered ops / pacing)
     "eslint/no-await-in-loop": "off",
-    // charCodeAt is intentional: the twemoji surrogate-pair algorithm needs UTF-16 code units
-    "unicorn/prefer-code-point": "off",
     // Required args typed `T | undefined` must receive an explicit undefined
     "unicorn/no-useless-undefined": "off",
     // Adding the `u` flag to existing regexes is behavior-changing and low-value here

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,16 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": [
-    "eslint",
-    "typescript",
-    "unicorn",
-    "oxc",
-    "import",
-    "promise",
-    "node",
-    "jsx-a11y",
-    "vitest"
-  ],
+  "plugins": ["typescript", "unicorn", "oxc", "import", "promise", "jsx-a11y", "vitest"],
   "categories": {
     "correctness": "error",
     "suspicious": "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,9 +17,7 @@
     // Sequential awaits are intentional (ordered ops / pacing)
     "eslint/no-await-in-loop": "off",
     // Required args typed `T | undefined` must receive an explicit undefined
-    "unicorn/no-useless-undefined": "off",
-    // Adding the `u` flag to existing regexes is behavior-changing and low-value here
-    "eslint/require-unicode-regexp": "off"
+    "unicorn/no-useless-undefined": "off"
   },
   "ignorePatterns": ["**/*-content/**", "**/public/**", "**/.cache/**"]
 }

--- a/apps/diary/src/layouts/base-layout.astro
+++ b/apps/diary/src/layouts/base-layout.astro
@@ -13,7 +13,7 @@ const {
   image,
 } = Astro.props;
 
-const pathname = Astro.url.pathname.replace(/index\.html$/, "");
+const pathname = Astro.url.pathname.replace(/index\.html$/u, "");
 const canonicalUrl = new URL(pathname, Astro.site).href;
 const ogImageUrl = image ? new URL(image.src, Astro.site).href : undefined;
 ---

--- a/apps/diary/src/pages/index.astro
+++ b/apps/diary/src/pages/index.astro
@@ -9,7 +9,7 @@ const imageModules = import.meta.glob<{
 
 const entries = Object.entries(imageModules)
   .map(([path, mod]) => {
-    const match = path.match(/\/(\d{4}-\d{2}-\d{2})\/(\d+)\.jpg$/);
+    const match = path.match(/\/(\d{4}-\d{2}-\d{2})\/(\d+)\.jpg$/u);
     if (!match?.[1] || !match[2]) return null;
     return { src: mod.default, date: match[1], fileNumber: match[2] };
   })

--- a/apps/lgtm/scripts/convert-videos.ts
+++ b/apps/lgtm/scripts/convert-videos.ts
@@ -32,7 +32,7 @@ for (const entryId of entryIds) {
   if (!entryStat.isDirectory()) continue;
 
   const files = await readdir(entryDir);
-  const movs = files.filter((f) => /\.mov$/i.test(f));
+  const movs = files.filter((f) => /\.mov$/iu.test(f));
   if (movs.length === 0) continue;
 
   for (const mov of movs) {

--- a/apps/lgtm/src/__tests__/pages/api-ids.test.ts
+++ b/apps/lgtm/src/__tests__/pages/api-ids.test.ts
@@ -90,7 +90,7 @@ describe("GET /api/ids.json", () => {
     const text = await response.text();
     const data = JSON.parse(text);
 
-    const isoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/;
+    const isoPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/u;
     expect(isoPattern.test(data.updatedAt)).toBe(true);
 
     const date = new Date(data.updatedAt);
@@ -102,7 +102,7 @@ describe("GET /api/ids.json", () => {
     const text = await response.text();
     const data = JSON.parse(text);
 
-    const ulidPattern = /^[0123456789abcdefghjkmnpqrstvwxyz]{26}$/;
+    const ulidPattern = /^[0123456789abcdefghjkmnpqrstvwxyz]{26}$/u;
     for (const id of data.ids) {
       expect(typeof id).toBe("string");
       expect(ulidPattern.test(id)).toBe(true);

--- a/apps/me/scripts/create-entry.ts
+++ b/apps/me/scripts/create-entry.ts
@@ -23,7 +23,7 @@ const getTodayDate = () => {
 };
 
 const validateDateFormat = (dateString: string) => {
-  const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+  const dateRegex = /^\d{4}-\d{2}-\d{2}$/u;
   if (!dateRegex.test(dateString)) {
     return false;
   }

--- a/apps/me/scripts/render-mermaid.ts
+++ b/apps/me/scripts/render-mermaid.ts
@@ -22,7 +22,7 @@ const getMermaidHash = (source: string): string => {
 
 const extractMermaidBlocks = (content: string): string[] => {
   const blocks: string[] = [];
-  const regex = /```mermaid\n([\s\S]*?)```/g;
+  const regex = /```mermaid\n([\s\S]*?)```/gu;
   for (const match of content.matchAll(regex)) {
     if (match[1]) {
       blocks.push(match[1].trim());
@@ -66,7 +66,7 @@ const main = async () => {
   if (existsSync(CACHE_DIR)) {
     const cachedFiles = readdirSync(CACHE_DIR);
     for (const file of cachedFiles) {
-      const hash = file.replace(/-(light|dark)\.svg$/, "");
+      const hash = file.replace(/-(light|dark)\.svg$/u, "");
       if (!uniqueBlocks.has(hash)) {
         unlinkSync(`${CACHE_DIR}/${file}`);
         console.log(`  Removed stale cache: ${file}`);

--- a/apps/me/src/__tests__/lib/api/emoji.test.ts
+++ b/apps/me/src/__tests__/lib/api/emoji.test.ts
@@ -21,7 +21,7 @@ describe("getIconCode", () => {
 
   it("handles ZWJ sequences (keeps U+200D)", () => {
     // Family emoji: U+1F468 U+200D U+1F469 U+200D U+1F467
-    const zwj = String.fromCharCode(8205);
+    const zwj = "\u200D";
     const emoji = `\uD83D\uDC68${zwj}\uD83D\uDC69${zwj}\uD83D\uDC67`;
     const result = getIconCode(emoji);
     expect(result).toContain("200d");
@@ -56,7 +56,7 @@ describe("getFirstGrapheme", () => {
 
   it("keeps a ZWJ sequence intact", () => {
     // Family emoji: U+1F468 U+200D U+1F469 U+200D U+1F467
-    const zwj = String.fromCharCode(8205);
+    const zwj = "\u200D";
     const family = `👨${zwj}👩${zwj}👧`;
     expect(getFirstGrapheme(`${family}😀`)).toBe(family);
   });

--- a/apps/me/src/__tests__/utils/hash.test.ts
+++ b/apps/me/src/__tests__/utils/hash.test.ts
@@ -27,6 +27,6 @@ describe("generateBech32m", () => {
 
   it("includes the prefix character in the result", () => {
     const result = generateBech32m("test", "h");
-    expect(result).toMatch(/^h/);
+    expect(result).toMatch(/^h/u);
   });
 });

--- a/apps/me/src/features/blog/components/ui/blocks/heading.astro
+++ b/apps/me/src/features/blog/components/ui/blocks/heading.astro
@@ -11,7 +11,7 @@ const { as: Tag, id, class: className, ...rest } = Astro.props;
 const classes = new Set([
   "heading",
   "budoux",
-  ...(className?.split(/\s+/).filter(Boolean) ?? []),
+  ...(className?.split(/\s+/u).filter(Boolean) ?? []),
 ]);
 ---
 

--- a/apps/me/src/features/blog/components/ui/blocks/memo-card.astro
+++ b/apps/me/src/features/blog/components/ui/blocks/memo-card.astro
@@ -22,7 +22,7 @@ const hasImages = memo && memo.images.length > 0;
 // collapse into a single run-together block).
 const paragraphs = memo
   ? memo.body
-      .split(/\n\s*\n/)
+      .split(/\n\s*\n/u)
       .map((paragraph) => paragraph.trim())
       .filter((paragraph) => paragraph.length > 0)
   : [];

--- a/apps/me/src/features/blog/components/ui/pagination.astro
+++ b/apps/me/src/features/blog/components/ui/pagination.astro
@@ -16,7 +16,7 @@ const format = String;
 // (`/blog`, `/blog/categories/tech`), the rest at `${base}/${n}`. Prev/next
 // reuse Astro-generated URLs so their format always matches the router.
 const firstUrl = page.url.first ?? page.url.current;
-const base = firstUrl.replace(/\/$/, "");
+const base = firstUrl.replace(/\/$/u, "");
 const hrefFor = (n: number) => (n === 1 ? firstUrl : `${base}/${n}`);
 
 const pages = Array.from({ length: lastPage }, (_, i) => i + 1);

--- a/apps/me/src/lib/api/emoji.ts
+++ b/apps/me/src/lib/api/emoji.ts
@@ -10,29 +10,20 @@ const apis = {
     `https://cdn.jsdelivr.net/gh/shuding/fluentui-emoji-unicode/assets/${code.toLowerCase()}_flat.svg`,
 };
 
+// Iterating a string with for...of yields whole code points, so surrogate
+// pairs (e.g. emoji above U+FFFF) stay intact without manual UTF-16 bookkeeping.
 const toCodePoint = (unicodeSurrogates: string) => {
-  const r = [];
-  let c = 0;
-  let i = 0;
-  let p = 0;
-
-  while (i < unicodeSurrogates.length) {
-    c = unicodeSurrogates.charCodeAt(i++);
-    if (p) {
-      r.push((65536 + ((p - 55296) << 10) + (c - 56320)).toString(16));
-      p = 0;
-    } else if (55296 <= c && c <= 56319) {
-      p = c;
-    } else {
-      r.push(c.toString(16));
-    }
+  const codePoints: string[] = [];
+  for (const char of unicodeSurrogates) {
+    const code = char.codePointAt(0);
+    if (code !== undefined) codePoints.push(code.toString(16));
   }
-  return r.join("-");
+  return codePoints.join("-");
 };
 
 export const getIconCode = (char: string) => {
-  const U200D = String.fromCharCode(8205);
-  const UFE0Fg = /\uFE0F/g;
+  const U200D = "\u200D";
+  const UFE0Fg = /\uFE0F/gu;
   return toCodePoint(char.includes(U200D) ? char : char.replace(UFE0Fg, ""));
 };
 

--- a/apps/me/src/lib/api/memo.ts
+++ b/apps/me/src/lib/api/memo.ts
@@ -56,6 +56,6 @@ export const getMemoPost = (id: string) =>
 
 /** Extract ID from memo.kkhys.me/post/[id] URL */
 export const extractMemoId = (url: string): string | null => {
-  const match = url.match(/^https?:\/\/memo\.kkhys\.me\/posts?\/([A-Z0-9]+)$/i);
+  const match = url.match(/^https?:\/\/memo\.kkhys\.me\/posts?\/([A-Z0-9]+)$/iu);
   return match?.[1] ?? null;
 };

--- a/apps/me/src/lib/api/metadata.ts
+++ b/apps/me/src/lib/api/metadata.ts
@@ -7,7 +7,7 @@ const cache = createResolvedCache<Metadata>();
 // Astro's sharp service refuses SVG inputs unless `image.dangerouslyProcessSVG`
 // is enabled, so drop SVG og:images here to keep `<Image>` from crashing the build.
 const isSvgSrc = (src: string): boolean => {
-  const pathname = src.split(/[?#]/, 1)[0] ?? src;
+  const pathname = src.split(/[?#]/u, 1)[0] ?? src;
   return pathname.toLowerCase().endsWith(".svg");
 };
 

--- a/apps/me/src/lib/loaders/zenn.ts
+++ b/apps/me/src/lib/loaders/zenn.ts
@@ -7,19 +7,19 @@ export type ZennFeedItem = {
   publishedAt: Date;
 };
 
-const stripCdata = (value: string): string => value.replace(/^<!\[CDATA\[([\s\S]*?)\]\]>$/, "$1");
+const stripCdata = (value: string): string => value.replace(/^<!\[CDATA\[([\s\S]*?)\]\]>$/u, "$1");
 
 const decodeEntities = (value: string): string =>
   value
     .replaceAll("&lt;", "<")
     .replaceAll("&gt;", ">")
     .replaceAll("&quot;", '"')
-    .replaceAll(/&#0*39;/g, "'")
+    .replaceAll(/&#0*39;/gu, "'")
     .replaceAll("&apos;", "'")
     .replaceAll("&amp;", "&");
 
 const getTagText = (block: string, tag: string): string | undefined => {
-  const match = block.match(new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</${tag}>`));
+  const match = block.match(new RegExp(`<${tag}(?:\\s[^>]*)?>([\\s\\S]*?)</${tag}>`, "u"));
   const raw = match?.[1];
   if (raw === undefined) return undefined;
   return decodeEntities(stripCdata(raw.trim()).trim());
@@ -33,7 +33,7 @@ const toSlug = (url: string): string | undefined => url.split("/").findLast(Bool
  * in the feed is ignored.
  */
 export const parseZennFeed = (xml: string): ZennFeedItem[] => {
-  const blocks = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/g)].map((match) => match[1] ?? "");
+  const blocks = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/gu)].map((match) => match[1] ?? "");
 
   return blocks.flatMap((block) => {
     const title = getTagText(block, "title");

--- a/apps/me/src/lib/rehype-mermaid-cached.ts
+++ b/apps/me/src/lib/rehype-mermaid-cached.ts
@@ -13,8 +13,8 @@ const getMermaidHash = (source: string) =>
   createHash("sha256").update(source).digest("hex").slice(0, 16);
 
 const extractDimensions = (svg: string): { width: string; height: string } | undefined => {
-  const widthMatch = svg.match(/width="([^"]+)"/);
-  const heightMatch = svg.match(/height="([^"]+)"/);
+  const widthMatch = svg.match(/width="([^"]+)"/u);
+  const heightMatch = svg.match(/height="([^"]+)"/u);
   if (!widthMatch?.[1] || !heightMatch?.[1]) return undefined;
   return {
     width: widthMatch[1],

--- a/apps/me/src/lib/rehype-slug-with-custom-id.ts
+++ b/apps/me/src/lib/rehype-slug-with-custom-id.ts
@@ -4,7 +4,7 @@ import { generateBech32m } from "../utils/hash";
 
 const rehypeSlugWithCustomId = () => (tree: Root) => {
   visit(tree, "element", (node) => {
-    if (node.tagName && /^h[1-6]$/.test(node.tagName)) {
+    if (node.tagName && /^h[1-6]$/u.test(node.tagName)) {
       const originalText = node.children
         .filter((child) => child.type === "text")
         .map((child) => child.value)

--- a/apps/me/src/lib/remark-blockquote-alert.ts
+++ b/apps/me/src/lib/remark-blockquote-alert.ts
@@ -1,13 +1,13 @@
 import type { Paragraph, PhrasingContent, Root, Text } from "mdast";
 import { visit } from "unist-util-visit";
 
-const alertRegex = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)]/i;
+const alertRegex = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/iu;
 
 const processAlertParagraph = (item: Paragraph, text: string): PhrasingContent[] => {
   if (text.includes("\n")) {
     item.children[0] = {
       type: "text",
-      value: text.replace(alertRegex, "").replace(/^\n+/, ""),
+      value: text.replace(alertRegex, "").replace(/^\n+/u, ""),
     } as Text;
     return item.children;
   }

--- a/apps/me/src/lib/remark-youtube-block.ts
+++ b/apps/me/src/lib/remark-youtube-block.ts
@@ -25,8 +25,8 @@ import { isBareExternalLink } from "./mdast-util-node-is";
  */
 const extractYoutubeId = (url: string): string | null => {
   const patterns = [
-    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/i,
-    /youtube\.com\/watch\?.*v=([a-zA-Z0-9_-]{11})/i,
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/iu,
+    /youtube\.com\/watch\?.*v=([a-zA-Z0-9_-]{11})/iu,
   ];
 
   for (const pattern of patterns) {

--- a/apps/me/src/pages/blog/tags/[tag]/[...page].astro
+++ b/apps/me/src/pages/blog/tags/[tag]/[...page].astro
@@ -24,7 +24,7 @@ export const getStaticPaths = async ({
       .toSorted((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
     return paginate(filteredEntries, {
       pageSize: countPerPage,
-      params: { tag: tag.toLowerCase().replaceAll(/[\s.]+/g, "-") },
+      params: { tag: tag.toLowerCase().replaceAll(/[\s.]+/gu, "-") },
     });
   });
 };

--- a/apps/me/src/utils/extract-description.ts
+++ b/apps/me/src/utils/extract-description.ts
@@ -8,44 +8,44 @@ export const extractDescription = (body: string, maxLength = 120): string => {
   let text = body;
 
   // Remove import statements
-  text = text.replaceAll(/^import\s+.*$/gm, "");
+  text = text.replaceAll(/^import\s+.*$/gmu, "");
 
   // Remove fenced code blocks
-  text = text.replaceAll(/```[\s\S]*?```/g, "");
+  text = text.replaceAll(/```[\s\S]*?```/gu, "");
 
   // Remove alert blockquotes (> [!NOTE] etc. and continuation lines)
   text = text.replaceAll(
-    /^> \[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\].*(?:\n(?:>\s?.*)?)*$/gm,
+    /^> \[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\].*(?:\n(?:>\s?.*)?)*$/gmu,
     "",
   );
 
   // Remove blockquote markers
-  text = text.replaceAll(/^>\s?/gm, "");
+  text = text.replaceAll(/^>\s?/gmu, "");
 
   // Remove headings
-  text = text.replaceAll(/^#{1,6}\s+.*$/gm, "");
+  text = text.replaceAll(/^#{1,6}\s+.*$/gmu, "");
 
   // Remove images
-  text = text.replaceAll(/!\[.*?\]\(.*?\)/g, "");
+  text = text.replaceAll(/!\[.*?\]\(.*?\)/gu, "");
 
   // Convert links to text only
-  text = text.replaceAll(/\[([^\]]*)\]\(.*?\)/g, "$1");
+  text = text.replaceAll(/\[([^\]]*)\]\(.*?\)/gu, "$1");
 
   // Remove inline code
-  text = text.replaceAll(/`[^`]+`/g, "");
+  text = text.replaceAll(/`[^`]+`/gu, "");
 
   // Remove bold/italic markers
-  text = text.replaceAll(/\*{1,3}(.*?)\*{1,3}/g, "$1");
-  text = text.replaceAll(/_{1,3}(.*?)_{1,3}/g, "$1");
+  text = text.replaceAll(/\*{1,3}(.*?)\*{1,3}/gu, "$1");
+  text = text.replaceAll(/_{1,3}(.*?)_{1,3}/gu, "$1");
 
   // Remove horizontal rules
-  text = text.replaceAll(/^[-*_]{3,}$/gm, "");
+  text = text.replaceAll(/^[-*_]{3,}$/gmu, "");
 
   // Remove HTML tags
-  text = text.replaceAll(/<[^>]+>/g, "");
+  text = text.replaceAll(/<[^>]+>/gu, "");
 
   // Remove footnote references
-  text = text.replaceAll(/\[\^[^\]]*\]/g, "");
+  text = text.replaceAll(/\[\^[^\]]*\]/gu, "");
 
   // Normalize whitespace and join
   text = text
@@ -53,7 +53,7 @@ export const extractDescription = (body: string, maxLength = 120): string => {
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
     .join(" ")
-    .replaceAll(/\s+/g, " ")
+    .replaceAll(/\s+/gu, " ")
     .trim();
 
   if (text.length <= maxLength) return text;
@@ -61,7 +61,7 @@ export const extractDescription = (body: string, maxLength = 120): string => {
   // Truncate at a punctuation boundary within the latter half
   const searchStart = Math.floor(maxLength / 2);
   const candidate = text.slice(0, maxLength);
-  const punctuationPattern = /[。、！？!?]/g;
+  const punctuationPattern = /[。、！？!?]/gu;
   let lastIndex = -1;
 
   for (

--- a/apps/memo/src/components/header.astro
+++ b/apps/memo/src/components/header.astro
@@ -12,8 +12,8 @@ const PATH_RULES = [
     getTitle: (p: string) => {
       const tagName = p
         .replace("/tag/", "")
-        .replace(/\/$/, "")
-        .replace(/\.html$/, "");
+        .replace(/\/$/u, "")
+        .replace(/\.html$/u, "");
       return tagName ? `#${tagName}` : "Tag";
     },
   },

--- a/apps/memo/src/content.config.ts
+++ b/apps/memo/src/content.config.ts
@@ -11,7 +11,7 @@ const memo = defineCollection({
     tag: z
       .string()
       .min(1)
-      .regex(/^[a-z0-9_]+$/)
+      .regex(/^[a-z0-9_]+$/u)
       .optional(),
     comment: z.ulid().optional(),
     quote: z.ulid().optional(),
@@ -32,7 +32,7 @@ const usersPath =
 const users = defineCollection({
   loader: file(usersPath),
   schema: z.object({
-    slug: z.string().regex(/^[a-z][a-z0-9_-]*$/),
+    slug: z.string().regex(/^[a-z][a-z0-9_-]*$/u),
     name: z.string(),
     bio: z.string().default(""),
     avatar: z.string(),

--- a/apps/memo/src/lib/remark-escape-syntax.ts
+++ b/apps/memo/src/lib/remark-escape-syntax.ts
@@ -44,34 +44,34 @@ const remarkEscapeSyntax: Plugin<[], Root> = function (this: Processor) {
 
     // 1. Protect code blocks (temporarily save before inline code processing)
     const codeBlocks: string[] = [];
-    text = text.replaceAll(/```[\s\S]*?```/gm, (match) => {
+    text = text.replaceAll(/```[\s\S]*?```/gmu, (match) => {
       codeBlocks.push(match);
       return `___CODEBLOCK_${codeBlocks.length - 1}___`;
     });
 
     // 2. Escape inline code
-    text = text.replaceAll(/`([^`]+)`/g, "\\`$1\\`");
+    text = text.replaceAll(/`([^`]+)`/gu, "\\`$1\\`");
 
     // 3. Restore code blocks (convert ``` to \```)
-    text = text.replaceAll(/___CODEBLOCK_(\d+)___/g, (_, index) => {
+    text = text.replaceAll(/___CODEBLOCK_(\d+)___/gu, (_, index) => {
       // Index always exists as it references saved codeBlocks
       return codeBlocks[Math.trunc(Number(index))]!.replaceAll("```", "\\```");
     });
 
     // 4. Escape headings
-    text = text.replaceAll(/^(#{1,6})\s/gm, "\\$1 ");
+    text = text.replaceAll(/^(#{1,6})\s/gmu, "\\$1 ");
 
     // 5. Escape blockquotes
-    text = text.replaceAll(/^(\s*)>\s/gm, "$1\\> ");
+    text = text.replaceAll(/^(\s*)>\s/gmu, "$1\\> ");
 
     // 6. Escape horizontal rules (before list markers)
-    text = text.replaceAll(/^(\s*)([-*_])\2{2,}\s*$/gm, "$1\\$2$2$2");
+    text = text.replaceAll(/^(\s*)([-*_])\2{2,}\s*$/gmu, "$1\\$2$2$2");
 
     // 7. Escape unordered lists
-    text = text.replaceAll(/^(\s*)([*\-+])\s/gm, "$1\\$2 ");
+    text = text.replaceAll(/^(\s*)([*\-+])\s/gmu, "$1\\$2 ");
 
     // 8. Escape ordered lists
-    text = text.replaceAll(/^(\s*)(\d+)\.\s/gm, "$1$2\\. ");
+    text = text.replaceAll(/^(\s*)(\d+)\.\s/gmu, "$1$2\\. ");
 
     // Note: Bold (**, __), italic (*, _), and strikethrough (~~) cannot be escaped
     // because remark interprets backslashes multiple times

--- a/apps/memo/src/lib/remark-extract-link.ts
+++ b/apps/memo/src/lib/remark-extract-link.ts
@@ -17,7 +17,7 @@ const remarkExtractLink = () => (tree: Root, file: VFile) => {
 
     const url = node.url;
 
-    if (/^https?:\/\//i.test(url)) {
+    if (/^https?:\/\//iu.test(url)) {
       firstExternalLink = url;
     }
   });

--- a/apps/memo/src/lib/remark-truncate-link-text.ts
+++ b/apps/memo/src/lib/remark-truncate-link-text.ts
@@ -35,7 +35,7 @@ export const truncateLinkText = (url: string) => {
 
 const remarkTruncateLinkText = () => (tree: Root) => {
   visit(tree, "link", (node) => {
-    if (!/^https?:\/\//i.test(node.url)) {
+    if (!/^https?:\/\//iu.test(node.url)) {
       return;
     }
 
@@ -43,7 +43,7 @@ const remarkTruncateLinkText = () => (tree: Root) => {
     if (node.children.length === 1 && firstChild?.type === "text") {
       const originalText = firstChild.value;
 
-      if (/^https?:\/\//i.test(originalText)) {
+      if (/^https?:\/\//iu.test(originalText)) {
         firstChild.value = truncateLinkText(node.url);
       }
     }

--- a/apps/memo/src/loaders/rss-parser.ts
+++ b/apps/memo/src/loaders/rss-parser.ts
@@ -5,7 +5,7 @@ export interface RssItem {
   pubDate: string;
 }
 
-const stripCdata = (text: string): string => text.replace(/^<!\[CDATA\[([\s\S]*?)]]>$/, "$1");
+const stripCdata = (text: string): string => text.replace(/^<!\[CDATA\[([\s\S]*?)\]\]>$/u, "$1");
 
 const decodeEntities = (text: string): string =>
   text
@@ -16,19 +16,19 @@ const decodeEntities = (text: string): string =>
     .replaceAll("&apos;", "'");
 
 const extractTag = (xml: string, tag: string): string | undefined => {
-  const match = xml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`));
+  const match = xml.match(new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`, "u"));
   if (!match?.[1]) return undefined;
   return decodeEntities(stripCdata(match[1].trim()));
 };
 
 export const parseRssItems = (xml: string): RssItem[] => {
   const items: RssItem[] = [];
-  const itemBlocks = xml.match(/<item>([\s\S]*?)<\/item>/g);
+  const itemBlocks = xml.match(/<item>([\s\S]*?)<\/item>/gu);
 
   if (!itemBlocks) return items;
 
   for (const block of itemBlocks) {
-    const content = block.replaceAll(/<\/?item>/g, "");
+    const content = block.replaceAll(/<\/?item>/gu, "");
 
     const title = extractTag(content, "title");
     const link = extractTag(content, "link");
@@ -44,6 +44,6 @@ export const parseRssItems = (xml: string): RssItem[] => {
 };
 
 export const generateRssEntryId = (guid: string, prefix = "rss"): string => {
-  const slug = guid.replace(/\/$/, "").split("/").pop();
+  const slug = guid.replace(/\/$/u, "").split("/").pop();
   return `${prefix}-${slug}`;
 };

--- a/apps/memo/src/utils/image.ts
+++ b/apps/memo/src/utils/image.ts
@@ -8,7 +8,7 @@ const imageModules = import.meta.glob<{ default: ImageMetadata }>(
 const imageMap = new Map<string, ImageMetadata>(
   Object.entries(imageModules)
     .map(([path, module]) => {
-      const match = path.match(/\/memo\/(.+)$/);
+      const match = path.match(/\/memo\/(.+)$/u);
       if (!match) return null;
       const key = match[1];
       return [key, module.default] as const;
@@ -17,7 +17,7 @@ const imageMap = new Map<string, ImageMetadata>(
 );
 
 export const getImagesForMemo = (memoId: string) => {
-  const dirName = memoId.replace(/\/index\.md$/, "");
+  const dirName = memoId.replace(/\/index\.md$/u, "");
   const prefix = `${dirName}/`;
 
   return Array.from(imageMap.entries())


### PR DESCRIPTION
- Drop the eslint and node oxlint plugins from .oxlintrc.json
- Re-enable require-unicode-regexp by adding the `u` flag to all regex literals across apps
- Re-enable unicorn/prefer-code-point by rewriting the twemoji surrogate-pair logic to iterate code points and use codePointAt
- Remove the now-unneeded per-rule disables (prefer-code-point, require-unicode-regexp) from the lint config