### PR TITLE
[main] feat: add optional footer toggle and remove bucket list nav

### DIFF
--- a/apps/me/src/config/navigation.ts
+++ b/apps/me/src/config/navigation.ts
@@ -20,11 +20,6 @@ export const navItems = [
     isExternal: false,
   },
   {
-    label: "Bucket List",
-    href: "/bucket-list",
-    isExternal: false,
-  },
-  {
     label: "Memo",
     href: me.memo,
     isExternal: true,

--- a/apps/me/src/layouts/base-layout.astro
+++ b/apps/me/src/layouts/base-layout.astro
@@ -6,9 +6,10 @@ import SiteNav from "#/components/ui/site-nav.astro";
 
 interface Props {
   class?: string;
+  showFooter?: boolean | undefined;
 }
 
-const { class: className } = Astro.props;
+const { class: className, showFooter = true } = Astro.props;
 ---
 
 <html lang="ja">
@@ -60,7 +61,7 @@ const { class: className } = Astro.props;
     <slot/>
   </div>
 </main>
-<SiteFooter />
+{showFooter && <SiteFooter />}
 </body>
 </html>
 

--- a/apps/me/src/pages/index.astro
+++ b/apps/me/src/pages/index.astro
@@ -9,7 +9,7 @@ import { BASE_URL } from "#/utils/base-url";
 const seoImage = `${BASE_URL}/api/og/default.png`;
 ---
 
-<BaseLayout>
+<BaseLayout showFooter={false}>
   <SEO image={seoImage} slot='seo' />
   <script
       is:inline


### PR DESCRIPTION
- Add an optional `showFooter` prop to base layout, defaulting to true
- Hide the site footer on the home page
- Remove the Bucket List item from site navigation