### PR TITLE
[main] chore: reduce renovate minimum release age to 1 day

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
   "assignees": ["kkhys"],
   "labels": ["type: bump-version"],
   "assignAutomerge": true,
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "1 day",
   "packageRules": [
     {
       "groupName": "DevDependencies",


### PR DESCRIPTION
- Reduce Renovate `minimumReleaseAge` from 3 days to 1 day