### PR TITLE
[main] feat: add interactive WebGL artwork to 404 page

### DIFF
--- a/apps/me/src/__tests__/features/pages/lib/not-found-art.test.ts
+++ b/apps/me/src/__tests__/features/pages/lib/not-found-art.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  addRipple,
+  clampDpr,
+  computeCanvasSize,
+  FLOATS_PER_RIPPLE,
+  FRAGMENT_SHADER_SOURCE,
+  MAX_DPR,
+  packRipples,
+  pruneRipples,
+  type Ripple,
+  RIPPLE_LIFETIME,
+  RIPPLE_SLOTS,
+  VERTEX_SHADER_SOURCE,
+} from "#/features/pages/lib/not-found-art";
+
+const ripple = (born: number): Ripple => ({ x: 0.5, y: 0.5, born, strength: 1 });
+
+describe("clampDpr", () => {
+  it("passes through values within range", () => {
+    expect(clampDpr(1.5)).toBe(1.5);
+  });
+
+  it("caps high-density displays at MAX_DPR", () => {
+    expect(clampDpr(3)).toBe(MAX_DPR);
+    expect(clampDpr(4)).toBe(MAX_DPR);
+  });
+
+  it("raises sub-1 values to 1", () => {
+    expect(clampDpr(0.5)).toBe(1);
+  });
+
+  it("respects a custom maximum", () => {
+    expect(clampDpr(3, 3)).toBe(3);
+  });
+});
+
+describe("computeCanvasSize", () => {
+  it("scales CSS size by the clamped device pixel ratio", () => {
+    expect(computeCanvasSize(672, 378, 2)).toEqual({ width: 1344, height: 756 });
+  });
+
+  it("clamps the ratio before scaling", () => {
+    expect(computeCanvasSize(672, 378, 3)).toEqual({ width: 1344, height: 756 });
+  });
+
+  it("rounds fractional pixel sizes", () => {
+    expect(computeCanvasSize(100.4, 56.5, 1)).toEqual({ width: 100, height: 57 });
+  });
+
+  it("never returns a dimension below 1", () => {
+    expect(computeCanvasSize(0, 0, 1)).toEqual({ width: 1, height: 1 });
+  });
+});
+
+describe("addRipple", () => {
+  it("appends new ripples", () => {
+    const ripples = addRipple([], ripple(1));
+    expect(ripples.length).toBe(1);
+  });
+
+  it("does not mutate the input", () => {
+    const initial = [ripple(1)];
+    addRipple(initial, ripple(2));
+    expect(initial.length).toBe(1);
+  });
+
+  it("caps the total at the slot count, dropping the oldest", () => {
+    let ripples: Ripple[] = [];
+    for (let i = 1; i <= RIPPLE_SLOTS + 3; i++) {
+      ripples = addRipple(ripples, ripple(i));
+    }
+    expect(ripples.length).toBe(RIPPLE_SLOTS);
+    expect(Math.min(...ripples.map((r) => r.born))).toBe(4);
+  });
+});
+
+describe("pruneRipples", () => {
+  it("keeps ripples that are still fading", () => {
+    expect(pruneRipples([ripple(10)], 10 + RIPPLE_LIFETIME - 0.1).length).toBe(1);
+  });
+
+  it("drops ripples past their lifetime", () => {
+    expect(pruneRipples([ripple(10)], 10 + RIPPLE_LIFETIME).length).toBe(0);
+  });
+});
+
+describe("packRipples", () => {
+  it("packs ripples into vec4 slots with their strength", () => {
+    const out = new Float32Array(RIPPLE_SLOTS * FLOATS_PER_RIPPLE);
+    packRipples([{ x: 0.5, y: 0.25, born: 2, strength: 0.35 }], out);
+    expect(out[0]).toBeCloseTo(0.5);
+    expect(out[1]).toBeCloseTo(0.25);
+    expect(out[2]).toBeCloseTo(2);
+    expect(out[3]).toBeCloseTo(0.35);
+    for (let i = FLOATS_PER_RIPPLE; i < out.length; i++) {
+      expect(out[i]).toBe(0);
+    }
+  });
+
+  it("clears slots left over from a previous pack", () => {
+    const out = new Float32Array(RIPPLE_SLOTS * FLOATS_PER_RIPPLE).fill(9);
+    packRipples([], out);
+    expect([...out].every((v) => v === 0)).toBe(true);
+  });
+});
+
+describe("shader sources", () => {
+  it("declares the attributes and uniforms the component binds", () => {
+    expect(VERTEX_SHADER_SOURCE).toContain("a_position");
+    for (const name of [
+      "u_resolution",
+      "u_time",
+      "u_pointer",
+      "u_pointerStrength",
+      "u_pointerVel",
+      "u_grip",
+      "u_glyphs",
+      "u_lineColor",
+      "u_lineAlpha",
+    ]) {
+      expect(FRAGMENT_SHADER_SOURCE).toContain(name);
+    }
+    expect(FRAGMENT_SHADER_SOURCE).toContain(`u_ripples[${RIPPLE_SLOTS}]`);
+  });
+});

