### PR TITLE
[main] fix: correct coverage hook separator parsing

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,7 @@
           },
           {
             "type": "command",
-            "command": "OUTPUT=$(pnpm run coverage 2>&1); RC=$?; if [ $RC -ne 0 ]; then echo \"$OUTPUT\" >&2; exit 1; fi; CLEAN=$(echo \"$OUTPUT\" | perl -pe 's/\\e\\[\\d+(?:;\\d+)*m//g'); if echo \"$CLEAN\" | awk -F'|' '/\\|/ && !/^-/ && !/File/ && !/All files/ { gsub(/[[:space:]]/,\"\",$2); gsub(/[[:space:]]/,\"\",$4); gsub(/[[:space:]]/,\"\",$5); if(($2!=\"\" && $2+0!=100) || ($4!=\"\" && $4+0!=100) || ($5!=\"\" && $5+0!=100)) { found=1 } } END { exit !found }'; then echo \"Coverage is not 100%. Fix the uncovered lines:\" >&2; echo \"$CLEAN\" | grep '|' >&2; exit 1; fi",
+            "command": "OUTPUT=$(pnpm run coverage 2>&1); RC=$?; if [ $RC -ne 0 ]; then echo \"$OUTPUT\" >&2; exit 1; fi; CLEAN=$(echo \"$OUTPUT\" | perl -pe 's/\\e\\[\\d+(?:;\\d+)*m//g'); REPORT=$(echo \"$CLEAN\" | awk -F'|' '/\\|/ && !/File/ && !/All files/ { s=$2; f=$4; l=$5; gsub(/[[:space:]]/,\"\",s); gsub(/[[:space:]]/,\"\",f); gsub(/[[:space:]]/,\"\",l); if((s ~ /^[0-9.]+$/ && s+0!=100) || (f ~ /^[0-9.]+$/ && f+0!=100) || (l ~ /^[0-9.]+$/ && l+0!=100)) { found=1; print } } END { exit !found }'); if [ $? -eq 0 ]; then echo \"Coverage is not 100%. Fix the uncovered lines:\" >&2; echo \"$REPORT\" >&2; exit 1; fi",
             "statusMessage": "Checking test coverage is 100%..."
           }
         ]


### PR DESCRIPTION
- Fix the Stop hook coverage check that failed on every run regardless of actual coverage
- Drop the `^-` separator filter that broke once `pnpm -r` prefixed each output line with the package name
- Match only numeric columns (`^[0-9.]+$`) so table separators and headers are ignored naturally
- Report just the rows below 100% instead of dumping every table line