### PR TITLE
[main] build: remove content submodules from pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,14 +1,14 @@
 minimumReleaseAge: 1440
-minimumReleaseAgeExclude:
-  - scrub-exif
 
+# Content submodules (apps/*/*-content) are intentionally NOT workspace members.
+# They are separate repos with their own authoring tooling (lefthook, scrub-exif,
+# bun scripts) and their own lockfiles; CI builds the apps against fixtures with
+# the submodules absent. Listing them here made the root lockfile churn on every
+# local `pnpm i`, because Renovate/CI regenerate it without the submodules
+# checked out while local installs re-add their importer entries.
 packages:
   - apps/*
   - packages/*
-  - apps/me/me-content
-  - apps/memo/memo-content
-  - apps/lgtm/lgtm-content
-  - apps/diary/diary-content
 
 catalog:
   "@astrojs/check": 0.9.9


### PR DESCRIPTION
- Remove the four content submodules (apps/*/*-content) from pnpm-workspace.yaml packages
- Add a comment explaining they are separate repos with their own tooling and lockfiles, built against fixtures in CI
- Stop the root lockfile from churning on local `pnpm i` when the submodules are checked out but absent in CI/Renovate
- Drop the now-unneeded minimumReleaseAgeExclude entry for scrub-exif