--- a/apps/me/src/features/pages/components/not-found-art.astro
+++ b/apps/me/src/features/pages/components/not-found-art.astro
@@ -1,0 +1,390 @@
+<div class="nf-art" data-nf-art>
+  <p class="nf-art__fallback" aria-hidden="true">404</p>
+  <canvas
+      class="nf-art__canvas"
+      data-nf-canvas
+      role="img"
+      aria-label="Interactive surface of calm flowing lines; they part around the pointer and ripple on click"
+  ></canvas>
+</div>
+
+<noscript>
+  <style is:inline>
+    .nf-art__fallback {
+      display: grid !important;
+    }
+  </style>
+</noscript>
+
+<script>
+  import {
+    addRipple,
+    ASPECT,
+    computeCanvasSize,
+    FLOATS_PER_RIPPLE,
+    FRAGMENT_SHADER_SOURCE,
+    packRipples,
+    pruneRipples,
+    type Ripple,
+    RIPPLE_SLOTS,
+    VERTEX_SHADER_SOURCE,
+  } from "#/features/pages/lib/not-found-art";
+
+  /** Time (in seconds) baked into the single frame drawn for reduced motion. */
+  const STATIC_TIME = 100;
+  const POINTER_EASE = 0.3;
+  const POINTER_STRENGTH_EASE = 0.12;
+  /** Gripping snaps shut quickly; letting go relaxes slowly. */
+  const GRIP_EASE_IN = 0.35;
+  const GRIP_EASE_OUT = 0.08;
+
+  const clampVel = (v: number): number => Math.min(Math.max(v, -1), 1);
+
+  const createShader = (
+    gl: WebGLRenderingContext,
+    type: number,
+    source: string,
+  ): WebGLShader | null => {
+    const shader = gl.createShader(type);
+    if (!shader) return null;
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      gl.deleteShader(shader);
+      return null;
+    }
+    return shader;
+  };
+
+  const createProgram = (gl: WebGLRenderingContext): WebGLProgram | null => {
+    const vertex = createShader(gl, gl.VERTEX_SHADER, VERTEX_SHADER_SOURCE);
+    const fragment = createShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_SHADER_SOURCE);
+    if (!vertex || !fragment) return null;
+    const program = gl.createProgram();
+    if (!program) return null;
+    gl.attachShader(program, vertex);
+    gl.attachShader(program, fragment);
+    gl.linkProgram(program);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      gl.deleteProgram(program);
+      return null;
+    }
+    return program;
+  };
+
+  /**
+   * Resolve a theme CSS variable (light-dark() included) to RGB floats.
+   * A 2D canvas does the parsing so any color syntax the browser understands
+   * (oklch included) works without a hand-written parser.
+   */
+  const resolveCssColor = (variable: string): [number, number, number] => {
+    const fallback: [number, number, number] = [0.5, 0.5, 0.5];
+    const probe = document.createElement("span");
+    probe.style.color = `var(${variable})`;
+    document.body.append(probe);
+    const resolved = getComputedStyle(probe).color;
+    probe.remove();
+
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return fallback;
+    ctx.fillStyle = resolved;
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+    if (r === undefined || g === undefined || b === undefined) return fallback;
+    return [r / 255, g / 255, b / 255];
+  };
+
+  /**
+   * A blurred "404" drawn to an offscreen canvas; the shader reads it as a
+   * height field that the lines swell over. Blur keeps the displacement
+   * smooth; browsers without ctx.filter get a multi-draw approximation.
+   */
+  const createGlyphTexture = (gl: WebGLRenderingContext): WebGLTexture | null => {
+    const source = document.createElement("canvas");
+    source.width = 512;
+    source.height = 288;
+    const ctx = source.getContext("2d");
+    if (!ctx) return null;
+    ctx.fillStyle = "#000";
+    ctx.fillRect(0, 0, source.width, source.height);
+    ctx.fillStyle = "#fff";
+    ctx.font = "700 190px system-ui, sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    const cx = source.width / 2;
+    const cy = source.height / 2 + 8;
+    ctx.filter = "blur(6px)";
+    if (ctx.filter === "blur(6px)") {
+      ctx.fillText("404", cx, cy);
+    } else {
+      ctx.globalAlpha = 1 / 9;
+      for (let dx = -6; dx <= 6; dx += 6) {
+        for (let dy = -6; dy <= 6; dy += 6) {
+          ctx.fillText("404", cx + dx, cy + dy);
+        }
+      }
+      ctx.globalAlpha = 1;
+    }
+
+    const texture = gl.createTexture();
+    if (!texture) return null;
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    // The canvas is not power-of-two sized, so clamp + linear, no mipmaps.
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 1);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.LUMINANCE, gl.LUMINANCE, gl.UNSIGNED_BYTE, source);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    return texture;
+  };
+
+  const init = (canvas: HTMLCanvasElement): boolean => {
+    const gl = canvas.getContext("webgl", {
+      antialias: true,
+      alpha: true,
+      premultipliedAlpha: false,
+    });
+    if (!gl) return false;
+    // Enables fwidth() so line density can be measured for moire suppression.
+    gl.getExtension("OES_standard_derivatives");
+    const program = createProgram(gl);
+    if (!program) return false;
+    if (!createGlyphTexture(gl)) return false;
+
+    gl.useProgram(program);
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    gl.clearColor(0, 0, 0, 0);
+
+    // Single oversized triangle covering the viewport.
+    gl.bindBuffer(gl.ARRAY_BUFFER, gl.createBuffer());
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
+    const position = gl.getAttribLocation(program, "a_position");
+    gl.enableVertexAttribArray(position);
+    gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
+
+    const uResolution = gl.getUniformLocation(program, "u_resolution");
+    const uTime = gl.getUniformLocation(program, "u_time");
+    const uPointer = gl.getUniformLocation(program, "u_pointer");
+    const uPointerStrength = gl.getUniformLocation(program, "u_pointerStrength");
+    const uPointerVel = gl.getUniformLocation(program, "u_pointerVel");
+    const uGrip = gl.getUniformLocation(program, "u_grip");
+    const uRipples = gl.getUniformLocation(program, "u_ripples[0]");
+    const uLineColor = gl.getUniformLocation(program, "u_lineColor");
+    const uLineAlpha = gl.getUniformLocation(program, "u_lineAlpha");
+    gl.uniform1i(gl.getUniformLocation(program, "u_glyphs"), 0);
+
+    let ripples: Ripple[] = [];
+    const packedRipples = new Float32Array(RIPPLE_SLOTS * FLOATS_PER_RIPPLE);
+    const pointer = { x: -10, y: -10 };
+    const target = { x: -10, y: -10 };
+    const prevPointer = { x: -10, y: -10 };
+    const velocity = { x: 0, y: 0 };
+    let pointerStrength = 0;
+    let pointerStrengthTarget = 0;
+    let pressed = false;
+    let grip = 0;
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const darkScheme = window.matchMedia("(prefers-color-scheme: dark)");
+    let frame = 0;
+
+    const draw = (time: number) => {
+      gl.uniform2f(uResolution, canvas.width, canvas.height);
+      gl.uniform1f(uTime, time);
+      gl.uniform2f(uPointer, pointer.x, pointer.y);
+      gl.uniform1f(uPointerStrength, pointerStrength);
+      gl.uniform2f(uPointerVel, velocity.x, velocity.y);
+      gl.uniform1f(uGrip, grip);
+      gl.uniform4fv(uRipples, packRipples(ripples, packedRipples));
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+    };
+
+    const applyThemeColors = () => {
+      gl.uniform3fv(uLineColor, resolveCssColor("--c-sub"));
+      // The dark theme needs stronger lines to stay visible on near-black.
+      gl.uniform1f(uLineAlpha, darkScheme.matches ? 0.8 : 0.55);
+    };
+
+    const resize = () => {
+      const size = computeCanvasSize(
+        canvas.clientWidth,
+        canvas.clientHeight,
+        window.devicePixelRatio,
+      );
+      if (canvas.width === size.width && canvas.height === size.height) return;
+      canvas.width = size.width;
+      canvas.height = size.height;
+      gl.viewport(0, 0, size.width, size.height);
+      if (reducedMotion.matches) draw(STATIC_TIME);
+    };
+
+    const loop = (now: number) => {
+      const time = now / 1000;
+      pointer.x += (target.x - pointer.x) * POINTER_EASE;
+      pointer.y += (target.y - pointer.y) * POINTER_EASE;
+      pointerStrength += (pointerStrengthTarget - pointerStrength) * POINTER_STRENGTH_EASE;
+      grip += ((pressed ? 1 : 0) - grip) * (pressed ? GRIP_EASE_IN : GRIP_EASE_OUT);
+      // Smoothed pointer velocity (clamped) drives the motion-drag shear.
+      velocity.x += (clampVel((pointer.x - prevPointer.x) * 12) - velocity.x) * 0.2;
+      velocity.y += (clampVel((pointer.y - prevPointer.y) * 12) - velocity.y) * 0.2;
+      prevPointer.x = pointer.x;
+      prevPointer.y = pointer.y;
+      ripples = pruneRipples(ripples, time);
+      draw(time);
+      frame = requestAnimationFrame(loop);
+    };
+
+    const start = () => {
+      if (frame || reducedMotion.matches) return;
+      frame = requestAnimationFrame(loop);
+    };
+
+    const stop = () => {
+      cancelAnimationFrame(frame);
+      frame = 0;
+    };
+
+    const toWorld = (event: PointerEvent): { x: number; y: number } => {
+      const rect = canvas.getBoundingClientRect();
+      return {
+        x: ((event.clientX - rect.left) / rect.width) * ASPECT,
+        y: 1 - (event.clientY - rect.top) / rect.height,
+      };
+    };
+
+    // The pointer trail deposits soft wakes, like drawing in sand.
+    const lastWake = { x: Number.NaN, y: Number.NaN };
+    const WAKE_SPACING = 0.09;
+
+    canvas.addEventListener("pointermove", (event) => {
+      const world = toWorld(event);
+      Object.assign(target, world);
+      pointerStrengthTarget = 1;
+      if (reducedMotion.matches) return;
+      const moved = Math.hypot(world.x - lastWake.x, world.y - lastWake.y);
+      if (Number.isNaN(moved)) {
+        Object.assign(lastWake, world);
+        return;
+      }
+      if (moved < WAKE_SPACING) return;
+      Object.assign(lastWake, world);
+      ripples = addRipple(ripples, {
+        x: world.x,
+        y: world.y,
+        born: performance.now() / 1000,
+        strength: 0.35,
+      });
+    });
+
+    canvas.addEventListener("pointerdown", (event) => {
+      pressed = true;
+      pointerStrengthTarget = 1;
+      Object.assign(target, toWorld(event));
+    });
+
+    // Releasing the grip lets the gathered lines fall back as a ripple.
+    canvas.addEventListener("pointerup", (event) => {
+      pressed = false;
+      pointerStrengthTarget = 1;
+      // Ripples are transient, so without animation there is nothing to show.
+      if (reducedMotion.matches) return;
+      const world = toWorld(event);
+      ripples = addRipple(ripples, {
+        x: world.x,
+        y: world.y,
+        born: performance.now() / 1000,
+        strength: 1,
+      });
+    });
+
+    canvas.addEventListener("pointerleave", () => {
+      pressed = false;
+      pointerStrengthTarget = 0;
+    });
+
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        start();
+      }
+    });
+
+    reducedMotion.addEventListener("change", () => {
+      if (reducedMotion.matches) {
+        stop();
+        pointerStrength = 0;
+        draw(STATIC_TIME);
+      } else {
+        start();
+      }
+    });
+
+    darkScheme.addEventListener("change", () => {
+      applyThemeColors();
+      if (reducedMotion.matches) draw(STATIC_TIME);
+    });
+
+    applyThemeColors();
+    new ResizeObserver(resize).observe(canvas);
+    resize();
+    if (reducedMotion.matches) {
+      draw(STATIC_TIME);
+    } else {
+      start();
+    }
+    return true;
+  };
+
+  const wrapper = document.querySelector<HTMLElement>("[data-nf-art]");
+  const canvas = wrapper?.querySelector<HTMLCanvasElement>("[data-nf-canvas]");
+  if (wrapper && canvas) {
+    // The fallback is hidden by default (it would flash before this module
+    // runs); it only appears when WebGL is unavailable.
+    wrapper.classList.add(init(canvas) ? "is-live" : "is-fallback");
+  }
+</script>
+
+<style>
+  .nf-art {
+    position: relative;
+    margin-top: 2.5rem;
+    aspect-ratio: 16 / 9;
+  }
+
+  .nf-art__canvas {
+    position: absolute;
+    inset: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    transition: opacity 0.6s ease;
+    touch-action: manipulation;
+  }
+
+  .nf-art.is-live .nf-art__canvas {
+    opacity: 1;
+  }
+
+  .nf-art__fallback {
+    position: absolute;
+    inset: 0;
+    display: none;
+    place-items: center;
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 2rem;
+    letter-spacing: 0.2em;
+    color: var(--c-sub);
+  }
+
+  .nf-art.is-fallback .nf-art__fallback {
+    display: grid;
+  }
+</style>

