### PR TITLE
[main] feat: add studio local memo composer app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Apps:
 - `apps/memo` — `@kkhys/memo`, short threaded memos at memo.kkhys.me. See `apps/memo/CLAUDE.md`.
 - `apps/lgtm` — `@kkhys/lgtm`, LGTM images for GitHub PRs at lgtm.kkhys.me. See `apps/lgtm/CLAUDE.md`.
 - `apps/diary` — `@kkhys/diary`, photo diary at diary.kkhys.me. See `apps/diary/CLAUDE.md`.
+- `apps/studio` — `@kkhys/studio`, local-only memo composer (never deployed). See `apps/studio/CLAUDE.md`.
 
 Packages:
 

--- a/apps/memo/CLAUDE.md
+++ b/apps/memo/CLAUDE.md
@@ -8,7 +8,7 @@ Astro-based memo posting site. Short memos (max 500 chars) in a threaded social 
 src/
 ├── pages/
 │   ├── [...page].astro        # Paginated feed with infinite scroll
-│   ├── post/[id].astro        # Single memo detail
+│   ├── posts/[id].astro       # Single memo detail
 │   └── tag/[tag].astro        # Tag-filtered feed
 ├── components/                 # Astro components
 ├── utils/

--- a/apps/studio/CLAUDE.md
+++ b/apps/studio/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+Local-only browser app for composing memos into `apps/memo/memo-content`. Never deployed — it runs on the developer's machine (`pnpm dev:studio`, binds to 127.0.0.1:5757) and writes directly to the memo-content submodule.
+
+## Codebase Map
+
+```
+src/
+├── server.ts        # Bun.serve: serves the UI (HTML import) + JSON API, git status/sync
+├── memo-store.ts    # Pure Node module: list/create memos, frontmatter, validation
+├── memo-filter.ts   # Pure Node module: free-text feed filtering (AND terms)
+├── request-guard.ts # Pure Node module: Host/Origin validation for all API routes
+├── index.html       # Single-page UI (bundled by Bun with client.ts / styles.css)
+├── client.ts        # Frontend: compose form, image attach, reply/quote, search, feed, sync
+├── styles.css       # Vanilla CSS on top of @kkhys/styles (uchu.css)
+└── __tests__/       # Vitest tests for the pure modules (run on Node — no Bun APIs there)
+```
+
+## API
+
+All API routes are guarded by a Host/Origin check (`request-guard.ts`) against DNS rebinding and cross-origin POSTs; non-localhost requests get 403.
+
+- `GET /api/memos` — all memos, newest first
+- `POST /api/memos` — multipart: `body`, `createdAt?`, `tag?`, `comment?`, `quote?`, `isDraft?`, `hideLinkCard?`, `images` (≤4, JPG/PNG)
+- `GET /api/images/:dirName/:file` — serve memo images for the feed
+- `GET /api/status` — uncommitted change count in memo-content
+- `POST /api/sync` — git add/commit/push of memo-content (same message format as memo-content's sync.ts). With JSON body `{"deploy": true}` (the header's Deploy checkbox, off by default) it also triggers `sync-submodule.yml` via `gh workflow run` so the pushed content deploys
+
+## Constraints
+
+- Writes must follow memo conventions: dir `YYYYMMDD_HHMMSS`, ULID lowercased and derived from `createdAt`, images numbered `01.jpg`…; body ≤500 chars counted like remark-word-limit (rendered text, not raw markdown)
+- `memo-store.ts` stays Bun-free so CI (Node + vitest) can test it; Bun APIs live in `server.ts` only
+- EXIF stripping is handled by memo-content's lefthook pre-commit hook, not here

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@kkhys/studio",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --hot src/server.ts",
+    "check": "tsc --noEmit",
+    "lint": "oxlint && oxfmt --check",
+    "lint:fix": "oxlint --fix && oxfmt",
+    "test": "vitest run",
+    "coverage": "vitest run --coverage"
+  },
+  "dependencies": {
+    "@kkhys/styles": "workspace:*",
+    "mdast-util-to-string": "4.0.0",
+    "remark": "15.0.1",
+    "ulid": "catalog:"
+  },
+  "devDependencies": {
+    "@types/bun": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/apps/studio/src/__tests__/memo-filter.test.ts
+++ b/apps/studio/src/__tests__/memo-filter.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { filterMemos } from "../memo-filter";
+
+const memos = [
+  { body: "右フックのコンビネーション", createdAt: "2026-06-29 19:55:00", tag: "boxing" },
+  { body: "Howも良いけど、Whyの記事を多く書きたい。", createdAt: "2026-06-24 20:35:56" },
+  { body: "Astro のビルドを速くしたい", createdAt: "2026-05-01 10:00:00", tag: "dev" },
+];
+
+describe("filterMemos", () => {
+  it("returns all memos for an empty or whitespace query", () => {
+    expect(filterMemos(memos, "")).toEqual(memos);
+    expect(filterMemos(memos, "   ")).toEqual(memos);
+  });
+
+  it("matches body text case-insensitively", () => {
+    expect(filterMemos(memos, "astro")).toEqual([memos[2]]);
+    expect(filterMemos(memos, "フック")).toEqual([memos[0]]);
+  });
+
+  it("matches by tag", () => {
+    expect(filterMemos(memos, "boxing")).toEqual([memos[0]]);
+  });
+
+  it("matches by createdAt substring", () => {
+    expect(filterMemos(memos, "2026-06")).toEqual([memos[0], memos[1]]);
+  });
+
+  it("ANDs whitespace-separated terms", () => {
+    expect(filterMemos(memos, "2026-06 boxing")).toEqual([memos[0]]);
+    expect(filterMemos(memos, "astro boxing")).toEqual([]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(filterMemos(memos, "nonexistent")).toEqual([]);
+  });
+});

--- a/apps/studio/src/__tests__/memo-store.test.ts
+++ b/apps/studio/src/__tests__/memo-store.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ulid } from "ulid";
 import { countMemoChars, createMemo, formatDateTime, listMemos } from "../memo-store";
 
 let baseDir: string;
@@ -105,8 +106,14 @@ describe("createMemo", () => {
       createdAt: "2026-06-24 20:35:56",
     });
 
-    // Same timestamp prefix as an id generated at the same instant
-    expect(memo.id.slice(0, 10)).toBe("01kvwpmnb0");
+    // The 10-char ULID prefix encodes the createdAt instant, so it matches a
+    // ULID generated from the same local time. Both sides use the local Date
+    // constructor, keeping the assertion timezone-independent (createMemo
+    // parses createdAt as local wall-clock time).
+    const expectedPrefix = ulid(new Date(2026, 5, 24, 20, 35, 56).getTime())
+      .slice(0, 10)
+      .toLowerCase();
+    expect(memo.id.slice(0, 10)).toBe(expectedPrefix);
   });
 
   it("rejects an empty body", () => {

--- a/apps/studio/src/__tests__/memo-store.test.ts
+++ b/apps/studio/src/__tests__/memo-store.test.ts
@@ -1,0 +1,215 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { countMemoChars, createMemo, formatDateTime, listMemos } from "../memo-store";
+
+let baseDir: string;
+
+beforeEach(() => {
+  baseDir = mkdtempSync(join(tmpdir(), "studio-memo-"));
+});
+
+afterEach(() => {
+  rmSync(baseDir, { recursive: true, force: true });
+});
+
+const writeMemoFixture = (dirName: string, content: string, images: string[] = []): void => {
+  const dir = join(baseDir, dirName);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "index.md"), content, "utf-8");
+  for (const image of images) {
+    writeFileSync(join(dir, image), Buffer.from([0xff]));
+  }
+};
+
+describe("countMemoChars", () => {
+  it("counts plain text length", () => {
+    expect(countMemoChars("こんにちは")).toBe(5);
+  });
+
+  it("excludes markdown syntax, matching remark-word-limit", () => {
+    expect(countMemoChars("[abc](https://example.com)")).toBe(3);
+    expect(countMemoChars("**bold** and _em_")).toBe(11);
+  });
+});
+
+describe("createMemo", () => {
+  it("creates a directory with frontmatter and body", () => {
+    const memo = createMemo(baseDir, {
+      body: "Hello, world.",
+      createdAt: "2026-07-04 12:34:56",
+    });
+
+    expect(memo.dirName).toBe("20260704_123456");
+    expect(memo.id).toMatch(/^[0-9a-hjkmnp-tv-z]{26}$/u);
+
+    const content = readFileSync(join(baseDir, "20260704_123456", "index.md"), "utf-8");
+    expect(content).toBe(
+      `---\nid: ${memo.id}\ncreatedAt: 2026-07-04 12:34:56\n---\n\nHello, world.\n`,
+    );
+  });
+
+  it("writes optional frontmatter fields in schema order", () => {
+    const parent = "01kw9kgfn8zsvt3dftz9kemfv9";
+    const memo = createMemo(baseDir, {
+      body: "Reply body",
+      createdAt: "2026-07-04 12:00:00",
+      tag: "boxing",
+      comment: parent,
+      isDraft: true,
+      hideLinkCard: true,
+    });
+
+    const content = readFileSync(join(baseDir, memo.dirName, "index.md"), "utf-8");
+    expect(content).toBe(
+      `---\nid: ${memo.id}\ncreatedAt: 2026-07-04 12:00:00\ntag: boxing\ncomment: ${parent}\nisDraft: true\nhideLinkCard: true\n---\n\nReply body\n`,
+    );
+  });
+
+  it("writes images as zero-padded numbered files", () => {
+    const memo = createMemo(baseDir, {
+      body: "With images",
+      createdAt: "2026-07-04 12:00:00",
+      images: [
+        { data: new Uint8Array([1]), ext: "jpg" },
+        { data: new Uint8Array([2]), ext: "png" },
+      ],
+    });
+
+    expect(memo.images).toEqual(["01.jpg", "02.png"]);
+    const files = readdirSync(join(baseDir, memo.dirName)).toSorted();
+    expect(files).toEqual(["01.jpg", "02.png", "index.md"]);
+  });
+
+  it("defaults createdAt to now", () => {
+    const before = formatDateTime(new Date());
+    const memo = createMemo(baseDir, { body: "Now" });
+
+    expect(memo.createdAt >= before).toBe(true);
+    expect(memo.createdAt).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/u);
+    expect(existsSync(join(baseDir, memo.dirName, "index.md"))).toBe(true);
+  });
+
+  it("derives the ULID from the createdAt timestamp", () => {
+    const memo = createMemo(baseDir, {
+      body: "Timestamped",
+      createdAt: "2026-06-24 20:35:56",
+    });
+
+    // Same timestamp prefix as an id generated at the same instant
+    expect(memo.id.slice(0, 10)).toBe("01kvwpmnb0");
+  });
+
+  it("rejects an empty body", () => {
+    expect(() => createMemo(baseDir, { body: "   " })).toThrow("Body is required");
+  });
+
+  it("rejects a body over 500 rendered characters", () => {
+    expect(() => createMemo(baseDir, { body: "a".repeat(501) })).toThrow(
+      "Character count exceeds the limit: 501",
+    );
+  });
+
+  it("allows markdown syntax overhead beyond 500 raw characters", () => {
+    const body = `[${"a".repeat(500)}](https://example.com)`;
+    expect(() => createMemo(baseDir, { body, createdAt: "2026-07-04 12:00:00" })).not.toThrow();
+  });
+
+  it("rejects an invalid tag", () => {
+    expect(() => createMemo(baseDir, { body: "x", tag: "Boxing" })).toThrow("Invalid tag");
+  });
+
+  it("rejects invalid comment and quote targets", () => {
+    expect(() => createMemo(baseDir, { body: "x", comment: "not-a-ulid" })).toThrow(
+      "Invalid comment target",
+    );
+    expect(() => createMemo(baseDir, { body: "x", quote: "not-a-ulid" })).toThrow(
+      "Invalid quote target",
+    );
+  });
+
+  it("rejects more than 4 images", () => {
+    const images = Array.from({ length: 5 }, () => ({
+      data: new Uint8Array([1]),
+      ext: "jpg" as const,
+    }));
+    expect(() => createMemo(baseDir, { body: "x", images })).toThrow("Too many images");
+  });
+
+  it("rejects an invalid datetime", () => {
+    expect(() => createMemo(baseDir, { body: "x", createdAt: "2026-13-01 00:00:00" })).toThrow(
+      "Invalid datetime",
+    );
+    expect(() => createMemo(baseDir, { body: "x", createdAt: "2026/07/04" })).toThrow(
+      "Invalid datetime format",
+    );
+  });
+
+  it("rejects a duplicate directory", () => {
+    createMemo(baseDir, { body: "first", createdAt: "2026-07-04 12:00:00" });
+    expect(() => createMemo(baseDir, { body: "second", createdAt: "2026-07-04 12:00:00" })).toThrow(
+      "already exists",
+    );
+  });
+});
+
+describe("listMemos", () => {
+  it("returns an empty list for a missing directory", () => {
+    expect(listMemos(join(baseDir, "nope"))).toEqual([]);
+  });
+
+  it("parses frontmatter, collects images, and sorts newest first", () => {
+    writeMemoFixture(
+      "20260101_000000",
+      "---\nid: 01aaaaaaaaaaaaaaaaaaaaaaaa\ncreatedAt: 2026-01-01 00:00:00\ntag: idea\n---\n\nOld memo\n",
+    );
+    writeMemoFixture(
+      "20260201_000000",
+      "---\nid: 01bbbbbbbbbbbbbbbbbbbbbbbb\ncreatedAt: 2026-02-01 00:00:00\nisDraft: true\n---\n\nNew memo\n",
+      ["02.png", "01.jpg"],
+    );
+
+    const memos = listMemos(baseDir);
+
+    expect(memos.map((memo) => memo.id)).toEqual([
+      "01bbbbbbbbbbbbbbbbbbbbbbbb",
+      "01aaaaaaaaaaaaaaaaaaaaaaaa",
+    ]);
+    expect(memos[0]).toMatchObject({
+      dirName: "20260201_000000",
+      body: "New memo",
+      isDraft: true,
+      images: ["01.jpg", "02.png"],
+    });
+    expect(memos[1]).toMatchObject({ tag: "idea", isDraft: false, images: [] });
+  });
+
+  it("skips directories without a parseable index.md", () => {
+    mkdirSync(join(baseDir, "empty-dir"));
+    writeMemoFixture("20260101_000000", "no frontmatter here");
+
+    expect(listMemos(baseDir)).toEqual([]);
+  });
+
+  it("round-trips a memo written by createMemo", () => {
+    const created = createMemo(baseDir, {
+      body: "Round trip",
+      createdAt: "2026-07-04 12:00:00",
+      tag: "test_tag",
+      quote: "01kw9kgfn8zsvt3dftz9kemfv9",
+      images: [{ data: new Uint8Array([1]), ext: "jpg" }],
+    });
+
+    const [memo] = listMemos(baseDir);
+    expect(memo).toEqual(created);
+  });
+});

