### PR TITLE
[main] build: add dev:memo root script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:diary": "pnpm --filter @kkhys/diary build",
     "dev:diary": "pnpm --filter @kkhys/diary dev",
     "deploy:diary": "pnpm --filter @kkhys/diary deploy",
+    "dev:memo": "pnpm --filter @kkhys/memo dev",
     "release": "bun run scripts/release.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
- Add dev:memo root script delegating to `pnpm --filter @kkhys/memo dev`
- Bring memo to parity with me/lgtm/diary, which already expose root dev shortcuts (memo lacked one as it deploys via CI)