### PR TITLE
[main] chore: group pnpm catalog updates into shared PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,18 @@
       "automerge": true
     },
     {
+      "groupName": "pnpm catalog (non-major)",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "groupName": "pnpm catalog (major)",
+      "matchDepTypes": ["pnpm.catalog.default"],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
       "groupName": "Expressive Code",
       "matchPackageNames": ["astro-expressive-code", "@expressive-code/**"],
       "automerge": true


### PR DESCRIPTION
## Why

After the monorepo migration, dependency versions were centralized into the `catalog:` block of `pnpm-workspace.yaml`. Renovate classifies these entries under the `pnpm.catalog.default` depType, so the existing `dependencies` / `devDependencies` grouping rules no longer matched them. As a result each catalog dependency opened its own PR (#654–#660), and because they all touch `pnpm-workspace.yaml` / the lockfile they mutually conflicted and required repeated rebases.

## What

Add two `packageRules` for `pnpm.catalog.default`:

- non-major (`minor` / `patch` / `pin` / `digest`) → one grouped, automerged PR
- major → a separate PR with automerge disabled for review

This restores batched PRs and removes the mutual lockfile conflicts, while keeping major (breaking-prone) updates isolated from the safe batch. The existing Expressive Code rule matches by package name so it stays separate.

## Notes

- catalog is flat and has no dev/prod distinction, so the previous dev/prod split cannot be reproduced for catalog entries; a single non-major group is the practical equivalent.
- Takes effect from the next Renovate run; existing open PRs are unaffected.