--- a/apps/studio/src/__tests__/request-guard.test.ts
+++ b/apps/studio/src/__tests__/request-guard.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { isAllowedRequest } from "../request-guard";
+
+const ALLOWED = new Set(["127.0.0.1:5757", "localhost:5757"]);
+
+const request = (headers: Record<string, string>): Request =>
+  new Request("http://127.0.0.1:5757/api/memos", { headers });
+
+describe("isAllowedRequest", () => {
+  it("allows a same-origin request without an Origin header", () => {
+    expect(isAllowedRequest(request({ host: "127.0.0.1:5757" }), ALLOWED)).toBe(true);
+    expect(isAllowedRequest(request({ host: "localhost:5757" }), ALLOWED)).toBe(true);
+  });
+
+  it("allows a request with a localhost Origin", () => {
+    expect(
+      isAllowedRequest(
+        request({ host: "127.0.0.1:5757", origin: "http://localhost:5757" }),
+        ALLOWED,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a missing or empty Host header", () => {
+    // Host is added at send time, so a bare Request has none
+    expect(isAllowedRequest(new Request("http://127.0.0.1:5757/"), ALLOWED)).toBe(false);
+    expect(isAllowedRequest(request({ host: "" }), ALLOWED)).toBe(false);
+  });
+
+  it("rejects a DNS-rebound Host header", () => {
+    expect(isAllowedRequest(request({ host: "evil.example:5757" }), ALLOWED)).toBe(false);
+  });
+
+  it("rejects a cross-origin request from another site", () => {
+    expect(
+      isAllowedRequest(
+        request({ host: "127.0.0.1:5757", origin: "https://evil.example" }),
+        ALLOWED,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects an allowed hostname on a different port", () => {
+    expect(isAllowedRequest(request({ host: "127.0.0.1:8080" }), ALLOWED)).toBe(false);
+    expect(
+      isAllowedRequest(
+        request({ host: "127.0.0.1:5757", origin: "http://127.0.0.1:8080" }),
+        ALLOWED,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a malformed Origin header", () => {
+    expect(isAllowedRequest(request({ host: "127.0.0.1:5757", origin: "null" }), ALLOWED)).toBe(
+      false,
+    );
+  });
+});

--- a/apps/studio/src/client.ts
+++ b/apps/studio/src/client.ts
@@ -1,0 +1,340 @@
+/**
+ * Studio frontend: compose form, image attachments, reply/quote selection,
+ * feed rendering, and sync trigger. Bundled by Bun's HTML import.
+ */
+
+import { filterMemos } from "./memo-filter";
+
+interface MemoSummary {
+  dirName: string;
+  id: string;
+  createdAt: string;
+  body: string;
+  tag?: string;
+  comment?: string;
+  quote?: string;
+  isDraft: boolean;
+  images: string[];
+}
+
+const MAX_BODY_LENGTH = 500;
+const MAX_IMAGES = 4;
+const FEED_PAGE_SIZE = 20;
+const SITE_URL = "https://memo.kkhys.me";
+
+const $ = <T extends HTMLElement>(id: string): T => {
+  const element = document.querySelector<T>(`#${id}`);
+  if (!element) throw new Error(`Missing element: #${id}`);
+  return element;
+};
+
+const form = $<HTMLFormElement>("compose");
+const bodyInput = $<HTMLTextAreaElement>("body");
+const counter = $<HTMLSpanElement>("counter");
+const createdAtInput = $<HTMLInputElement>("created-at");
+const tagInput = $<HTMLInputElement>("tag");
+const tagList = $<HTMLDataListElement>("tag-list");
+const isDraftInput = $<HTMLInputElement>("is-draft");
+const hideLinkCardInput = $<HTMLInputElement>("hide-link-card");
+const imagesInput = $<HTMLInputElement>("images");
+const previews = $<HTMLDivElement>("previews");
+const replyBanner = $<HTMLDivElement>("reply-banner");
+const replyLabel = $<HTMLSpanElement>("reply-label");
+const replyExcerpt = $<HTMLSpanElement>("reply-excerpt");
+const replyClear = $<HTMLButtonElement>("reply-clear");
+const postButton = $<HTMLButtonElement>("post");
+const message = $<HTMLParagraphElement>("message");
+const statusLabel = $<HTMLSpanElement>("status");
+const syncButton = $<HTMLButtonElement>("sync");
+const deployInput = $<HTMLInputElement>("deploy");
+const feed = $<HTMLOListElement>("feed");
+const loadMoreButton = $<HTMLButtonElement>("load-more");
+const searchInput = $<HTMLInputElement>("search");
+
+let memos: MemoSummary[] = [];
+let attachedImages: File[] = [];
+let replyTarget: { type: "comment" | "quote"; memo: MemoSummary } | null = null;
+let feedLimit = FEED_PAGE_SIZE;
+
+const showMessage = (text: string, isError = false): void => {
+  message.textContent = text;
+  message.classList.toggle("message--error", isError);
+  message.hidden = false;
+};
+
+const updateCounter = (): void => {
+  const count = bodyInput.value.length;
+  counter.textContent = `${count} / ${MAX_BODY_LENGTH}`;
+  counter.classList.toggle("compose__counter--over", count > MAX_BODY_LENGTH);
+};
+
+const renderPreviews = (): void => {
+  previews.replaceChildren();
+  attachedImages.forEach((file, index) => {
+    const item = document.createElement("figure");
+    item.className = "compose__preview";
+
+    const img = document.createElement("img");
+    img.src = URL.createObjectURL(file);
+    img.alt = file.name;
+    img.addEventListener("load", () => URL.revokeObjectURL(img.src));
+
+    const remove = document.createElement("button");
+    remove.type = "button";
+    remove.className = "compose__preview-remove";
+    remove.setAttribute("aria-label", `Remove image ${index + 1}`);
+    remove.textContent = "×";
+    remove.addEventListener("click", () => {
+      attachedImages = attachedImages.filter((_, i) => i !== index);
+      renderPreviews();
+    });
+
+    item.append(img, remove);
+    previews.append(item);
+  });
+};
+
+const addImages = (files: Iterable<File>): void => {
+  for (const file of files) {
+    if (file.type !== "image/jpeg" && file.type !== "image/png") continue;
+    if (attachedImages.length >= MAX_IMAGES) {
+      showMessage(`Up to ${MAX_IMAGES} images per memo`, true);
+      break;
+    }
+    attachedImages.push(file);
+  }
+  renderPreviews();
+};
+
+const setReplyTarget = (type: "comment" | "quote", memo: MemoSummary): void => {
+  replyTarget = { type, memo };
+  replyLabel.textContent = type === "comment" ? "Reply to" : "Quote";
+  replyExcerpt.textContent = memo.body.slice(0, 60) || memo.dirName;
+  replyBanner.hidden = false;
+  bodyInput.focus();
+};
+
+const clearReplyTarget = (): void => {
+  replyTarget = null;
+  replyBanner.hidden = true;
+};
+
+const renderTagList = (): void => {
+  const tags = [...new Set(memos.map((memo) => memo.tag).filter(Boolean))] as string[];
+  tagList.replaceChildren(
+    ...tags.toSorted().map((tag) => {
+      const option = document.createElement("option");
+      option.value = tag;
+      return option;
+    }),
+  );
+};
+
+const renderFeedItem = (memo: MemoSummary): HTMLLIElement => {
+  const item = document.createElement("li");
+  item.className = "feed__item";
+
+  const meta = document.createElement("div");
+  meta.className = "feed__meta";
+
+  const time = document.createElement("time");
+  time.textContent = memo.createdAt;
+
+  if (memo.isDraft) {
+    meta.append(time);
+  } else {
+    // Drafts are filtered out in production, so only published memos get a link
+    const permalink = document.createElement("a");
+    permalink.className = "feed__permalink";
+    permalink.href = `${SITE_URL}/posts/${memo.id}`;
+    permalink.target = "_blank";
+    permalink.rel = "noopener";
+    permalink.append(time);
+    meta.append(permalink);
+  }
+
+  if (memo.tag) {
+    const tag = document.createElement("span");
+    tag.className = "chip";
+    tag.textContent = `#${memo.tag}`;
+    meta.append(tag);
+  }
+  if (memo.isDraft) {
+    const draft = document.createElement("span");
+    draft.className = "chip chip--draft";
+    draft.textContent = "draft";
+    meta.append(draft);
+  }
+  if (memo.comment) {
+    const reply = document.createElement("span");
+    reply.className = "chip";
+    reply.textContent = "reply";
+    meta.append(reply);
+  }
+  if (memo.quote) {
+    const quote = document.createElement("span");
+    quote.className = "chip";
+    quote.textContent = "quote";
+    meta.append(quote);
+  }
+
+  const body = document.createElement("p");
+  body.className = "feed__body";
+  body.textContent = memo.body;
+
+  item.append(meta, body);
+
+  if (memo.images.length > 0) {
+    const gallery = document.createElement("div");
+    gallery.className = "feed__images";
+    for (const image of memo.images) {
+      const img = document.createElement("img");
+      img.src = `/api/images/${memo.dirName}/${image}`;
+      img.alt = "";
+      img.loading = "lazy";
+      gallery.append(img);
+    }
+    item.append(gallery);
+  }
+
+  const actions = document.createElement("div");
+  actions.className = "feed__actions";
+  for (const [label, type] of [
+    ["Reply", "comment"],
+    ["Quote", "quote"],
+  ] as const) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "btn btn--ghost btn--small";
+    button.textContent = label;
+    button.addEventListener("click", () => setReplyTarget(type, memo));
+    actions.append(button);
+  }
+  item.append(actions);
+
+  return item;
+};
+
+const renderFeed = (): void => {
+  const visible = filterMemos(memos, searchInput.value);
+  feed.replaceChildren(...visible.slice(0, feedLimit).map((memo) => renderFeedItem(memo)));
+  loadMoreButton.hidden = visible.length <= feedLimit;
+};
+
+const refreshMemos = async (): Promise<void> => {
+  const response = await fetch("/api/memos");
+  const data = (await response.json()) as { memos: MemoSummary[] };
+  memos = data.memos;
+  renderFeed();
+  renderTagList();
+};
+
+const refreshStatus = async (): Promise<void> => {
+  const response = await fetch("/api/status");
+  const data = (await response.json()) as { changes?: number };
+  const changes = data.changes ?? 0;
+  statusLabel.textContent = changes === 0 ? "clean" : `${changes} unsynced`;
+  statusLabel.classList.toggle("header__status--dirty", changes > 0);
+};
+
+const toCreatedAt = (value: string): string | undefined => {
+  if (value === "") return undefined;
+  const normalized = value.replace("T", " ");
+  return normalized.length === 16 ? `${normalized}:00` : normalized;
+};
+
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  message.hidden = true;
+  postButton.disabled = true;
+
+  try {
+    const formData = new FormData();
+    formData.set("body", bodyInput.value);
+
+    const createdAt = toCreatedAt(createdAtInput.value);
+    if (createdAt) formData.set("createdAt", createdAt);
+    if (tagInput.value.trim()) formData.set("tag", tagInput.value.trim());
+    if (replyTarget) formData.set(replyTarget.type, replyTarget.memo.id);
+    if (isDraftInput.checked) formData.set("isDraft", "true");
+    if (hideLinkCardInput.checked) formData.set("hideLinkCard", "true");
+    for (const file of attachedImages) formData.append("images", file);
+
+    const response = await fetch("/api/memos", { method: "POST", body: formData });
+    const data = (await response.json()) as { memo?: MemoSummary; error?: string };
+
+    if (!response.ok) {
+      showMessage(data.error ?? `Failed to post (${response.status})`, true);
+      return;
+    }
+
+    form.reset();
+    attachedImages = [];
+    renderPreviews();
+    clearReplyTarget();
+    updateCounter();
+    showMessage(`Posted: ${data.memo?.dirName ?? ""}`);
+    await Promise.all([refreshMemos(), refreshStatus()]);
+  } catch (error) {
+    showMessage(error instanceof Error ? error.message : String(error), true);
+  } finally {
+    postButton.disabled = false;
+  }
+});
+
+syncButton.addEventListener("click", async () => {
+  message.hidden = true;
+  syncButton.disabled = true;
+
+  try {
+    const response = await fetch("/api/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ deploy: deployInput.checked }),
+    });
+    const data = (await response.json()) as { message?: string; error?: string };
+    showMessage(data.message ?? data.error ?? "Sync failed", !response.ok);
+    await refreshStatus();
+  } catch (error) {
+    showMessage(error instanceof Error ? error.message : String(error), true);
+  } finally {
+    syncButton.disabled = false;
+  }
+});
+
+bodyInput.addEventListener("input", updateCounter);
+
+bodyInput.addEventListener("paste", (event) => {
+  const files = event.clipboardData?.files;
+  if (files && files.length > 0) {
+    event.preventDefault();
+    addImages(files);
+  }
+});
+
+form.addEventListener("dragover", (event) => event.preventDefault());
+form.addEventListener("drop", (event) => {
+  event.preventDefault();
+  if (event.dataTransfer?.files) addImages(event.dataTransfer.files);
+});
+
+imagesInput.addEventListener("change", () => {
+  if (imagesInput.files) addImages(imagesInput.files);
+  imagesInput.value = "";
+});
+
+replyClear.addEventListener("click", clearReplyTarget);
+
+loadMoreButton.addEventListener("click", () => {
+  feedLimit += FEED_PAGE_SIZE;
+  renderFeed();
+});
+
+searchInput.addEventListener("input", () => {
+  feedLimit = FEED_PAGE_SIZE;
+  renderFeed();
+});
+
+updateCounter();
+void refreshMemos();
+void refreshStatus();

--- a/apps/studio/src/index.html
+++ b/apps/studio/src/index.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Studio</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script type="module" src="./client.ts"></script>
+  </head>
+  <body>
+    <main class="container">
+      <header class="header">
+        <h1 class="header__title">Studio</h1>
+        <div class="header__sync">
+          <span id="status" class="header__status" role="status"></span>
+          <label class="toggle"><input id="deploy" type="checkbox" /> Deploy</label>
+          <button id="sync" class="btn" type="button">Sync</button>
+        </div>
+      </header>
+
+      <form id="compose" class="compose">
+        <div id="reply-banner" class="compose__reply" hidden>
+          <span id="reply-label" class="compose__reply-label"></span>
+          <span id="reply-excerpt" class="compose__reply-excerpt"></span>
+          <button
+            id="reply-clear"
+            class="compose__reply-clear"
+            type="button"
+            aria-label="Clear reply target"
+          >
+            ×
+          </button>
+        </div>
+
+        <textarea
+          id="body"
+          class="compose__body"
+          rows="5"
+          placeholder="What's on your mind?"
+          autofocus
+        ></textarea>
+
+        <div id="previews" class="compose__previews"></div>
+
+        <div class="compose__meta">
+          <input
+            id="created-at"
+            class="compose__input"
+            type="datetime-local"
+            step="1"
+            aria-label="Created at"
+          />
+          <input
+            id="tag"
+            class="compose__input"
+            type="text"
+            list="tag-list"
+            placeholder="tag"
+            pattern="[a-z0-9_]+"
+            aria-label="Tag"
+          />
+          <datalist id="tag-list"></datalist>
+          <label class="toggle"><input id="is-draft" type="checkbox" /> Draft</label>
+          <label class="toggle"><input id="hide-link-card" type="checkbox" /> No link card</label>
+        </div>
+
+        <div class="compose__actions">
+          <label class="btn btn--ghost compose__attach">
+            Images
+            <input id="images" type="file" accept="image/jpeg,image/png" multiple hidden />
+          </label>
+          <span id="counter" class="compose__counter">0 / 500</span>
+          <button id="post" class="btn btn--primary" type="submit">Post</button>
+        </div>
+      </form>
+
+      <p id="message" class="message" role="status" hidden></p>
+
+      <section class="feed" aria-label="Recent memos">
+        <input
+          id="search"
+          class="feed__search"
+          type="search"
+          placeholder="Search memos"
+          aria-label="Search memos"
+        />
+        <ol id="feed" class="feed__list"></ol>
+        <button id="load-more" class="btn btn--ghost feed__more" type="button" hidden>
+          Load more
+        </button>
+      </section>
+    </main>
+  </body>
+</html>

--- a/apps/studio/src/memo-filter.ts
+++ b/apps/studio/src/memo-filter.ts
@@ -1,0 +1,24 @@
+/**
+ * Client-side feed filtering. Shared shape with the API's memo summaries;
+ * kept DOM-free so it can be unit-tested on Node.
+ */
+
+export interface FilterableMemo {
+  body: string;
+  createdAt: string;
+  tag?: string | undefined;
+}
+
+/**
+ * Filter memos by a free-text query. Whitespace-separated terms are ANDed;
+ * each term matches case-insensitively against body, tag, or createdAt.
+ */
+export const filterMemos = <T extends FilterableMemo>(memos: T[], query: string): T[] => {
+  const terms = query.trim().toLowerCase().split(/\s+/u).filter(Boolean);
+  if (terms.length === 0) return memos;
+
+  return memos.filter((memo) => {
+    const haystack = `${memo.body}\n${memo.tag ?? ""}\n${memo.createdAt}`.toLowerCase();
+    return terms.every((term) => haystack.includes(term));
+  });
+};

--- a/apps/studio/src/memo-store.ts
+++ b/apps/studio/src/memo-store.ts
@@ -1,0 +1,251 @@
+/**
+ * Filesystem-backed store for memo-content.
+ *
+ * Reads and writes memo directories (`<base>/YYYYMMDD_HHMMSS/index.md` plus
+ * numbered images) following the same conventions as the memo app's content
+ * loader. Kept free of Bun-specific APIs so it can be unit-tested on Node.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { toString as mdastToString } from "mdast-util-to-string";
+import { remark } from "remark";
+import { ulid } from "ulid";
+
+export const MAX_BODY_LENGTH = 500;
+export const MAX_IMAGES = 4;
+
+const DATE_TIME_PATTERN = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/u;
+const TAG_PATTERN = /^[a-z0-9_]+$/u;
+const ULID_PATTERN = /^[0-9a-hjkmnp-tv-z]{26}$/u;
+const IMAGE_FILE_PATTERN = /\.(jpg|png)$/u;
+
+export type MemoImageExt = "jpg" | "png";
+
+export interface MemoImageInput {
+  data: Uint8Array;
+  ext: MemoImageExt;
+}
+
+export interface CreateMemoInput {
+  body: string;
+  createdAt?: string | undefined;
+  tag?: string | undefined;
+  comment?: string | undefined;
+  quote?: string | undefined;
+  isDraft?: boolean | undefined;
+  hideLinkCard?: boolean | undefined;
+  images?: MemoImageInput[] | undefined;
+}
+
+export interface MemoSummary {
+  dirName: string;
+  id: string;
+  createdAt: string;
+  body: string;
+  tag?: string | undefined;
+  comment?: string | undefined;
+  quote?: string | undefined;
+  isDraft: boolean;
+  images: string[];
+}
+
+const processor = remark();
+
+/**
+ * Count body characters the same way the memo app's remark-word-limit plugin
+ * does: markdown syntax is excluded, only rendered text is counted.
+ */
+export const countMemoChars = (body: string): number => mdastToString(processor.parse(body)).length;
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+export const formatDateTime = (date: Date): string =>
+  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+  ` ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+
+/** Parse a `YYYY-MM-DD HH:mm:ss` string, rejecting impossible dates. */
+const parseDateTime = (dateTimeStr: string): Date => {
+  const match = dateTimeStr.match(DATE_TIME_PATTERN);
+  if (!match) {
+    throw new Error(`Invalid datetime format (expected YYYY-MM-DD HH:mm:ss): ${dateTimeStr}`);
+  }
+
+  const [, year, month, day, hour, minute, second] = match.map(Number) as [
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+    number,
+  ];
+  const date = new Date(year, month - 1, day, hour, minute, second);
+
+  if (formatDateTime(date) !== dateTimeStr) {
+    throw new Error(`Invalid datetime: ${dateTimeStr}`);
+  }
+
+  return date;
+};
+
+const dirNameFromDateTime = (dateTimeStr: string): string =>
+  dateTimeStr.replaceAll("-", "").replaceAll(":", "").replace(" ", "_");
+
+interface ParsedMemoFile {
+  frontmatter: Map<string, string>;
+  body: string;
+}
+
+const parseMemoFile = (content: string): ParsedMemoFile | undefined => {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/u);
+  if (!match) return undefined;
+
+  const frontmatter = new Map<string, string>();
+  for (const line of (match[1] as string).split("\n")) {
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    frontmatter.set(line.slice(0, separator).trim(), line.slice(separator + 1).trim());
+  }
+
+  return { frontmatter, body: (match[2] as string).trim() };
+};
+
+const serializeMemoFile = (
+  frontmatter: { id: string; createdAt: string } & Omit<CreateMemoInput, "body" | "images">,
+  body: string,
+): string => {
+  const lines = [`id: ${frontmatter.id}`, `createdAt: ${frontmatter.createdAt}`];
+  if (frontmatter.tag) lines.push(`tag: ${frontmatter.tag}`);
+  if (frontmatter.comment) lines.push(`comment: ${frontmatter.comment}`);
+  if (frontmatter.quote) lines.push(`quote: ${frontmatter.quote}`);
+  if (frontmatter.isDraft) lines.push("isDraft: true");
+  if (frontmatter.hideLinkCard) lines.push("hideLinkCard: true");
+
+  return `---\n${lines.join("\n")}\n---\n\n${body.trim()}\n`;
+};
+
+const validateInput = (input: CreateMemoInput): void => {
+  if (input.body.trim() === "") {
+    throw new Error("Body is required");
+  }
+
+  const charCount = countMemoChars(input.body);
+  if (charCount > MAX_BODY_LENGTH) {
+    throw new Error(
+      `Character count exceeds the limit: ${charCount} characters (limit: ${MAX_BODY_LENGTH} characters)`,
+    );
+  }
+
+  if (input.tag !== undefined && !TAG_PATTERN.test(input.tag)) {
+    throw new Error(`Invalid tag (allowed: a-z, 0-9, _): ${input.tag}`);
+  }
+
+  for (const [field, value] of [
+    ["comment", input.comment],
+    ["quote", input.quote],
+  ] as const) {
+    if (value !== undefined && !ULID_PATTERN.test(value)) {
+      throw new Error(`Invalid ${field} target (expected a lowercase ULID): ${value}`);
+    }
+  }
+
+  if (input.images !== undefined && input.images.length > MAX_IMAGES) {
+    throw new Error(`Too many images: ${input.images.length} (limit: ${MAX_IMAGES})`);
+  }
+};
+
+/**
+ * Create a memo directory with index.md and numbered image files.
+ *
+ * @returns Summary of the created memo
+ */
+export const createMemo = (baseDir: string, input: CreateMemoInput): MemoSummary => {
+  validateInput(input);
+
+  const createdAt = input.createdAt ?? formatDateTime(new Date());
+  const timestamp = parseDateTime(createdAt).getTime();
+  const id = ulid(timestamp).toLowerCase();
+  const dirName = dirNameFromDateTime(createdAt);
+  const memoDir = join(baseDir, dirName);
+
+  if (existsSync(memoDir)) {
+    throw new Error(`Memo directory already exists: ${dirName}`);
+  }
+
+  const body = input.body.trim();
+  const images = input.images ?? [];
+
+  mkdirSync(memoDir, { recursive: true });
+  writeFileSync(
+    join(memoDir, "index.md"),
+    serializeMemoFile(
+      {
+        id,
+        createdAt,
+        tag: input.tag,
+        comment: input.comment,
+        quote: input.quote,
+        isDraft: input.isDraft,
+        hideLinkCard: input.hideLinkCard,
+      },
+      body,
+    ),
+    "utf-8",
+  );
+
+  const imageNames = images.map((image, index) => {
+    const name = `${String(index + 1).padStart(2, "0")}.${image.ext}`;
+    writeFileSync(join(memoDir, name), image.data);
+    return name;
+  });
+
+  return {
+    dirName,
+    id,
+    createdAt,
+    body,
+    tag: input.tag,
+    comment: input.comment,
+    quote: input.quote,
+    isDraft: input.isDraft ?? false,
+    images: imageNames,
+  };
+};
+
+/** List all memos under baseDir, newest first. */
+export const listMemos = (baseDir: string): MemoSummary[] => {
+  if (!existsSync(baseDir)) return [];
+
+  const memos: MemoSummary[] = [];
+
+  for (const entry of readdirSync(baseDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const indexPath = join(baseDir, entry.name, "index.md");
+    if (!existsSync(indexPath)) continue;
+
+    const parsed = parseMemoFile(readFileSync(indexPath, "utf-8"));
+    const id = parsed?.frontmatter.get("id");
+    const createdAt = parsed?.frontmatter.get("createdAt");
+    if (!parsed || !id || !createdAt) continue;
+
+    const images = readdirSync(join(baseDir, entry.name))
+      .filter((file) => IMAGE_FILE_PATTERN.test(file))
+      .toSorted((a, b) => a.localeCompare(b));
+
+    memos.push({
+      dirName: entry.name,
+      id,
+      createdAt,
+      body: parsed.body,
+      tag: parsed.frontmatter.get("tag"),
+      comment: parsed.frontmatter.get("comment"),
+      quote: parsed.frontmatter.get("quote"),
+      isDraft: parsed.frontmatter.get("isDraft") === "true",
+      images,
+    });
+  }
+
+  return memos.toSorted((a, b) => b.createdAt.localeCompare(a.createdAt));
+};

--- a/apps/studio/src/request-guard.ts
+++ b/apps/studio/src/request-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * Request guard against DNS rebinding and cross-origin requests.
+ *
+ * The server binds to localhost, but browsers will happily send cross-origin
+ * POSTs to 127.0.0.1 from any page (CORS only blocks reading the response),
+ * and DNS rebinding can point an attacker's hostname at 127.0.0.1. Both are
+ * rejected here by validating the Host and Origin headers.
+ */
+
+export const isAllowedRequest = (req: Request, allowedHosts: ReadonlySet<string>): boolean => {
+  const host = req.headers.get("host");
+  if (!host || !allowedHosts.has(host)) return false;
+
+  // Same-origin fetches may omit Origin; only validate it when present.
+  const origin = req.headers.get("origin");
+  if (origin === null) return true;
+
+  let originHost: string;
+  try {
+    originHost = new URL(origin).host;
+  } catch {
+    return false;
+  }
+
+  return allowedHosts.has(originHost);
+};

--- a/apps/studio/src/server.ts
+++ b/apps/studio/src/server.ts
@@ -1,0 +1,166 @@
+/**
+ * Local-only dev server for composing memos.
+ *
+ * Serves the studio UI (bundled by Bun's HTML import) and a JSON API that
+ * reads/writes the memo-content submodule directly. Never deployed; binds to
+ * localhost only.
+ */
+
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { $, type BunRequest } from "bun";
+import homepage from "./index.html";
+import { createMemo, listMemos, type MemoImageInput } from "./memo-store";
+import { isAllowedRequest } from "./request-guard";
+
+const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
+const CONTENT_DIR = fileURLToPath(new URL("../../memo/memo-content", import.meta.url));
+const MEMO_DIR = join(CONTENT_DIR, "memo");
+const PORT = Number(process.env.PORT ?? 5757);
+
+const ALLOWED_HOSTS: ReadonlySet<string> = new Set([`127.0.0.1:${PORT}`, `localhost:${PORT}`]);
+
+const guarded =
+  <T extends string>(handler: (req: BunRequest<T>) => Response | Promise<Response>) =>
+  (req: BunRequest<T>): Response | Promise<Response> =>
+    isAllowedRequest(req, ALLOWED_HOSTS)
+      ? handler(req)
+      : new Response("Forbidden", { status: 403 });
+
+const DIR_NAME_PATTERN = /^\d{8}_\d{6}$/u;
+const IMAGE_NAME_PATTERN = /^\d{2}\.(jpg|png)$/u;
+
+const IMAGE_EXT_BY_MIME: Record<string, MemoImageInput["ext"]> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+};
+
+const errorResponse = (error: unknown, status = 400) =>
+  Response.json({ error: error instanceof Error ? error.message : String(error) }, { status });
+
+const formField = (form: FormData, name: string): string | undefined => {
+  const value = form.get(name);
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+};
+
+const syncTimestamp = () =>
+  new Date()
+    .toLocaleString("ja-JP", {
+      timeZone: "Asia/Tokyo",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    })
+    .replaceAll("/", "-");
+
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: PORT,
+  development: true,
+  routes: {
+    "/": homepage,
+
+    "/api/memos": {
+      GET: guarded(() => Response.json({ memos: listMemos(MEMO_DIR) })),
+
+      POST: guarded(async (req) => {
+        try {
+          const form = await req.formData();
+
+          const images: MemoImageInput[] = [];
+          for (const value of form.getAll("images")) {
+            if (!(value instanceof File) || value.size === 0) continue;
+            const ext = IMAGE_EXT_BY_MIME[value.type];
+            if (!ext) return errorResponse(`Unsupported image type: ${value.type || "unknown"}`);
+            images.push({ data: new Uint8Array(await value.arrayBuffer()), ext });
+          }
+
+          const memo = createMemo(MEMO_DIR, {
+            body: formField(form, "body") ?? "",
+            createdAt: formField(form, "createdAt"),
+            tag: formField(form, "tag"),
+            comment: formField(form, "comment"),
+            quote: formField(form, "quote"),
+            isDraft: form.get("isDraft") === "true",
+            hideLinkCard: form.get("hideLinkCard") === "true",
+            images,
+          });
+
+          return Response.json({ memo }, { status: 201 });
+        } catch (error) {
+          return errorResponse(error);
+        }
+      }),
+    },
+
+    "/api/images/:dirName/:file": guarded(async (req) => {
+      const { dirName, file } = req.params;
+      if (!DIR_NAME_PATTERN.test(dirName) || !IMAGE_NAME_PATTERN.test(file)) {
+        return new Response("Not Found", { status: 404 });
+      }
+
+      const image = Bun.file(join(MEMO_DIR, dirName, file));
+      if (!(await image.exists())) {
+        return new Response("Not Found", { status: 404 });
+      }
+
+      return new Response(image);
+    }),
+
+    "/api/status": guarded(async () => {
+      try {
+        const status = await $`git -C ${CONTENT_DIR} status --porcelain`.text();
+        return Response.json({ changes: status.split("\n").filter(Boolean).length });
+      } catch (error) {
+        return errorResponse(error, 500);
+      }
+    }),
+
+    "/api/sync": {
+      POST: guarded(async (req) => {
+        const deploy = await req
+          .json()
+          .then((body: unknown) => (body as { deploy?: unknown } | null)?.deploy === true)
+          .catch(() => false);
+
+        try {
+          const status = await $`git -C ${CONTENT_DIR} status --porcelain`.text();
+          if (!status.trim()) {
+            return Response.json({ synced: false, message: "No changes to commit" });
+          }
+
+          await $`git -C ${CONTENT_DIR} add -A`;
+          await $`git -C ${CONTENT_DIR} commit -m ${`feat: update memos ${syncTimestamp()}`}`;
+          await $`git -C ${CONTENT_DIR} push`;
+        } catch (error) {
+          return errorResponse(error, 500);
+        }
+
+        if (!deploy) {
+          return Response.json({ synced: true, message: "Synced successfully" });
+        }
+
+        // Bump the submodule pointer in the main repo so the push actually
+        // deploys (sync-submodule.yml opens an auto-merging PR).
+        try {
+          await $`gh workflow run sync-submodule.yml`.cwd(REPO_ROOT).quiet();
+          return Response.json({ synced: true, message: "Synced, submodule sync triggered" });
+        } catch (error) {
+          const reason = error instanceof Error ? error.message : String(error);
+          return Response.json({
+            synced: true,
+            message: `Synced, but workflow trigger failed: ${reason}`,
+          });
+        }
+      }),
+    },
+  },
+
+  fetch: () => new Response("Not Found", { status: 404 }),
+});
+
+console.log(`studio running at ${server.url}`);

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -1,0 +1,340 @@
+@import "@kkhys/styles/uchu.css";
+
+:root {
+  color-scheme: light dark;
+
+  /* Same palette mapping as apps/memo global.css (uchu values are static) */
+  --color-bg: light-dark(var(--uchu-yang), var(--uchu-yin));
+  --color-surface: light-dark(var(--uchu-gray-1), var(--uchu-yin-9));
+  --color-border: light-dark(var(--uchu-gray-3), var(--uchu-yin-8));
+  --color-text: light-dark(var(--uchu-yin-9), var(--uchu-yin-1));
+  --color-text-muted: var(--uchu-yin-5);
+  --color-accent: light-dark(var(--uchu-blue-5), var(--uchu-blue-4));
+  --color-danger: light-dark(var(--uchu-red-6), var(--uchu-red-4));
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: system-ui, sans-serif;
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 40rem;
+  margin-inline: auto;
+  padding: 1.5rem 1rem 4rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header__title {
+  font-size: 1.25rem;
+}
+
+.header__sync {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.header__status {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.header__status--dirty {
+  color: var(--color-danger);
+}
+
+.btn {
+  appearance: none;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  padding: 0.375rem 0.875rem;
+  cursor: pointer;
+}
+
+.btn:hover {
+  border-color: var(--color-accent);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.btn--primary {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--uchu-yang);
+}
+
+.btn--ghost {
+  background: transparent;
+}
+
+.btn--small {
+  font-size: 0.75rem;
+  padding: 0.125rem 0.625rem;
+}
+
+.compose {
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  background: var(--color-surface);
+  padding: 1rem;
+}
+
+.compose__reply {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  border-inline-start: 3px solid var(--color-accent);
+  padding-inline-start: 0.5rem;
+}
+
+.compose__reply-label {
+  color: var(--color-accent);
+  flex-shrink: 0;
+}
+
+.compose__reply-excerpt {
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compose__reply-clear {
+  border: none;
+  background: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 1rem;
+  margin-inline-start: auto;
+}
+
+.compose__body {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  resize: vertical;
+}
+
+.compose__body:focus {
+  outline: none;
+}
+
+.compose__previews {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.compose__previews:empty {
+  display: none;
+}
+
+.compose__preview {
+  position: relative;
+}
+
+.compose__preview img {
+  width: 6rem;
+  height: 6rem;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-border);
+}
+
+.compose__preview-remove {
+  position: absolute;
+  top: -0.375rem;
+  right: -0.375rem;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+  cursor: pointer;
+  line-height: 1;
+}
+
+.compose__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+}
+
+.compose__input {
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  background: var(--color-bg);
+  color: inherit;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.compose__input:invalid {
+  border-color: var(--color-danger);
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.compose__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.compose__attach {
+  cursor: pointer;
+}
+
+.compose__counter {
+  margin-inline-start: auto;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.compose__counter--over {
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
+.message {
+  font-size: 0.875rem;
+  color: var(--color-accent);
+}
+
+.message--error {
+  color: var(--color-danger);
+}
+
+.feed {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.feed__search {
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  background: var(--color-surface);
+  color: inherit;
+  font-size: 0.875rem;
+  padding: 0.375rem 0.75rem;
+}
+
+.feed__search:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.feed__list {
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.feed__permalink {
+  color: inherit;
+  text-decoration: none;
+}
+
+.feed__permalink:hover {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
+.feed__item {
+  border: 1px solid var(--color-border);
+  border-radius: 0.75rem;
+  background: var(--color-surface);
+  padding: 0.875rem 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.feed__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.chip {
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0 0.5rem;
+  font-size: 0.7rem;
+}
+
+.chip--draft {
+  color: var(--color-danger);
+  border-color: var(--color-danger);
+}
+
+.feed__body {
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.feed__images {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.feed__images img {
+  width: 5rem;
+  height: 5rem;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-border);
+}
+
+.feed__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.feed__more {
+  width: 100%;
+}

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["bun"],
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/studio/vitest.config.ts
+++ b/apps/studio/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/__tests__/**/*.test.ts"],
+    coverage: {
+      include: ["src/memo-store.ts", "src/memo-filter.ts", "src/request-guard.ts"],
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev:diary": "pnpm --filter @kkhys/diary dev",
     "deploy:diary": "pnpm --filter @kkhys/diary deploy",
     "dev:memo": "pnpm --filter @kkhys/memo dev",
+    "dev:studio": "pnpm --filter @kkhys/studio dev",
     "release": "bun run scripts/release.ts"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ catalogs:
     typescript:
       specifier: 6.0.3
       version: 6.0.3
+    ulid:
+      specifier: 3.0.1
+      version: 3.0.1
     unist-util-visit:
       specifier: 5.1.0
       version: 5.1.0
@@ -97,7 +100,7 @@ importers:
         version: link:../../packages/styles
       astro:
         specifier: 'catalog:'
-        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2)
+        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2)
       kiso.css:
         specifier: 'catalog:'
         version: 1.2.4
@@ -143,7 +146,7 @@ importers:
         version: link:../../packages/styles
       astro:
         specifier: 'catalog:'
-        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2)
+        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2)
       kiso.css:
         specifier: 'catalog:'
         version: 1.2.4
@@ -159,7 +162,7 @@ importers:
         version: 3.7.3
       '@playform/compress':
         specifier: 0.2.3
-        version: 0.2.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(yaml@2.8.2)
+        version: 0.2.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(yaml@2.8.2)
       '@types/bun':
         specifier: 'catalog:'
         version: 1.3.14
@@ -197,6 +200,21 @@ importers:
         specifier: 'catalog:'
         version: 4.105.0
 
+  apps/lgtm/lgtm-content:
+    devDependencies:
+      '@types/bun':
+        specifier: 1.3.3
+        version: 1.3.3
+      lefthook:
+        specifier: 2.1.8
+        version: 2.1.8
+      scrub-exif:
+        specifier: 0.1.0
+        version: 0.1.0
+      ulid:
+        specifier: 3.0.1
+        version: 3.0.1
+
   apps/me:
     dependencies:
       '@astrojs/check':
@@ -207,7 +225,7 @@ importers:
         version: 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/mdx':
         specifier: 7.0.1
-        version: 7.0.1(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2))
+        version: 7.0.1(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2))
       '@astrojs/react':
         specifier: 'catalog:'
         version: 6.0.0(@types/node@25.0.3)(@types/react-dom@19.1.6(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(terser@5.46.1)(yaml@2.8.2)
@@ -231,10 +249,10 @@ importers:
         version: link:../../packages/styles
       astro:
         specifier: 'catalog:'
-        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2)
+        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2)
       astro-expressive-code:
         specifier: 0.44.0
-        version: 0.44.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2))
+        version: 0.44.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2))
       graphql-request:
         specifier: 7.4.0
         version: 7.4.0(graphql@16.11.0)
@@ -333,6 +351,15 @@ importers:
         specifier: 'catalog:'
         version: 4.105.0
 
+  apps/me/me-content:
+    devDependencies:
+      lefthook:
+        specifier: 2.1.8
+        version: 2.1.8
+      scrub-exif:
+        specifier: 0.1.0
+        version: 0.1.0
+
   apps/memo:
     dependencies:
       '@astrojs/compiler-rs':
@@ -352,7 +379,7 @@ importers:
         version: link:../../packages/styles
       astro:
         specifier: 'catalog:'
-        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2)
+        version: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2)
       kiso.css:
         specifier: 'catalog:'
         version: 1.2.4
@@ -371,7 +398,7 @@ importers:
         version: 3.7.3
       '@playform/compress':
         specifier: 0.2.3
-        version: 0.2.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(yaml@2.8.2)
+        version: 0.2.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(yaml@2.8.2)
       '@types/bun':
         specifier: 'catalog:'
         version: 1.3.14
@@ -427,11 +454,60 @@ importers:
         specifier: 'catalog:'
         version: 4.105.0
 
+  apps/memo/memo-content:
+    devDependencies:
+      '@types/bun':
+        specifier: 1.3.3
+        version: 1.3.3
+      lefthook:
+        specifier: 2.1.8
+        version: 2.1.8
+      scrub-exif:
+        specifier: 0.1.0
+        version: 0.1.0
+      ulid:
+        specifier: 3.0.1
+        version: 3.0.1
+
+  apps/studio:
+    dependencies:
+      '@kkhys/styles':
+        specifier: workspace:*
+        version: link:../../packages/styles
+      mdast-util-to-string:
+        specifier: 4.0.0
+        version: 4.0.0
+      remark:
+        specifier: 15.0.1
+        version: 15.0.1
+      ulid:
+        specifier: 'catalog:'
+        version: 3.0.1
+    devDependencies:
+      '@types/bun':
+        specifier: 'catalog:'
+        version: 1.3.14
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.9(vitest@4.1.9)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.56.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.71.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@types/node@25.0.3)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@25.0.3)(esbuild@0.28.1)(terser@5.46.1)(yaml@2.8.2))
+
   packages/og:
     dependencies:
       astro:
         specifier: ^7.0.0
-        version: 7.0.2(@astrojs/markdown-remark@7.2.0)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2)
+        version: 7.0.2(@astrojs/markdown-remark@7.2.0)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2)
       react:
         specifier: 'catalog:'
         version: 19.2.7
@@ -465,7 +541,7 @@ importers:
     dependencies:
       astro:
         specifier: ^7.0.0
-        version: 7.0.2(@astrojs/markdown-remark@7.2.0)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2)
+        version: 7.0.2(@astrojs/markdown-remark@7.2.0)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2)
 
   packages/styles: {}
 
@@ -1773,144 +1849,6 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.59.0':
-    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
-    cpu: [arm]
-    os: [android]
-
-  '@rollup/rollup-android-arm64@4.59.0':
-    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rollup/rollup-darwin-arm64@4.59.0':
-    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rollup/rollup-darwin-x64@4.59.0':
-    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rollup/rollup-freebsd-arm64@4.59.0':
-    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.59.0':
-    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
-    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
-    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
-    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
-    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
-    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
-    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
-    cpu: [loong64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
-    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
-    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
-    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
-    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
-    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rollup/rollup-linux-x64-musl@4.59.0':
-    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rollup/rollup-openbsd-x64@4.59.0':
-    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
-    cpu: [x64]
-    os: [openbsd]
-
-  '@rollup/rollup-openharmony-arm64@4.59.0':
-    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
-    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
-    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
-    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
-    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
-    cpu: [x64]
-    os: [win32]
-
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
     engines: {node: '>=20'}
@@ -1974,6 +1912,9 @@ packages:
 
   '@types/bun@1.3.14':
     resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
+  '@types/bun@1.3.3':
+    resolution: {integrity: sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -2363,6 +2304,9 @@ packages:
 
   bun-types@1.3.14:
     resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+
+  bun-types@1.3.3:
+    resolution: {integrity: sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ==}
 
   camel-case@4.1.2:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
@@ -3239,6 +3183,60 @@ packages:
   layout-base@2.0.1:
     resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
+  lefthook-darwin-arm64@2.1.8:
+    resolution: {integrity: sha512-6dZr2QUdJOOvy9FjQHZoFVfPjgxb9IH5f9DeU0OBYMQ0cUGvb5YjHnkUkRrWIlASmwFm1bk3OPwhqKU7pTsICw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.8:
+    resolution: {integrity: sha512-DW1yc+W5RBHdwaPJ94/mwFNROmNHI8Osu0iziIeJFXJIdkQ2P+KHfoxBWejYd2QA2Eu5W9i+gBssTDkJ4kX2kA==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.8:
+    resolution: {integrity: sha512-rmWVdImTihY/V1bLSb3zeDxEHjRBQtudnkKKsoph934enIWPwzIap5zVHHAj8q9mzp0wpn5r1ybX55aO2wM61A==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.8:
+    resolution: {integrity: sha512-o1AG4CpmgESxLqZWzkXhne+PhLhLFV0GHVAIJCmieOwq4q2+rDYAudGhtot/NrgSpyMCo84qVSQmI8Dgnu1XJw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.8:
+    resolution: {integrity: sha512-er3zTjx2DMxojPJ1LZv0G3ug9Th+mAapqWrt5ZZhQNcXWW28pfvo2fCqBs6Fz14GMn4xassmwOpGovutSh1UtA==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.8:
+    resolution: {integrity: sha512-3yGx0VFbPcaKiIir313ETNcyq34CfAwkIU+Ry3WMGDjrsRNuA/YlDxm0BHKLcum7u+rpVfT4Uz6r8gHdaHXolg==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.8:
+    resolution: {integrity: sha512-Dq+GJdJdclOwxt4NneTFHjLSA4v8tI7XUZq40KUVtpUQDpZcYhXSdkTytB0uLmD52tbFKt9Kx0VbB6uvxPvLvw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.8:
+    resolution: {integrity: sha512-/Gv2EdlzyiDoK+9fDWIn+EeTgrNeVncQsSeAF47X2Abe5LGxuFjZbBXxEIkY1BU79OQNNLnkx0gFHbrr5mmd9Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.8:
+    resolution: {integrity: sha512-S+/pBBj/7hMQOl9pLBS4Ut8+U0feQbzmD7iN0ifNth4r/uqW8UFFAHwERbclfsVnni4ceHpt7lFr7sXsu0RU8g==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.8:
+    resolution: {integrity: sha512-MpdgKMU/JLLCsEpTqJ9jWlxngSdDh3EknvUHveWePrIms7G11y6R3oZBNRSqZ+zx/PGNl/HKvqEtbwtw8Hz3gw==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.8:
+    resolution: {integrity: sha512-tJIoVpFF52PuU8YPJI9bRprGwzI6FR2GNeBbpMnXdRjjfJHyOR4VRLXilzoQ6lbhKVHfTohXhrQgLpU41bKITg==}
+    hasBin: true
+
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -3931,11 +3929,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup@4.59.0:
-    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
-    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
-    hasBin: true
-
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
@@ -3973,6 +3966,11 @@ packages:
 
   schema-dts@2.0.0:
     resolution: {integrity: sha512-t7NoCy3Rn5GHGx6p7s1qIYK/AeIb8ZxJNR9WUNFkwMv2CiiGZBmqqYWc2FlZVm5ZbiHMY4OvBWhj7QtyrFO2Jw==}
+
+  scrub-exif@0.1.0:
+    resolution: {integrity: sha512-91b8qyrPyyFAJqy4GUKbJYoNIbFU7duVpE1UIpjie8Rb9N4p76IOaO8NKUmMeaSX5mbyIc5zN4wAdK8FP6jNJA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4146,6 +4144,10 @@ packages:
 
   uhyphen@0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
+
+  ulid@3.0.1:
+    resolution: {integrity: sha512-dPJyqPzx8preQhqq24bBG1YNkvigm87K8kVEHCD+ruZg24t6IFEFv00xMWfxcC4djmFtiTLdFuADn4+DOz6R7Q==}
+    hasBin: true
 
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
@@ -4727,13 +4729,13 @@ snapshots:
       github-slugger: 2.0.0
       satteri: 0.9.3
 
-  '@astrojs/mdx@7.0.1(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2))':
+  '@astrojs/mdx@7.0.1(@astrojs/markdown-satteri@0.3.2)(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/markdown-remark': 7.2.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2)
+      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -5578,12 +5580,12 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.71.0':
     optional: true
 
-  '@playform/compress@0.2.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(yaml@2.8.2)':
+  '@playform/compress@0.2.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(yaml@2.8.2)':
     dependencies:
       '@playform/pipe': 0.1.5
       '@types/csso': 5.0.4
       '@types/html-minifier-terser': 7.0.2
-      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2)
+      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2)
       commander: 14.0.3
       csso: 5.0.5
       deepmerge-ts: 7.1.5
@@ -5700,88 +5702,11 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
+  '@rollup/pluginutils@5.3.0':
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
-    optionalDependencies:
-      rollup: 4.59.0
-
-  '@rollup/rollup-android-arm-eabi@4.59.0':
-    optional: true
-
-  '@rollup/rollup-android-arm64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-darwin-arm64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-darwin-x64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-freebsd-arm64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-arm64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-loong64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-ppc64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-riscv64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-s390x-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-linux-x64-musl@4.59.0':
-    optional: true
-
-  '@rollup/rollup-openbsd-x64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-openharmony-arm64@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-arm64-msvc@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-ia32-msvc@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-gnu@4.59.0':
-    optional: true
-
-  '@rollup/rollup-win32-x64-msvc@4.59.0':
-    optional: true
 
   '@shikijs/core@4.0.2':
     dependencies:
@@ -5863,6 +5788,10 @@ snapshots:
   '@types/bun@1.3.14':
     dependencies:
       bun-types: 1.3.14
+
+  '@types/bun@1.3.3':
+    dependencies:
+      bun-types: 1.3.3
 
   '@types/chai@5.2.3':
     dependencies:
@@ -6227,13 +6156,13 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.44.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2)):
+  astro-expressive-code@0.44.0(astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2)):
     dependencies:
-      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2)
+      astro: 7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2)
       rehype-expressive-code: 0.44.0
       url-extras: 0.1.0
 
-  astro@7.0.2(@astrojs/markdown-remark@7.2.0)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2):
+  astro@7.0.2(@astrojs/markdown-remark@7.2.0)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler-rs': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/internal-helpers': 0.10.0
@@ -6242,7 +6171,7 @@ snapshots:
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.1.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
+      '@rollup/pluginutils': 5.3.0
       am-i-vibing: 0.4.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -6329,7 +6258,7 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(rollup@4.59.0)(terser@5.46.1)(yaml@2.8.2):
+  astro@7.0.3(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.46.1)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler-rs': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/internal-helpers': 0.10.0
@@ -6338,7 +6267,7 @@ snapshots:
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.1.0
       '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
+      '@rollup/pluginutils': 5.3.0
       am-i-vibing: 0.4.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
@@ -6469,6 +6398,10 @@ snapshots:
   buffer-from@1.1.2: {}
 
   bun-types@1.3.14:
+    dependencies:
+      '@types/node': 25.0.3
+
+  bun-types@1.3.3:
     dependencies:
       '@types/node': 25.0.3
 
@@ -7466,6 +7399,49 @@ snapshots:
   layout-base@1.0.2: {}
 
   layout-base@2.0.1: {}
+
+  lefthook-darwin-arm64@2.1.8:
+    optional: true
+
+  lefthook-darwin-x64@2.1.8:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.8:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.8:
+    optional: true
+
+  lefthook-linux-arm64@2.1.8:
+    optional: true
+
+  lefthook-linux-x64@2.1.8:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.8:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.8:
+    optional: true
+
+  lefthook-windows-arm64@2.1.8:
+    optional: true
+
+  lefthook-windows-x64@2.1.8:
+    optional: true
+
+  lefthook@2.1.8:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.8
+      lefthook-darwin-x64: 2.1.8
+      lefthook-freebsd-arm64: 2.1.8
+      lefthook-freebsd-x64: 2.1.8
+      lefthook-linux-arm64: 2.1.8
+      lefthook-linux-x64: 2.1.8
+      lefthook-openbsd-arm64: 2.1.8
+      lefthook-openbsd-x64: 2.1.8
+      lefthook-windows-arm64: 2.1.8
+      lefthook-windows-x64: 2.1.8
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -8546,38 +8522,6 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.3
       '@rolldown/binding-win32-x64-msvc': 1.1.3
 
-  rollup@4.59.0:
-    dependencies:
-      '@types/estree': 1.0.8
-    optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.59.0
-      '@rollup/rollup-android-arm64': 4.59.0
-      '@rollup/rollup-darwin-arm64': 4.59.0
-      '@rollup/rollup-darwin-x64': 4.59.0
-      '@rollup/rollup-freebsd-arm64': 4.59.0
-      '@rollup/rollup-freebsd-x64': 4.59.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
-      '@rollup/rollup-linux-arm64-gnu': 4.59.0
-      '@rollup/rollup-linux-arm64-musl': 4.59.0
-      '@rollup/rollup-linux-loong64-gnu': 4.59.0
-      '@rollup/rollup-linux-loong64-musl': 4.59.0
-      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
-      '@rollup/rollup-linux-ppc64-musl': 4.59.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
-      '@rollup/rollup-linux-riscv64-musl': 4.59.0
-      '@rollup/rollup-linux-s390x-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-gnu': 4.59.0
-      '@rollup/rollup-linux-x64-musl': 4.59.0
-      '@rollup/rollup-openbsd-x64': 4.59.0
-      '@rollup/rollup-openharmony-arm64': 4.59.0
-      '@rollup/rollup-win32-arm64-msvc': 4.59.0
-      '@rollup/rollup-win32-ia32-msvc': 4.59.0
-      '@rollup/rollup-win32-x64-gnu': 4.59.0
-      '@rollup/rollup-win32-x64-msvc': 4.59.0
-      fsevents: 2.3.3
-    optional: true
-
   roughjs@4.6.6:
     dependencies:
       hachure-fill: 0.5.2
@@ -8639,6 +8583,8 @@ snapshots:
       schema-dts-lib: 1.0.0(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
+
+  scrub-exif@0.1.0: {}
 
   semver@6.3.1: {}
 
@@ -8850,6 +8796,8 @@ snapshots:
   ufo@1.6.3: {}
 
   uhyphen@0.2.0: {}
+
+  ulid@3.0.1: {}
 
   ultrahtml@1.6.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,6 +30,7 @@ catalog:
   satori: 0.26.0
   sharp: 0.35.2
   typescript: 6.0.3
+  ulid: 3.0.1
   unist-util-visit: 5.1.0
   vitest: 4.1.9
   wrangler: 4.105.0


### PR DESCRIPTION
- Add apps/studio, a local-only memo composer app (never deployed) with Bun server and browser UI
- Add memo store, feed filter, and request guard modules with unit tests
- Wire the new package into the pnpm workspace and root scripts
- Document the studio app in apps/studio/CLAUDE.md and the root CLAUDE.md
- Update me-content and memo-content submodules