### PR TITLE
[main] feat: add global navigation config

### DIFF
--- a/apps/me/src/config/navigation.ts
+++ b/apps/me/src/config/navigation.ts
@@ -1,0 +1,42 @@
+import { me } from "#/config/site";
+
+export type NavItem = {
+  label: string;
+  href: string;
+  isExternal: boolean;
+};
+
+// No "Home" item: the site name pinned to the top-left (breadcrumb) is the
+// home link, so listing it here would duplicate that role.
+export const navItems = [
+  {
+    label: "Blog",
+    href: "/blog",
+    isExternal: false,
+  },
+  {
+    label: "About",
+    href: "/about",
+    isExternal: false,
+  },
+  {
+    label: "Bucket List",
+    href: "/bucket-list",
+    isExternal: false,
+  },
+  {
+    label: "Memo",
+    href: me.memo,
+    isExternal: true,
+  },
+  {
+    label: "Diary",
+    href: me.diary,
+    isExternal: true,
+  },
+  {
+    label: "GitHub",
+    href: me.github.url,
+    isExternal: true,
+  },
+] as const satisfies NavItem[];

--- a/apps/me/src/config/site.ts
+++ b/apps/me/src/config/site.ts
@@ -17,6 +17,7 @@ export const me = {
   },
   twitter: "@kkhys_",
   memo: "https://memo.kkhys.me",
+  diary: "https://diary.kkhys.me",
   zenn: {
     url: "https://zenn.dev/kkhys",
     feed: "https://zenn.dev/kkhys/feed",


### PR DESCRIPTION
- Add the diary site URL to the shared site config
- Add a navigation config listing internal pages and external links