--- a/apps/me/src/features/pages/lib/not-found-art.ts
+++ b/apps/me/src/features/pages/lib/not-found-art.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure helpers for the 404 page WebGL artwork: a still-water surface of
+ * flowing horizontal lines. The pointer parts the lines as it hovers and a
+ * click sends a widening ripple through them. Everything is drawn as line
+ * displacement; there are no circular shapes. Ripple bookkeeping lives here
+ * as pure functions so it is unit-testable; the .astro script only owns the
+ * GL plumbing.
+ */
+
+/** Cap the device pixel ratio so 4x displays don't quadruple the fill cost. */
+export const MAX_DPR = 2;
+
+export const clampDpr = (dpr: number, max: number = MAX_DPR): number =>
+  Math.min(Math.max(dpr, 1), max);
+
+export const computeCanvasSize = (
+  cssWidth: number,
+  cssHeight: number,
+  dpr: number,
+): { width: number; height: number } => {
+  const scale = clampDpr(dpr);
+  return {
+    width: Math.max(1, Math.round(cssWidth * scale)),
+    height: Math.max(1, Math.round(cssHeight * scale)),
+  };
+};
+
+/** World space: x in [0, ASPECT], y in [0, 1], isotropic on a 16:9 canvas. */
+export const ASPECT = 16 / 9;
+
+/** The shader tracks a fixed number of ripple slots. */
+export const RIPPLE_SLOTS = 12;
+
+/** Seconds until a ripple has fully faded (amplitude decays exponentially). */
+export const RIPPLE_LIFETIME = 4;
+
+/** Packed ripple layout: x, y, bornTime, strength. */
+export const FLOATS_PER_RIPPLE = 4;
+
+export interface Ripple {
+  x: number;
+  y: number;
+  born: number;
+  /** Relative amplitude: clicks are strong, pointer-trail wakes are soft. */
+  strength: number;
+}
+
+/**
+ * Register a click ripple. The surface keeps at most RIPPLE_SLOTS of them;
+ * beyond that the oldest is dropped. Returns a new array.
+ */
+export const addRipple = (ripples: readonly Ripple[], ripple: Ripple): Ripple[] => {
+  const next = [...ripples, ripple];
+  while (next.length > RIPPLE_SLOTS) {
+    const oldest = next.reduce((a, b) => (a.born <= b.born ? a : b));
+    next.splice(next.indexOf(oldest), 1);
+  }
+  return next;
+};
+
+/** Drop ripples that have fully faded. */
+export const pruneRipples = (ripples: readonly Ripple[], time: number): Ripple[] =>
+  ripples.filter((r) => time < r.born + RIPPLE_LIFETIME);
+
+/** Pack ripples into vec4 slots for the shader; unused slots stay inactive. */
+export const packRipples = (ripples: readonly Ripple[], out: Float32Array): Float32Array => {
+  out.fill(0);
+  for (let i = 0; i < Math.min(ripples.length, RIPPLE_SLOTS); i++) {
+    const ripple = ripples[i];
+    if (!ripple) continue;
+    out[i * FLOATS_PER_RIPPLE] = ripple.x;
+    out[i * FLOATS_PER_RIPPLE + 1] = ripple.y;
+    out[i * FLOATS_PER_RIPPLE + 2] = ripple.born;
+    out[i * FLOATS_PER_RIPPLE + 3] = ripple.strength;
+  }
+  return out;
+};
+
+export const VERTEX_SHADER_SOURCE = `
+attribute vec2 a_position;
+
+void main() {
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}
+`;
+
+export const FRAGMENT_SHADER_SOURCE = `
+#extension GL_OES_standard_derivatives : enable
+
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+
+uniform vec2 u_resolution;
+uniform float u_time;
+uniform vec2 u_pointer;
+uniform float u_pointerStrength;
+uniform vec2 u_pointerVel;
+uniform float u_grip;
+uniform vec4 u_ripples[${RIPPLE_SLOTS}];
+uniform sampler2D u_glyphs;
+uniform vec3 u_lineColor;
+uniform float u_lineAlpha;
+
+const float LINE_FREQ = 32.0;
+
+// Smooth sign: -1..1 without the hard step (GLSL ES 1.0 has no tanh).
+float softsign(float x) {
+  return x / sqrt(1.0 + x * x);
+}
+
+void main() {
+  vec2 uv = gl_FragCoord.xy / u_resolution;
+  float aspect = u_resolution.x / u_resolution.y;
+  vec2 p = vec2(uv.x * aspect, uv.y);
+
+  // Layered swells: slow currents vary the line density across the
+  // surface, so the pattern flows like silk rather than sitting still.
+  float drift = u_time * 0.3;
+  float phase = p.y
+    + 0.014 * sin(p.x * 2.1 + drift * 0.5) * sin(p.y * 2.6 + drift * 0.23 + 1.0)
+    + 0.007 * sin(p.x * 4.7 + p.y * 3.4 - drift * 0.7)
+    + 0.004 * sin(p.x * 10.0 + 1.3 + drift * 1.1);
+
+  // A buried "404": the lines swell over the blurred glyphs, and the number
+  // emerges purely from how they bend. It breathes, faintly. The second
+  // term pulls lines toward the glyph core, so the digits also read as a
+  // denser weave.
+  float glyph = texture2D(u_glyphs, uv).r;
+  phase += glyph * (0.075 + 0.012 * sin(u_time * 0.4));
+  phase += glyph * (p.y - 0.5) * 0.45;
+
+  // The pointer parts the lines: above the cursor they lift, below they
+  // sink, opening a soft seam that closes when it leaves. While pressed
+  // (u_grip -> 1) the seam inverts into a grip: the lines gather into the
+  // cursor and stay clenched until release.
+  vec2 dp = p - u_pointer;
+  float env = exp(-dot(dp, dp) * 12.0) * u_pointerStrength;
+  env *= 1.0 + 0.6 * u_grip;
+  phase += 0.05 * softsign(dp.y * 9.0) * env * (1.0 - 2.2 * u_grip);
+  phase += 0.012 * sin(p.x * 16.0 - u_time * 2.0) * env * (1.0 - u_grip);
+
+  // Motion drag: the fabric follows the pointer's movement and springs
+  // back when it stops.
+  phase -= u_pointerVel.y * env * 0.10;
+  phase += softsign(dp.x * 5.0) * u_pointerVel.x * env * 0.06;
+
+  // Ripples: a click blooms a wide seam that settles back smoothly;
+  // pointer-trail wakes leave the same mark, softer.
+  for (int i = 0; i < ${RIPPLE_SLOTS}; i++) {
+    vec4 r = u_ripples[i];
+    float age = u_time - r.z;
+    float alive = step(0.0001, r.w) * step(0.0, age);
+    float spread = 1.0 + age * 2.4;
+    float k = 12.0 / (spread * spread);
+    float e = smoothstep(0.0, 0.18, age) * exp(-age * 1.2) * alive * r.w;
+    vec2 dr = p - r.xy;
+    phase += 0.08 * softsign(dr.y * 9.0) * exp(-dot(dr, dr) * k) * e;
+  }
+
+  // Thin flat lines, anti-aliased against the local line density.
+  float cell = phase * LINE_FREQ;
+  float g = fract(cell);
+  float dLine = min(g, 1.0 - g);
+#ifdef GL_OES_standard_derivatives
+  float grad = max(fwidth(cell), 1e-5);
+#else
+  float grad = LINE_FREQ / u_resolution.y;
+#endif
+  float line = 1.0 - smoothstep(0.4, 1.5, dLine / grad);
+  // Where the pattern compresses below pixel size, melt it into a flat
+  // surface instead of shimmering (moire).
+  line *= 1.0 - smoothstep(0.25, 0.5, grad);
+
+  gl_FragColor = vec4(u_lineColor, line * u_lineAlpha);
+}
+`;

--- a/apps/me/src/pages/404.astro
+++ b/apps/me/src/pages/404.astro
@@ -1,6 +1,7 @@
 ---
 import SEO from "#/components/seo/seo.astro";
 import SiteBrand from "#/components/ui/site-brand.astro";
+import NotFoundArt from "#/features/pages/components/not-found-art.astro";
 import BaseLayout from "#/layouts/base-layout.astro";
 ---
 
@@ -12,6 +13,7 @@ import BaseLayout from "#/layouts/base-layout.astro";
   />
   <SiteBrand />
   <h1 class="page-title">
-    ページが見つかりませんでした
+    404
   </h1>
+  <NotFoundArt />
 </BaseLayout>


### PR DESCRIPTION
- Replace the 404 page message with an interactive WebGL surface of flowing lines that part around the pointer and ripple on click
- Bury a blurred "404" in the line displacement so the digits emerge from how the lines bend
- Extract ripple bookkeeping and shader sources into pure, unit-tested helpers in the pages feature module
- Fall back to a static "404" when WebGL is unavailable and honor prefers-reduced-motion
- Resolve line color from theme CSS variables and update on prefers-color-scheme changes
