### PR TITLE
[main] feat: add previous and next post navigation

### DIFF
--- a/apps/me/src/__tests__/features/blog/utils/entry.test.ts
+++ b/apps/me/src/__tests__/features/blog/utils/entry.test.ts
@@ -41,10 +41,9 @@ const mockEntries: MockEntry[] = [
   }),
 ];
 
-const loadGetRelatedPosts = async () => {
-  const mod = await import("#/features/blog/utils/entry");
-  return mod.getRelatedPosts;
-};
+const loadEntryModule = () => import("#/features/blog/utils/entry");
+
+const loadGetRelatedPosts = async () => (await loadEntryModule()).getRelatedPosts;
 
 type GetRelatedPosts = Awaited<ReturnType<typeof loadGetRelatedPosts>>;
 
@@ -146,5 +145,30 @@ describe("getRelatedPosts", () => {
       tags: ["React"],
     });
     expect(results).toEqual([]);
+  });
+});
+
+describe("toPostNavItem", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doMock("astro:env/client", () => ({ NODE_ENV: "production" }));
+    vi.doMock("astro:content", () => ({
+      getCollection: vi.fn<() => Promise<MockEntry[]>>(() => Promise.resolve(mockEntries)),
+    }));
+  });
+
+  it("maps an entry to its navigation fields", async () => {
+    const { toPostNavItem } = await loadEntryModule();
+    const entry = {
+      id: "a",
+      data: { title: "Post A", emoji: "🚀" },
+    } as Parameters<typeof toPostNavItem>[0];
+
+    expect(toPostNavItem(entry)).toEqual({ id: "a", title: "Post A", emoji: "🚀" });
+  });
+
+  it("returns undefined for an out-of-range neighbor", async () => {
+    const { toPostNavItem } = await loadEntryModule();
+    expect(toPostNavItem(undefined)).toBeUndefined();
   });
 });

