### PR TITLE
[main] feat: make image wide display opt-in via prop

### DIFF
--- a/apps/me/src/components/ui/image/image.astro
+++ b/apps/me/src/components/ui/image/image.astro
@@ -6,7 +6,7 @@ import type { CustomImageProps } from "./types";
 
 type Props = CustomImageProps;
 
-const { class: className, title, ...rest } = Astro.props;
+const { class: className, title, allowWide = false, ...rest } = Astro.props;
 
 const blurryImage = await getImage({
   ...(rest as UnresolvedImageTransform),
@@ -23,7 +23,7 @@ const metadata =
 const intrinsicWidth = metadata?.width ?? 0;
 const intrinsicHeight = metadata?.height ?? 0;
 const isLandscape = intrinsicWidth > intrinsicHeight;
-const isWide = isLandscape && intrinsicWidth >= WIDE_THRESHOLD_PX;
+const isWide = allowWide && isLandscape && intrinsicWidth >= WIDE_THRESHOLD_PX;
 
 const widths = isWide
   ? [640, 750, 828, 1080, 1344, 1792]

--- a/apps/me/src/components/ui/image/types.ts
+++ b/apps/me/src/components/ui/image/types.ts
@@ -1,3 +1,11 @@
 import type { LocalImageProps, RemoteImageProps } from "astro:assets";
 
-export type CustomImageProps = LocalImageProps | RemoteImageProps;
+export type CustomImageProps = (LocalImageProps | RemoteImageProps) & {
+  /**
+   * Whether landscape images with enough resolution break out beyond the body
+   * width (wide display). Defaults to false so every image renders at the
+   * unified body size. Flip the default (or pass `allowWide`) to restore the
+   * previous large display.
+   */
+  allowWide?: boolean | undefined;
+};


### PR DESCRIPTION
- Add `allowWide` prop (default `false`) to the custom image component so landscape images no longer break out beyond body width unless explicitly requested
- Gate the `isWide` calculation in image.astro on `allowWide` so images render at the unified body size by default
- Extend `CustomImageProps` with the documented `allowWide?` option