### PR TITLE
[main] feat: weight related posts by shared tags

### DIFF
--- a/apps/me/src/__tests__/features/blog/utils/entry.test.ts
+++ b/apps/me/src/__tests__/features/blog/utils/entry.test.ts
@@ -93,14 +93,54 @@ describe("getRelatedPosts", () => {
     expect(results.every((r) => r.id !== "current")).toBe(true);
   });
 
-  it("only includes posts from the same category", async () => {
+  it("includes cross-category posts that share tags", async () => {
     const getRelatedPosts = await loadGetRelatedPosts();
     const results = await getRelatedPosts({
       id: "current",
-      category: "Tech",
+      category: "Life",
       tags: ["React"],
     });
-    expect(results.every((r) => r.data.category === "Tech")).toBe(true);
+    // "a", "b", "g" are Tech posts sharing the React tag.
+    expect(results.some((r) => r.data.category === "Tech")).toBe(true);
+  });
+
+  it("excludes cross-category posts with no shared tags", async () => {
+    const getRelatedPosts = await loadGetRelatedPosts();
+    const results = await getRelatedPosts({
+      id: "current",
+      category: "Life",
+      tags: ["React"],
+    });
+    // "c" (Go), "d" (no tags), "f" (TypeScript) are Tech posts without React.
+    const ids = results.map((r) => r.id);
+    expect(ids).not.toContain("c");
+    expect(ids).not.toContain("d");
+    expect(ids).not.toContain("f");
+  });
+
+  it("ranks tag matches above posts that only share the category", async () => {
+    const getRelatedPosts = await loadGetRelatedPosts();
+    const results = await getRelatedPosts({
+      id: "current",
+      category: "Life",
+      tags: ["React", "TypeScript"],
+    });
+    // "a" and "g" (Tech, 2 shared tags, score 4) outrank "e" (Life, 1 shared
+    // tag + same category, score 3).
+    const ids = results.map((r) => r.id);
+    expect(ids.slice(0, 2).toSorted()).toEqual(["a", "g"]);
+    expect(ids[2]).toBe("e");
+  });
+
+  it("falls back to same-category posts without shared tags", async () => {
+    const getRelatedPosts = await loadGetRelatedPosts();
+    const results = await getRelatedPosts({
+      id: "current",
+      category: "Life",
+      tags: undefined,
+    });
+    // Only "e" shares the Life category; nothing else scores.
+    expect(results.map((r) => r.id)).toEqual(["e"]);
   });
 
   it("returns at most relatedEntriesCount posts", async () => {
@@ -137,12 +177,12 @@ describe("getRelatedPosts", () => {
     expect(results.every((r) => r.data.category === "Tech")).toBe(true);
   });
 
-  it("returns empty array when no posts match the category", async () => {
+  it("returns empty array when nothing shares a category or tag", async () => {
     const getRelatedPosts = await loadGetRelatedPosts();
     const results = await getRelatedPosts({
       id: "current",
       category: "DIY",
-      tags: ["React"],
+      tags: undefined,
     });
     expect(results).toEqual([]);
   });

--- a/apps/me/src/features/blog/components/ui/entry-list.astro
+++ b/apps/me/src/features/blog/components/ui/entry-list.astro
@@ -10,9 +10,10 @@ import { convertDateToString } from "#/utils/date";
 interface Props extends HTMLAttributes<"div"> {
   entries: ListEntry[];
   showDate?: boolean;
+  umamiEvent?: string | undefined;
 }
 
-const { entries, class: className, showDate = false, ...rest } = Astro.props;
+const { entries, class: className, showDate = false, umamiEvent, ...rest } = Astro.props;
 ---
 
 {
@@ -29,6 +30,7 @@ const { entries, class: className, showDate = false, ...rest } = Astro.props;
             target="_blank"
             rel="noreferrer"
             data-astro-prefetch="false"
+            data-umami-event={umamiEvent}
           >
             <div class="entry-left">
               <SiteIcon siteName={entry.siteName} />
@@ -52,7 +54,7 @@ const { entries, class: className, showDate = false, ...rest } = Astro.props;
       }
 
       return (
-        <a href={`/blog/posts/${entry.id}`} class="entry-item">
+        <a href={`/blog/posts/${entry.id}`} class="entry-item" data-umami-event={umamiEvent}>
           <div class="entry-left">
             <EmojiEyeCatch emoji={entry.emoji} size="sm" isColored class="entry-emoji" />
             <Budoux>

--- a/apps/me/src/features/blog/utils/entry.ts
+++ b/apps/me/src/features/blog/utils/entry.ts
@@ -93,16 +93,20 @@ export const getRelatedPosts = async ({
   category,
   tags,
 }: { id: string } & Pick<InferEntrySchema<"blog">, "category" | "tags">) => {
-  const candidates = (await getPublicBlogEntries()).filter(
-    (post) => post.id !== id && post.data.category === category,
-  );
+  const candidates = (await getPublicBlogEntries()).filter((post) => post.id !== id);
 
-  const scored = candidates.map((post) => ({
-    post,
-    score: tags?.filter((tag) => post.data.tags?.includes(tag)).length ?? 0,
-  }));
+  // Shared tags weigh double so a cross-category post on the same topic can
+  // outrank a same-category post that merely shares the category.
+  const scored = candidates
+    .map((post) => ({
+      post,
+      score:
+        (tags?.filter((tag) => post.data.tags?.includes(tag)).length ?? 0) * 2 +
+        (post.data.category === category ? 1 : 0),
+    }))
+    .filter(({ score }) => score > 0);
 
-  // Sort by shared tag count (desc), shuffle within same score
+  // Sort by score (desc), shuffle within same score
   scored.sort((a, b) => b.score - a.score || Math.random() - 0.5);
 
   return scored.map(({ post }) => post).slice(0, relatedEntriesCount);

--- a/apps/me/src/layouts/blog-layout.astro
+++ b/apps/me/src/layouts/blog-layout.astro
@@ -136,7 +136,7 @@ const currentDate = new Date();
     {relatedPosts?.length > 0 && (
       <div class="related-posts">
         <div class="related-posts-title">こちらもおすすめ</div>
-        <EntryList entries={toListEntries(relatedPosts)} />
+        <EntryList entries={toListEntries(relatedPosts)} umamiEvent="related-post" />
       </div>
     )}
   </section>


### PR DESCRIPTION
- Weight related posts by shared tags so cross-category matches can surface
- Support umami event tracking on entry lists
- Track related post clicks with umami