--- a/apps/me/src/features/blog/components/ui/post-navigation.astro
+++ b/apps/me/src/features/blog/components/ui/post-navigation.astro
@@ -1,0 +1,122 @@
+---
+import type { HTMLAttributes } from "astro/types";
+import Budoux from "#/components/budoux.astro";
+import EmojiEyeCatch from "#/components/ui/emoji-eye-catch.astro";
+import type { PostNavItem } from "#/features/blog/utils/entry";
+
+interface Props extends HTMLAttributes<"nav"> {
+  olderPost: PostNavItem | undefined;
+  newerPost: PostNavItem | undefined;
+}
+
+const { olderPost, newerPost, class: className, ...rest } = Astro.props;
+---
+
+{(olderPost || newerPost) && (
+  <nav class:list={["post-nav", className]} aria-label="Post navigation" {...rest}>
+    {olderPost ? (
+      <a
+        href={`/blog/posts/${olderPost.id}`}
+        class="post-nav-item"
+        rel="prev"
+        data-umami-event="post-nav"
+        data-umami-event-direction="older"
+      >
+        <span class="post-nav-label">前の記事</span>
+        <span class="post-nav-body">
+          <EmojiEyeCatch emoji={olderPost.emoji} size="sm" isColored />
+          <Budoux>
+            <span class="post-nav-title palt">{olderPost.title}</span>
+          </Budoux>
+        </span>
+      </a>
+    ) : (
+      <span class="post-nav-spacer" />
+    )}
+    {newerPost && (
+      <a
+        href={`/blog/posts/${newerPost.id}`}
+        class="post-nav-item post-nav-item--newer"
+        rel="next"
+        data-umami-event="post-nav"
+        data-umami-event-direction="newer"
+      >
+        <span class="post-nav-label">次の記事</span>
+        <span class="post-nav-body">
+          <EmojiEyeCatch emoji={newerPost.emoji} size="sm" isColored />
+          <Budoux>
+            <span class="post-nav-title palt">{newerPost.title}</span>
+          </Budoux>
+        </span>
+      </a>
+    )}
+  </nav>
+)}
+
+<style>
+  .post-nav {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  @media (width >= 640px) {
+    .post-nav {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  .post-nav-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: var(--c-prose-text);
+    transition: background-color 0.2s;
+  }
+
+  .post-nav-item:hover {
+    background-color: oklch(from var(--c-surface) l c h / 50%);
+  }
+
+  .post-nav-item--newer {
+    align-items: flex-end;
+    text-align: right;
+  }
+
+  .post-nav-spacer {
+    display: none;
+  }
+
+  @media (width >= 640px) {
+    .post-nav-spacer {
+      display: block;
+    }
+  }
+
+  .post-nav-label {
+    font-size: var(--fs-xs);
+    color: var(--c-sub);
+  }
+
+  .post-nav-body {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .post-nav-item--newer .post-nav-body {
+    flex-direction: row-reverse;
+  }
+
+  .post-nav-title {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    font-size: var(--fs-sm);
+    line-height: 1.5;
+  }
+</style>

--- a/apps/me/src/features/blog/utils/entry.ts
+++ b/apps/me/src/features/blog/utils/entry.ts
@@ -107,3 +107,14 @@ export const getRelatedPosts = async ({
 
   return scored.map(({ post }) => post).slice(0, relatedEntriesCount);
 };
+
+export type PostNavItem = Pick<InternalEntry, "id" | "title" | "emoji">;
+
+export const toPostNavItem = (
+  entry: CollectionEntry<"blog"> | undefined,
+): PostNavItem | undefined =>
+  entry && {
+    id: entry.id,
+    title: entry.data.title,
+    emoji: entry.data.emoji,
+  };

--- a/apps/me/src/layouts/blog-layout.astro
+++ b/apps/me/src/layouts/blog-layout.astro
@@ -8,11 +8,12 @@ import SiteBrand from "#/components/ui/site-brand.astro";
 import Separator from "#/components/ui/separator.astro";
 import { me } from "#/config/site";
 import EntryList from "#/features/blog/components/ui/entry-list.astro";
+import PostNavigation from "#/features/blog/components/ui/post-navigation.astro";
 import TagCloud from "#/features/blog/components/ui/tag-cloud.astro";
 import Toc from "#/features/blog/components/ui/toc.astro";
 import { getCategoryBySlug } from "#/features/blog/config/category";
 import { tags as allTags } from "#/features/blog/config/tag";
-import { getRelatedPosts, toListEntries } from "#/features/blog/utils/entry";
+import { getRelatedPosts, type PostNavItem, toListEntries } from "#/features/blog/utils/entry";
 import BaseLayout from "#/layouts/base-layout.astro";
 import { BASE_URL } from "#/utils/base-url";
 
@@ -20,6 +21,8 @@ interface Props extends InferEntrySchema<"blog"> {
   id: string;
   description: string;
   headings: MarkdownHeading[];
+  newerPost: PostNavItem | undefined;
+  olderPost: PostNavItem | undefined;
 }
 
 const {
@@ -35,6 +38,8 @@ const {
   description,
   status,
   headings,
+  newerPost,
+  olderPost,
 } = Astro.props;
 
 const hasUpdatedAt = Boolean(updatedAt && updatedAtString);
@@ -127,6 +132,7 @@ const currentDate = new Date();
         <TagCloud tags={tagCloudItems} class="post-tags" />
     )}
     <Separator class="post-separator" />
+    <PostNavigation olderPost={olderPost} newerPost={newerPost} class="post-nav" />
     {relatedPosts?.length > 0 && (
       <div class="related-posts">
         <div class="related-posts-title">こちらもおすすめ</div>
@@ -267,6 +273,10 @@ const currentDate = new Date();
   }
 
   .post-separator {
+    margin-top: 3rem;
+  }
+
+  .post-nav {
     margin-top: 3rem;
   }
 

--- a/apps/me/src/pages/blog/posts/[id].astro
+++ b/apps/me/src/pages/blog/posts/[id].astro
@@ -4,14 +4,17 @@ import type { GetStaticPaths } from "astro";
 import type { BreadcrumbList, WithContext } from "schema-dts";
 import ContentWrapper from "#/features/blog/components/content-wrapper.astro";
 import { getCategoryByTitle } from "#/features/blog/config/category";
-import { getPublicBlogEntries } from "#/features/blog/utils/entry";
+import { getPublicBlogEntries, toPostNavItem } from "#/features/blog/utils/entry";
 import BlogLayout from "#/layouts/blog-layout.astro";
 import { getBlogPostingSchema } from "#/lib/json-ld";
 import { convertDateToString } from "#/utils/date";
 import { extractDescription } from "#/utils/extract-description";
 
-export const getStaticPaths = (async () =>
-  (await getPublicBlogEntries()).map((entry) => {
+export const getStaticPaths = (async () => {
+  // Entries are sorted newest first, so the previous index is the newer post.
+  const entries = await getPublicBlogEntries();
+
+  return entries.map((entry, index) => {
     return {
       params: {
         id: entry.id,
@@ -19,11 +22,14 @@ export const getStaticPaths = (async () =>
       props: {
         entry,
         description: extractDescription(entry.body ?? ""),
+        newerPost: toPostNavItem(entries[index - 1]),
+        olderPost: toPostNavItem(entries[index + 1]),
       },
     };
-  })) satisfies GetStaticPaths;
+  });
+}) satisfies GetStaticPaths;
 
-const { entry, description } = Astro.props;
+const { entry, description, newerPost, olderPost } = Astro.props;
 const { Content, headings } = await render(entry);
 const publishedAtString = convertDateToString(entry.data.publishedAt);
 
@@ -73,7 +79,7 @@ const jsonLd = {
 };
 ---
 
-<BlogLayout id={entry.id} publishedAtString={publishedAtString} description={description} headings={headings} {...entry.data}>
+<BlogLayout id={entry.id} publishedAtString={publishedAtString} description={description} headings={headings} newerPost={newerPost} olderPost={olderPost} {...entry.data}>
   <script
       is:inline
       type='application/ld+json'


### PR DESCRIPTION
- Add a helper and type that map a blog entry to post navigation fields
- Add a post navigation component linking neighboring posts
- Link the previous and next posts on blog post pages
- Cover the post navigation helper with unit tests