### PR TITLE
[main] refactor: shared dev-only favicon routes

### DIFF
--- a/apps/lgtm/CLAUDE.md
+++ b/apps/lgtm/CLAUDE.md
@@ -12,7 +12,7 @@ src/
   config/constants.ts             # TITLE, TWITTER_ACCOUNT_NAME, IMAGES_PER_PAGE
   layouts/layout.astro            # Base layout (Header, Main, Footer)
   assets/BBHBartle-Regular.ttf    # Font for the LGTM text overlay
-  components/seo/                 # SEO adapters + OG card + favicon (see Shared Packages)
+  components/seo/                 # SEO adapters + OG card (see Shared Packages)
   pages/
     [...page].astro               # Gallery with pagination + infinite scroll
     [id].astro                    # Detail page with format selector
@@ -20,7 +20,7 @@ src/
     [id]-[size].[format].ts       # Sized image API (400/1000/1200px)
     api/ids.json.ts               # JSON listing of all image IDs
     api/og/                       # OG images: default.png (shared handler) + [id].png (per-image, app-local)
-    api/favicon/                  # Dev-only favicon endpoints (404 in prod)
+    api/favicon/                  # Dev-only favicon endpoints (omitted from prod builds)
   __tests__/                      # Vitest unit tests
   __fixtures__/lgtm-sample/       # CI fixtures (used when GITHUB_ACTIONS=true)
 lgtm-content/                     # Git submodule (private) — source images, one media file per ULID dir
@@ -33,7 +33,7 @@ Consumed as source (no build step); this app supplies its own config via thin wr
 
 - `@kkhys/styles` — uchu.css OKLCH palette, imported in `src/styles/global.css`. The `--c-*` semantic tokens and the `prefers-color-scheme` dark mode stay app-local.
 - `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard primitives, wrapped by thin adapters in `src/components/seo/`. `head-meta.astro` and `json-ld.astro` are app-local.
-- `@kkhys/og` — favicon generators (`src/components/seo/favicon/index.ts`, bound to the green gradient) + route handlers. The default OG card (`opengraph-image.tsx`) and the per-id OG (`pages/api/og/[id].png.ts`) stay app-local (bespoke layouts).
+- `@kkhys/og` — favicon routes (`src/pages/api/favicon/[file].ts`, bound to the green gradient) + OG route handlers. The default OG card (`opengraph-image.tsx`) and the per-id OG (`pages/api/og/[id].png.ts`) stay app-local (bespoke layouts).
 
 ## Key Design Decisions
 
@@ -59,4 +59,4 @@ Consumed as source (no build step); this app supplies its own config via thin wr
 - `BBHBartle-Regular.ttf` must exist in `src/assets/`
 - ULIDs must be lowercase
 - Non-first gallery pages (`/2`, `/3`, …) redirect to `/` when accessed directly — they exist only for the infinite-scroll fetch
-- Favicon endpoints (`api/favicon/*`) are dev-only (404 in production); production serves favicons as static assets
+- Favicon endpoints (`api/favicon/*`) are dev-only (their `getStaticPaths` emits no paths in prod builds); production serves favicons as static assets

--- a/apps/lgtm/src/components/seo/favicon/index.ts
+++ b/apps/lgtm/src/components/seo/favicon/index.ts
@@ -1,6 +1,0 @@
-import { createFaviconGenerators } from "@kkhys/og/favicon";
-
-const gradient = "radial-gradient(circle at 35% 35%, #c8e6c9 0%, #81c784 40%, #4caf50 100%)";
-
-export const { IconSvg, Icon192Png, Icon512Png, IconMaskPng, AppleTouchIconPng } =
-  createFaviconGenerators(gradient);

--- a/apps/lgtm/src/pages/api/favicon/[file].ts
+++ b/apps/lgtm/src/pages/api/favicon/[file].ts
@@ -1,0 +1,5 @@
+import { createFaviconRoutes } from "@kkhys/og/handlers";
+
+export const { getStaticPaths, GET } = createFaviconRoutes(
+  "radial-gradient(circle at 35% 35%, #c8e6c9 0%, #81c784 40%, #4caf50 100%)",
+);

--- a/apps/lgtm/src/pages/api/favicon/apple-touch-icon.png.ts
+++ b/apps/lgtm/src/pages/api/favicon/apple-touch-icon.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { AppleTouchIconPng } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(AppleTouchIconPng);

--- a/apps/lgtm/src/pages/api/favicon/icon-192.png.ts
+++ b/apps/lgtm/src/pages/api/favicon/icon-192.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { Icon192Png } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(Icon192Png);

--- a/apps/lgtm/src/pages/api/favicon/icon-512.png.ts
+++ b/apps/lgtm/src/pages/api/favicon/icon-512.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { Icon512Png } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(Icon512Png);

--- a/apps/lgtm/src/pages/api/favicon/icon-mask.png.ts
+++ b/apps/lgtm/src/pages/api/favicon/icon-mask.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { IconMaskPng } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(IconMaskPng);

--- a/apps/lgtm/src/pages/api/favicon/icon.svg.ts
+++ b/apps/lgtm/src/pages/api/favicon/icon.svg.ts
@@ -1,4 +1,0 @@
-import { createSvgHandler } from "@kkhys/og/handlers";
-import { IconSvg } from "#/components/seo/favicon";
-
-export const GET = createSvgHandler(IconSvg);

--- a/apps/me/CLAUDE.md
+++ b/apps/me/CLAUDE.md
@@ -17,7 +17,7 @@ Consumed as source (no build step); this app supplies its own config via thin wr
 
 - `@kkhys/styles` — uchu.css OKLCH palette
 - `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard primitives, wrapped in `src/components/seo/`
-- `@kkhys/og` — Satori OG image + favicon generators, wired in `src/components/seo/favicon/` and `src/pages/api/`
+- `@kkhys/og` — Satori OG image + favicon generators, wired in `src/pages/api/`
 
 ## Content System
 

--- a/apps/me/src/components/seo/favicon/index.ts
+++ b/apps/me/src/components/seo/favicon/index.ts
@@ -1,6 +1,0 @@
-import { createFaviconGenerators } from "@kkhys/og/favicon";
-
-const gradient = "linear-gradient(to bottom right, #dbe7f0 0%, #527ce0 50%, #03077c 100%)";
-
-export const { IconSvg, Icon192Png, Icon512Png, IconMaskPng, AppleTouchIconPng } =
-  createFaviconGenerators(gradient);

--- a/apps/me/src/pages/api/favicon/[file].ts
+++ b/apps/me/src/pages/api/favicon/[file].ts
@@ -1,0 +1,5 @@
+import { createFaviconRoutes } from "@kkhys/og/handlers";
+
+export const { getStaticPaths, GET } = createFaviconRoutes(
+  "linear-gradient(to bottom right, #dbe7f0 0%, #527ce0 50%, #03077c 100%)",
+);

--- a/apps/me/src/pages/api/favicon/apple-touch-icon.png.ts
+++ b/apps/me/src/pages/api/favicon/apple-touch-icon.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { AppleTouchIconPng } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(AppleTouchIconPng);

--- a/apps/me/src/pages/api/favicon/icon-192.png.ts
+++ b/apps/me/src/pages/api/favicon/icon-192.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { Icon192Png } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(Icon192Png);

--- a/apps/me/src/pages/api/favicon/icon-512.png.ts
+++ b/apps/me/src/pages/api/favicon/icon-512.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { Icon512Png } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(Icon512Png);

--- a/apps/me/src/pages/api/favicon/icon-mask.png.ts
+++ b/apps/me/src/pages/api/favicon/icon-mask.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { IconMaskPng } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(IconMaskPng);

--- a/apps/me/src/pages/api/favicon/icon.svg.ts
+++ b/apps/me/src/pages/api/favicon/icon.svg.ts
@@ -1,4 +1,0 @@
-import { createSvgHandler } from "@kkhys/og/handlers";
-import { IconSvg } from "#/components/seo/favicon";
-
-export const GET = createSvgHandler(IconSvg);

--- a/apps/memo/src/components/seo/favicon/index.ts
+++ b/apps/memo/src/components/seo/favicon/index.ts
@@ -1,6 +1,0 @@
-import { createFaviconGenerators } from "@kkhys/og/favicon";
-
-const gradient = "radial-gradient(circle at 35% 35%, #ffffff 0%, #d0d0d0 40%, #808080 100%)";
-
-export const { IconSvg, Icon192Png, Icon512Png, IconMaskPng, AppleTouchIconPng } =
-  createFaviconGenerators(gradient);

--- a/apps/memo/src/pages/api/favicon/[file].ts
+++ b/apps/memo/src/pages/api/favicon/[file].ts
@@ -1,0 +1,5 @@
+import { createFaviconRoutes } from "@kkhys/og/handlers";
+
+export const { getStaticPaths, GET } = createFaviconRoutes(
+  "radial-gradient(circle at 35% 35%, #ffffff 0%, #d0d0d0 40%, #808080 100%)",
+);

--- a/apps/memo/src/pages/api/favicon/apple-touch-icon.png.ts
+++ b/apps/memo/src/pages/api/favicon/apple-touch-icon.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { AppleTouchIconPng } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(AppleTouchIconPng);

--- a/apps/memo/src/pages/api/favicon/icon-192.png.ts
+++ b/apps/memo/src/pages/api/favicon/icon-192.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { Icon192Png } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(Icon192Png);

--- a/apps/memo/src/pages/api/favicon/icon-512.png.ts
+++ b/apps/memo/src/pages/api/favicon/icon-512.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { Icon512Png } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(Icon512Png);

--- a/apps/memo/src/pages/api/favicon/icon-mask.png.ts
+++ b/apps/memo/src/pages/api/favicon/icon-mask.png.ts
@@ -1,4 +1,0 @@
-import { createPngHandler } from "@kkhys/og/handlers";
-import { IconMaskPng } from "#/components/seo/favicon";
-
-export const GET = createPngHandler(IconMaskPng);

--- a/apps/memo/src/pages/api/favicon/icon.svg.ts
+++ b/apps/memo/src/pages/api/favicon/icon.svg.ts
@@ -1,4 +1,0 @@
-import { createSvgHandler } from "@kkhys/og/handlers";
-import { IconSvg } from "#/components/seo/favicon";
-
-export const GET = createSvgHandler(IconSvg);

--- a/packages/og/package.json
+++ b/packages/og/package.json
@@ -9,13 +9,23 @@
     "./handlers": "./src/handlers.ts",
     "./og": "./src/og.tsx"
   },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "vitest run",
+    "coverage": "vitest run --coverage"
+  },
   "dependencies": {
     "react": "catalog:",
     "satori": "catalog:",
     "sharp": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "catalog:"
+    "@types/bun": "catalog:",
+    "@types/react": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "astro": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "astro": "^7.0.0"

--- a/packages/og/src/favicon.tsx
+++ b/packages/og/src/favicon.tsx
@@ -53,50 +53,37 @@ const convertSvgToPng = (svg: string) => {
 };
 
 /**
- * Renders a circular gradient icon via satori. The `gradient` is any CSS
- * background value (e.g. linear/radial-gradient). Returns an SVG string, or a
- * PNG Buffer when `format` is "png".
+ * Renders a circular gradient icon via satori as an SVG string. The `gradient`
+ * is any CSS background value (e.g. linear/radial-gradient).
  */
-export const generateIcon = async (
+const generateIconSvg = (
   gradient: string,
   satoriOptions: SatoriOptions,
   iconStyleOptions?: IconStyleOptions,
-  format: "svg" | "png" = "svg",
-) => {
+): Promise<string> => {
   const element = createIconElement(gradient, iconStyleOptions);
-  const svg = await generateSvg(element, satoriOptions);
-
-  if (format === "png") {
-    return convertSvgToPng(svg);
-  }
-
-  return svg;
+  return generateSvg(element, satoriOptions);
 };
+
+/** PNG variant of {@link generateIconSvg}. */
+const generateIconPng = async (
+  gradient: string,
+  satoriOptions: SatoriOptions,
+  iconStyleOptions?: IconStyleOptions,
+): Promise<Buffer> =>
+  convertSvgToPng(await generateIconSvg(gradient, satoriOptions, iconStyleOptions));
 
 /**
  * Builds the five favicon asset generators bound to a single gradient. Each app
- * calls this with its own gradient and exposes the result to its favicon route
- * handlers.
+ * supplies its own gradient; the route factory in handlers.ts exposes the
+ * result as dev-only endpoints.
  */
 export const createFaviconGenerators = (gradient: string) => ({
-  IconSvg: async () =>
-    (await generateIcon(gradient, { width: 500, height: 500 }, undefined, "svg")) as string,
-  Icon192Png: async () =>
-    (await generateIcon(gradient, { width: 192, height: 192 }, undefined, "png")) as Buffer,
-  Icon512Png: async () =>
-    (await generateIcon(gradient, { width: 512, height: 512 }, undefined, "png")) as Buffer,
-  IconMaskPng: async () =>
-    (await generateIcon(
-      gradient,
-      { width: 512, height: 512 },
-      { width: 409, height: 409 },
-      "png",
-    )) as Buffer,
-  AppleTouchIconPng: async () =>
-    (await generateIcon(
-      gradient,
-      { width: 180, height: 180 },
-      { width: 140, height: 140 },
-      "png",
-    )) as Buffer,
+  IconSvg: () => generateIconSvg(gradient, { width: 500, height: 500 }),
+  Icon192Png: () => generateIconPng(gradient, { width: 192, height: 192 }),
+  Icon512Png: () => generateIconPng(gradient, { width: 512, height: 512 }),
+  IconMaskPng: () =>
+    generateIconPng(gradient, { width: 512, height: 512 }, { width: 409, height: 409 }),
+  AppleTouchIconPng: () =>
+    generateIconPng(gradient, { width: 180, height: 180 }, { width: 140, height: 140 }),
 });

--- a/packages/og/src/handlers.test.ts
+++ b/packages/og/src/handlers.test.ts
@@ -1,0 +1,53 @@
+import type { APIContext } from "astro";
+import { describe, expect, it } from "vitest";
+import { createFaviconRoutes } from "./handlers";
+
+const GRADIENT = "linear-gradient(to bottom, #000000 0%, #ffffff 100%)";
+
+const contextFor = (file: string) => ({ params: { file } }) as unknown as APIContext;
+
+describe("createFaviconRoutes", () => {
+  it("emits no routes in production builds", () => {
+    const { getStaticPaths } = createFaviconRoutes(GRADIENT, { prod: true });
+    expect(getStaticPaths()).toEqual([]);
+  });
+
+  it("serves every favicon file in dev", () => {
+    const { getStaticPaths } = createFaviconRoutes(GRADIENT, { prod: false });
+    const files = getStaticPaths().map(({ params }) => params.file);
+    expect(files).toEqual([
+      "icon.svg",
+      "icon-192.png",
+      "icon-512.png",
+      "icon-mask.png",
+      "apple-touch-icon.png",
+    ]);
+  });
+
+  it("serves SVG with the right headers", async () => {
+    const { GET } = createFaviconRoutes(GRADIENT, { prod: false });
+    const response = await GET(contextFor("icon.svg"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("image/svg+xml");
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=31536000, immutable");
+    expect(await response.text()).toContain("<svg");
+  });
+
+  it("serves PNG bytes", async () => {
+    const { GET } = createFaviconRoutes(GRADIENT, { prod: false });
+    const response = await GET(contextFor("icon-192.png"));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("image/png");
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    expect(Array.from(bytes.slice(0, 4))).toEqual([0x89, 0x50, 0x4e, 0x47]);
+  });
+
+  it("returns 404 for unknown files", async () => {
+    const { GET } = createFaviconRoutes(GRADIENT, { prod: false });
+    const response = await GET(contextFor("nope.png"));
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/og/src/handlers.ts
+++ b/packages/og/src/handlers.ts
@@ -1,48 +1,60 @@
 import type { APIRoute } from "astro";
+import { createFaviconGenerators } from "./favicon";
 
 const IMAGE_CACHE_CONTROL = "public, max-age=31536000, immutable";
 
+interface FaviconAsset {
+  contentType: string;
+  generate: () => Promise<string | Buffer>;
+}
+
 /**
- * Wraps a PNG generator as a dev-only route handler. Favicon assets ship as
- * static files in production, so this returns 404 when PROD to avoid serving
- * them dynamically.
+ * Builds a dev-only favicon endpoint for a `[file].ts` route. Favicon assets
+ * ship as static files in production, so getStaticPaths emits no paths in
+ * PROD builds — prerendering a guard response instead would write literal
+ * "Not Found" bodies into dist and serve them with status 200.
+ *
+ * `prod` is overridable for tests.
  */
-export const createPngHandler = (generator: () => Promise<ArrayBuffer | Buffer>): APIRoute => {
-  return async () => {
-    if (import.meta.env.PROD) {
+export const createFaviconRoutes = (
+  gradient: string,
+  // Vite inlines a real boolean, but Bun's ImportMeta types env values as
+  // strings; compare the text so a literal "false" cannot read as truthy.
+  { prod = String(import.meta.env.PROD) === "true" }: { prod?: boolean | undefined } = {},
+) => {
+  const generators = createFaviconGenerators(gradient);
+  const files: Record<string, FaviconAsset> = {
+    "icon.svg": { contentType: "image/svg+xml", generate: generators.IconSvg },
+    "icon-192.png": { contentType: "image/png", generate: generators.Icon192Png },
+    "icon-512.png": { contentType: "image/png", generate: generators.Icon512Png },
+    "icon-mask.png": { contentType: "image/png", generate: generators.IconMaskPng },
+    "apple-touch-icon.png": { contentType: "image/png", generate: generators.AppleTouchIconPng },
+  };
+
+  const getStaticPaths = () =>
+    prod ? [] : Object.keys(files).map((file) => ({ params: { file } }));
+
+  const GET: APIRoute = async ({ params }) => {
+    const asset = files[params.file ?? ""];
+    if (!asset) {
       return new Response("Not Found", { status: 404 });
     }
 
-    const image = await generator();
-    return new Response(new Uint8Array(image), {
+    const body = await asset.generate();
+    return new Response(typeof body === "string" ? body : new Uint8Array(body), {
       headers: {
-        "Content-Type": "image/png",
+        "Content-Type": asset.contentType,
         "Cache-Control": IMAGE_CACHE_CONTROL,
       },
     });
   };
-};
 
-/** Dev-only SVG route handler. See {@link createPngHandler}. */
-export const createSvgHandler = (generator: () => Promise<string>): APIRoute => {
-  return async () => {
-    if (import.meta.env.PROD) {
-      return new Response("Not Found", { status: 404 });
-    }
-
-    const svg = await generator();
-    return new Response(svg, {
-      headers: {
-        "Content-Type": "image/svg+xml",
-        "Cache-Control": IMAGE_CACHE_CONTROL,
-      },
-    });
-  };
+  return { getStaticPaths, GET };
 };
 
 /**
  * Wraps a PNG generator as a production OG-image route handler. Unlike the
- * favicon handlers, OG images are served in production (no PROD guard).
+ * favicon routes, OG images are served in production.
  */
 export const createOgResponse = (generator: () => Promise<ArrayBuffer | Buffer>): APIRoute => {
   return async () => {

--- a/packages/og/tsconfig.json
+++ b/packages/og/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext"],
+    "jsx": "react-jsx",
+    "types": ["bun"],
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,7 +100,7 @@ importers:
         version: link:../../packages/styles
       astro:
         specifier: 'catalog:'
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.0.3)(terser@5.49.2)(yaml@2.8.2)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
       kiso.css:
         specifier: 'catalog:'
         version: 1.2.4
@@ -134,7 +134,7 @@ importers:
         version: 0.3.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@astrojs/react':
         specifier: 'catalog:'
-        version: 6.0.2(@types/node@25.0.3)(@types/react-dom@19.1.6(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(terser@5.49.2)(yaml@2.8.2)
+        version: 6.0.2(@types/node@25.0.3)(@types/react-dom@19.1.6(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(terser@5.49.2)(yaml@2.8.2)
       '@kkhys/og':
         specifier: workspace:*
         version: link:../../packages/og
@@ -146,7 +146,7 @@ importers:
         version: link:../../packages/styles
       astro:
         specifier: 'catalog:'
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
       kiso.css:
         specifier: 'catalog:'
         version: 1.2.4
@@ -162,7 +162,7 @@ importers:
         version: 3.7.3
       '@playform/compress':
         specifier: 0.2.4
-        version: 0.2.4(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(yaml@2.8.2)
+        version: 0.2.4(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(yaml@2.8.2)
       '@types/bun':
         specifier: 'catalog:'
         version: 1.3.14
@@ -210,10 +210,10 @@ importers:
         version: 0.3.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@astrojs/mdx':
         specifier: 7.0.5
-        version: 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2))(supports-color@10.2.2)
+        version: 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2))
       '@astrojs/react':
         specifier: 'catalog:'
-        version: 6.0.2(@types/node@26.1.2)(@types/react-dom@19.1.6(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(terser@5.49.2)(yaml@2.8.2)
+        version: 6.0.2(@types/node@26.1.2)(@types/react-dom@19.1.6(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(terser@5.49.2)(yaml@2.8.2)
       '@astrojs/rss':
         specifier: 4.0.19
         version: 4.0.19
@@ -234,10 +234,10 @@ importers:
         version: link:../../packages/styles
       astro:
         specifier: 'catalog:'
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
       astro-expressive-code:
         specifier: 0.44.1
-        version: 0.44.1(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2))
+        version: 0.44.1(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2))
       graphql-request:
         specifier: 7.4.0
         version: 7.4.0(graphql@16.11.0)
@@ -250,7 +250,7 @@ importers:
     devDependencies:
       '@astrojs/markdown-remark':
         specifier: 'catalog:'
-        version: 7.2.2(supports-color@10.2.2)
+        version: 7.2.2
       '@expressive-code/plugin-line-numbers':
         specifier: 0.44.1
         version: 0.44.1
@@ -277,10 +277,10 @@ importers:
         version: 2.0.0
       budoux:
         specifier: 0.8.4
-        version: 0.8.4(supports-color@10.2.2)
+        version: 0.8.4
       fetch-site-metadata:
         specifier: 'catalog:'
-        version: 0.2.0(supports-color@10.2.2)
+        version: 0.2.0
       hast-util-from-html:
         specifier: 2.0.3
         version: 2.0.3
@@ -292,10 +292,10 @@ importers:
         version: 0.18.13
       mdast-util-mdx-jsx:
         specifier: 3.2.0
-        version: 3.2.0(supports-color@10.2.2)
+        version: 3.2.0
       mermaid-isomorphic:
         specifier: 3.1.0
-        version: 3.1.0(playwright@1.62.1)(supports-color@10.2.2)
+        version: 3.1.0(playwright@1.62.1)
       mini-svg-data-uri:
         specifier: 1.4.4
         version: 1.4.4
@@ -343,7 +343,7 @@ importers:
         version: 0.3.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@astrojs/react':
         specifier: 'catalog:'
-        version: 6.0.2(@types/node@26.1.2)(@types/react-dom@19.1.6(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(terser@5.49.2)(yaml@2.8.2)
+        version: 6.0.2(@types/node@26.1.2)(@types/react-dom@19.1.6(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(terser@5.49.2)(yaml@2.8.2)
       '@kkhys/og':
         specifier: workspace:*
         version: link:../../packages/og
@@ -355,7 +355,7 @@ importers:
         version: link:../../packages/styles
       astro:
         specifier: 'catalog:'
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
       kiso.css:
         specifier: 'catalog:'
         version: 1.2.4
@@ -368,13 +368,13 @@ importers:
         version: 0.9.10(prettier@3.6.2)(typescript@6.0.3)
       '@astrojs/markdown-remark':
         specifier: 'catalog:'
-        version: 7.2.2(supports-color@10.2.2)
+        version: 7.2.2
       '@astrojs/sitemap':
         specifier: 'catalog:'
         version: 3.7.3
       '@playform/compress':
         specifier: 0.2.4
-        version: 0.2.4(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(yaml@2.8.2)
+        version: 0.2.4(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(yaml@2.8.2)
       '@types/bun':
         specifier: 'catalog:'
         version: 1.3.14
@@ -389,7 +389,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       fetch-site-metadata:
         specifier: 'catalog:'
-        version: 0.2.0(supports-color@10.2.2)
+        version: 0.2.0
       mdast-util-to-string:
         specifier: 4.0.0
         version: 4.0.0
@@ -410,7 +410,7 @@ importers:
         version: 3.0.0
       remark:
         specifier: 15.0.1
-        version: 15.0.1(supports-color@10.2.2)
+        version: 15.0.1
       satori:
         specifier: 'catalog:'
         version: 0.29.0
@@ -440,7 +440,7 @@ importers:
         version: 4.0.0
       remark:
         specifier: 15.0.1
-        version: 15.0.1(supports-color@10.2.2)
+        version: 15.0.1
       ulid:
         specifier: 'catalog:'
         version: 3.0.2
@@ -466,9 +466,6 @@ importers:
 
   packages/og:
     dependencies:
-      astro:
-        specifier: ^7.0.0
-        version: 7.0.7(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.49.2)(yaml@2.8.2)
       react:
         specifier: 'catalog:'
         version: 19.2.8
@@ -479,9 +476,24 @@ importers:
         specifier: 'catalog:'
         version: 0.35.3(@types/node@25.0.3)
     devDependencies:
+      '@types/bun':
+        specifier: 'catalog:'
+        version: 1.3.14
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.18
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      astro:
+        specifier: 'catalog:'
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@25.0.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
 
   packages/release:
     devDependencies:
@@ -502,7 +514,7 @@ importers:
     dependencies:
       astro:
         specifier: ^7.0.0
-        version: 7.0.7(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+        version: 7.0.7(@astrojs/markdown-remark@7.2.1)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.0.3)(terser@5.49.2)(yaml@2.8.2)
 
   packages/styles: {}
 
@@ -2209,30 +2221,15 @@ packages:
 
   '@volar/language-server@2.4.28':
     resolution: {integrity: sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@volar/language-service@2.4.28':
     resolution: {integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@volar/source-map@2.4.28':
     resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@vscode/emmet-helper@2.11.0':
     resolution: {integrity: sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==}
@@ -2324,6 +2321,16 @@ packages:
     hasBin: true
     peerDependencies:
       '@astrojs/markdown-remark': 7.2.1
+    peerDependenciesMeta:
+      '@astrojs/markdown-remark':
+        optional: true
+
+  astro@7.1.6:
+    resolution: {integrity: sha512-83x9rYbHazMaZkYrAFRVZXSQx2moFkz0F7cjTDUF3GWfS0a3p2vZXG1ZdhV86rStHApQCodBJW+XTD37xISIrQ==}
+    engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
+    hasBin: true
+    peerDependencies:
+      '@astrojs/markdown-remark': 7.2.2
     peerDependenciesMeta:
       '@astrojs/markdown-remark':
         optional: true
@@ -4603,22 +4610,16 @@ packages:
     resolution: {integrity: sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
-      typescript: '*'
     peerDependenciesMeta:
       '@volar/language-service':
-        optional: true
-      typescript:
         optional: true
 
   volar-service-typescript@0.0.70:
     resolution: {integrity: sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==}
     peerDependencies:
       '@volar/language-service': ~2.4.0
-      typescript: '*'
     peerDependenciesMeta:
       '@volar/language-service':
-        optional: true
-      typescript:
         optional: true
 
   volar-service-yaml@0.0.70:
@@ -4829,9 +4830,17 @@ snapshots:
   '@astrojs/compiler-binding-linux-x64-musl@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding-wasm32-wasi@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@astrojs/compiler-binding-wasm32-wasi@0.3.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@astrojs/compiler-binding-wasm32-wasi@0.3.2':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.2.0
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -4857,7 +4866,7 @@ snapshots:
   '@astrojs/compiler-binding-win32-x64-msvc@0.3.2':
     optional: true
 
-  '@astrojs/compiler-binding@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@astrojs/compiler-binding@0.3.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     optionalDependencies:
       '@astrojs/compiler-binding-darwin-arm64': 0.3.1
       '@astrojs/compiler-binding-darwin-x64': 0.3.1
@@ -4865,9 +4874,24 @@ snapshots:
       '@astrojs/compiler-binding-linux-arm64-musl': 0.3.1
       '@astrojs/compiler-binding-linux-x64-gnu': 0.3.1
       '@astrojs/compiler-binding-linux-x64-musl': 0.3.1
-      '@astrojs/compiler-binding-wasm32-wasi': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@astrojs/compiler-binding-wasm32-wasi': 0.3.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@astrojs/compiler-binding-win32-arm64-msvc': 0.3.1
       '@astrojs/compiler-binding-win32-x64-msvc': 0.3.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  '@astrojs/compiler-binding@0.3.2':
+    optionalDependencies:
+      '@astrojs/compiler-binding-darwin-arm64': 0.3.2
+      '@astrojs/compiler-binding-darwin-x64': 0.3.2
+      '@astrojs/compiler-binding-linux-arm64-gnu': 0.3.2
+      '@astrojs/compiler-binding-linux-arm64-musl': 0.3.2
+      '@astrojs/compiler-binding-linux-x64-gnu': 0.3.2
+      '@astrojs/compiler-binding-linux-x64-musl': 0.3.2
+      '@astrojs/compiler-binding-wasm32-wasi': 0.3.2
+      '@astrojs/compiler-binding-win32-arm64-msvc': 0.3.2
+      '@astrojs/compiler-binding-win32-x64-msvc': 0.3.2
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -4887,9 +4911,16 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@astrojs/compiler-rs@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@astrojs/compiler-rs@0.3.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     dependencies:
-      '@astrojs/compiler-binding': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@astrojs/compiler-binding': 0.3.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  '@astrojs/compiler-rs@0.3.2':
+    dependencies:
+      '@astrojs/compiler-binding': 0.3.2
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -4932,17 +4963,17 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@volar/kit': 2.4.28(typescript@6.0.3)
       '@volar/language-core': 2.4.28
-      '@volar/language-server': 2.4.28(typescript@6.0.3)
-      '@volar/language-service': 2.4.28(typescript@6.0.3)
+      '@volar/language-server': 2.4.28
+      '@volar/language-service': 2.4.28
       muggle-string: 0.4.1
       tinyglobby: 0.2.17
-      volar-service-css: 0.0.70(@volar/language-service@2.4.28(typescript@6.0.3))
-      volar-service-emmet: 0.0.70(@volar/language-service@2.4.28(typescript@6.0.3))
-      volar-service-html: 0.0.70(@volar/language-service@2.4.28(typescript@6.0.3))
-      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28(typescript@6.0.3))(prettier@3.6.2)
-      volar-service-typescript: 0.0.70(@volar/language-service@2.4.28(typescript@6.0.3))(typescript@6.0.3)
-      volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28(typescript@6.0.3))(typescript@6.0.3)
-      volar-service-yaml: 0.0.70(@volar/language-service@2.4.28(typescript@6.0.3))
+      volar-service-css: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-html: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.6.2)
+      volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-yaml: 0.0.70(@volar/language-service@2.4.28)
       vscode-html-languageservice: 5.6.2
       vscode-uri: 3.1.0
     optionalDependencies:
@@ -4960,8 +4991,8 @@ snapshots:
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1(supports-color@10.2.2)
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
       unified: 11.0.5
@@ -4973,7 +5004,7 @@ snapshots:
       - supports-color
     optional: true
 
-  '@astrojs/markdown-remark@7.2.2(supports-color@10.2.2)':
+  '@astrojs/markdown-remark@7.2.2':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
       '@astrojs/prism': 4.0.2
@@ -4983,8 +5014,8 @@ snapshots:
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1(supports-color@10.2.2)
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
       unified: 11.0.5
@@ -5010,19 +5041,19 @@ snapshots:
       hast-util-from-html: 2.0.3
       satteri: 0.9.3
 
-  '@astrojs/mdx@7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2))(supports-color@10.2.2)':
+  '@astrojs/mdx@7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2))':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
-      '@astrojs/markdown-remark': 7.2.2(supports-color@10.2.2)
-      '@mdx-js/mdx': 3.1.1(supports-color@10.2.2)
+      '@astrojs/markdown-remark': 7.2.2
+      '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+      astro: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
       piccolore: 0.1.3
       rehype-raw: 7.0.0
-      remark-gfm: 4.0.1(supports-color@10.2.2)
+      remark-gfm: 4.0.1
       remark-smartypants: 3.0.2
       source-map: 0.7.6
       unist-util-visit: 5.1.0
@@ -5036,12 +5067,12 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@6.0.2(@types/node@25.0.3)(@types/react-dom@19.1.6(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(terser@5.49.2)(yaml@2.8.2)':
+  '@astrojs/react@6.0.2(@types/node@25.0.3)(@types/react-dom@19.1.6(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(terser@5.49.2)(yaml@2.8.2)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
       '@types/react': 19.2.18
       '@types/react-dom': 19.1.6(@types/react@19.2.18)
-      '@vitejs/plugin-react': 5.2.0(supports-color@10.2.2)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
+      '@vitejs/plugin-react': 5.2.0(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
       devalue: 5.8.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -5062,12 +5093,12 @@ snapshots:
       - tsx
       - yaml
 
-  '@astrojs/react@6.0.2(@types/node@26.1.2)(@types/react-dom@19.1.6(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(terser@5.49.2)(yaml@2.8.2)':
+  '@astrojs/react@6.0.2(@types/node@26.1.2)(@types/react-dom@19.1.6(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(terser@5.49.2)(yaml@2.8.2)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
       '@types/react': 19.2.18
       '@types/react-dom': 19.1.6(@types/react@19.2.18)
-      '@vitejs/plugin-react': 5.2.0(supports-color@10.2.2)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
+      '@vitejs/plugin-react': 5.2.0(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
       devalue: 5.8.1
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
@@ -5119,20 +5150,20 @@ snapshots:
 
   '@babel/compat-data@7.29.0': {}
 
-  '@babel/core@7.29.0(supports-color@10.2.2)':
+  '@babel/core@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.28.6
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5157,19 +5188,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.28.6(supports-color@10.2.2)':
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/helper-module-imports': 7.28.6(supports-color@10.2.2)
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@10.2.2)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5190,14 +5221,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0(supports-color@10.2.2))':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/template@7.28.6':
@@ -5206,7 +5237,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0(supports-color@10.2.2)':
+  '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -5214,7 +5245,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5487,12 +5518,12 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@iconify/utils@2.3.0(supports-color@10.2.2)':
+  '@iconify/utils@2.3.0':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@antfu/utils': 8.1.1
       '@iconify/types': 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       globals: 15.15.0
       kolorist: 1.8.0
       local-pkg: 1.1.1
@@ -5741,7 +5772,7 @@ snapshots:
 
   '@justinribeiro/lite-youtube@1.9.0': {}
 
-  '@mdx-js/mdx@3.1.1(supports-color@10.2.2)':
+  '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
@@ -5753,14 +5784,14 @@ snapshots:
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
+      hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
       recma-jsx: 1.0.0(acorn@8.16.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0(supports-color@10.2.2)
-      remark-mdx: 3.1.0(supports-color@10.2.2)
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      rehype-recma: 1.0.0
+      remark-mdx: 3.1.0
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -5775,10 +5806,15 @@ snapshots:
     dependencies:
       langium: 3.3.1
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.0':
+    dependencies:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -5926,12 +5962,12 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.77.0':
     optional: true
 
-  '@playform/compress@0.2.4(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(yaml@2.8.2)':
+  '@playform/compress@0.2.4(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(yaml@2.8.2)':
     dependencies:
       '@playform/pipe': 0.1.6
       '@types/csso': 5.0.5
       '@types/html-minifier-terser': 7.0.2
-      astro: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+      astro: 7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
       commander: 15.0.0
       csso: 5.0.5
       deepmerge-ts: 7.1.5
@@ -5968,6 +6004,7 @@ snapshots:
       - ioredis
       - jiti
       - less
+      - rollup
       - sass
       - sass-embedded
       - stylus
@@ -6327,11 +6364,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@5.2.0(supports-color@10.2.2)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.2.0(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@10.2.2)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0(supports-color@10.2.2))
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
@@ -6401,8 +6438,8 @@ snapshots:
 
   '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
-      '@volar/language-service': 2.4.28(typescript@6.0.3)
-      '@volar/typescript': 2.4.28(typescript@6.0.3)
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
       typesafe-path: 0.2.2
       typescript: 6.0.3
       vscode-languageserver-textdocument: 1.0.12
@@ -6412,38 +6449,32 @@ snapshots:
     dependencies:
       '@volar/source-map': 2.4.28
 
-  '@volar/language-server@2.4.28(typescript@6.0.3)':
+  '@volar/language-server@2.4.28':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@volar/language-service': 2.4.28(typescript@6.0.3)
-      '@volar/typescript': 2.4.28(typescript@6.0.3)
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
       path-browserify: 1.0.1
       request-light: 0.7.0
       vscode-languageserver: 9.0.1
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
-    optionalDependencies:
-      typescript: 6.0.3
 
-  '@volar/language-service@2.4.28(typescript@6.0.3)':
+  '@volar/language-service@2.4.28':
     dependencies:
       '@volar/language-core': 2.4.28
       vscode-languageserver-protocol: 3.17.5
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
-    optionalDependencies:
-      typescript: 6.0.3
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28(typescript@6.0.3)':
+  '@volar/typescript@2.4.28':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
-    optionalDependencies:
-      typescript: 6.0.3
 
   '@vscode/emmet-helper@2.11.0':
     dependencies:
@@ -6511,15 +6542,15 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.44.1(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)):
+  astro-expressive-code@0.44.1(astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)):
     dependencies:
-      astro: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+      astro: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
       rehype-expressive-code: 0.44.1
       url-extras: 0.1.0
 
-  astro@7.0.7(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.3)(terser@5.49.2)(yaml@2.8.2):
+  astro@7.0.7(@astrojs/markdown-remark@7.2.1)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.0.3)(terser@5.49.2)(yaml@2.8.2):
     dependencies:
-      '@astrojs/compiler-rs': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@astrojs/compiler-rs': 0.3.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@astrojs/internal-helpers': 0.10.1
       '@astrojs/markdown-satteri': 0.3.3
       '@astrojs/telemetry': 3.3.3
@@ -6610,11 +6641,11 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@7.0.7(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2):
+  astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2):
     dependencies:
-      '@astrojs/compiler-rs': 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      '@astrojs/internal-helpers': 0.10.1
-      '@astrojs/markdown-satteri': 0.3.3
+      '@astrojs/compiler-rs': 0.3.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@astrojs/internal-helpers': 0.10.2
+      '@astrojs/markdown-satteri': 0.3.5
       '@astrojs/telemetry': 3.3.3
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.1.0
@@ -6626,7 +6657,7 @@ snapshots:
       ci-info: 4.4.0
       clsx: 2.1.1
       common-ancestor-path: 2.0.0
-      cookie: 1.1.1
+      cookie: 2.0.1
       devalue: 5.8.1
       diff: 8.0.3
       dset: 3.1.4
@@ -6638,12 +6669,12 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       jsonc-parser: 3.3.1
-      magic-string: 0.30.21
+      magic-string: 1.1.0
       magicast: 0.5.2
       mrmime: 2.0.1
-      neotraverse: 0.6.18
+      neotraverse: 1.0.1
       obug: 2.1.1
       p-limit: 7.3.0
       p-queue: 9.1.0
@@ -6666,7 +6697,7 @@ snapshots:
       yargs-parser: 22.0.0
       zod: 4.3.6
     optionalDependencies:
-      '@astrojs/markdown-remark': 7.2.1
+      '@astrojs/markdown-remark': 7.2.2
       sharp: 0.35.3(@types/node@26.1.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -6703,7 +6734,7 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2):
+  astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler-rs': 0.3.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
       '@astrojs/internal-helpers': 0.10.2
@@ -6758,7 +6789,7 @@ snapshots:
       yargs-parser: 22.0.0
       zod: 4.3.6
     optionalDependencies:
-      '@astrojs/markdown-remark': 7.2.2(supports-color@10.2.2)
+      '@astrojs/markdown-remark': 7.2.2
       sharp: 0.35.3(@types/node@26.1.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -6794,9 +6825,9 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@25.0.3)(terser@5.49.2)(yaml@2.8.2):
+  astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2):
     dependencies:
-      '@astrojs/compiler-rs': 0.3.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@astrojs/compiler-rs': 0.3.2
       '@astrojs/internal-helpers': 0.10.2
       '@astrojs/markdown-satteri': 0.3.5
       '@astrojs/telemetry': 3.3.3
@@ -6843,14 +6874,14 @@ snapshots:
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unstorage: 1.17.5
-      vite: 8.1.0(@types/node@25.0.3)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2)
-      vitefu: 1.1.2(vite@8.1.0(@types/node@25.0.3)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
+      vite: 8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2)
+      vitefu: 1.1.2(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.3.6
     optionalDependencies:
-      '@astrojs/markdown-remark': 7.2.2(supports-color@10.2.2)
-      sharp: 0.35.3(@types/node@25.0.3)
+      '@astrojs/markdown-remark': 7.2.2
+      sharp: 0.35.3(@types/node@26.1.2)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -6916,10 +6947,10 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.0)
 
-  budoux@0.8.4(supports-color@10.2.2):
+  budoux@0.8.4:
     dependencies:
       commander: 14.0.3
-      google-artifactregistry-auth: 3.5.0(supports-color@10.2.2)
+      google-artifactregistry-auth: 3.5.0
       linkedom: 0.18.13
     transitivePeerDependencies:
       - canvas
@@ -7289,23 +7320,17 @@ snapshots:
 
   dayjs@1.11.13: {}
 
-  debug@2.6.9(supports-color@10.2.2):
+  debug@2.6.9:
     dependencies:
       ms: 2.0.0
-    optionalDependencies:
-      supports-color: 10.2.2
 
-  debug@3.2.7(supports-color@10.2.2):
+  debug@3.2.7:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.2.2
 
-  debug@4.4.3(supports-color@10.2.2):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.2.2
 
   decode-named-character-reference@1.1.0:
     dependencies:
@@ -7540,11 +7565,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  fetch-site-metadata@0.2.0(supports-color@10.2.2):
+  fetch-site-metadata@0.2.0:
     dependencies:
       entities: 4.5.0
       html-rewriter-wasm: 0.4.1
-      probe-image-size: 7.2.3(supports-color@10.2.2)
+      probe-image-size: 7.2.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7570,10 +7595,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  gaxios@6.7.1(supports-color@10.2.2):
+  gaxios@6.7.1:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0
       uuid: 9.0.1
@@ -7581,9 +7606,9 @@ snapshots:
       - encoding
       - supports-color
 
-  gcp-metadata@6.1.1(supports-color@10.2.2):
+  gcp-metadata@6.1.1:
     dependencies:
-      gaxios: 6.7.1(supports-color@10.2.2)
+      gaxios: 6.7.1
       google-logging-utils: 0.0.2
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -7608,22 +7633,22 @@ snapshots:
 
   globals@15.15.0: {}
 
-  google-artifactregistry-auth@3.5.0(supports-color@10.2.2):
+  google-artifactregistry-auth@3.5.0:
     dependencies:
-      google-auth-library: 9.15.1(supports-color@10.2.2)
+      google-auth-library: 9.15.1
       js-yaml: 4.3.0
       yargs: 17.7.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  google-auth-library@9.15.1(supports-color@10.2.2):
+  google-auth-library@9.15.1:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1(supports-color@10.2.2)
-      gcp-metadata: 6.1.1(supports-color@10.2.2)
-      gtoken: 7.1.0(supports-color@10.2.2)
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -7638,9 +7663,9 @@ snapshots:
 
   graphql@16.11.0: {}
 
-  gtoken@7.1.0(supports-color@10.2.2):
+  gtoken@7.1.0:
     dependencies:
-      gaxios: 6.7.1(supports-color@10.2.2)
+      gaxios: 6.7.1
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
@@ -7732,7 +7757,7 @@ snapshots:
       unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
-  hast-util-to-estree@3.1.3(supports-color@10.2.2):
+  hast-util-to-estree@3.1.3:
     dependencies:
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
@@ -7742,9 +7767,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.16
@@ -7767,7 +7792,7 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
-  hast-util-to-jsx-runtime@2.3.6(supports-color@10.2.2):
+  hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
       '@types/hast': 3.0.5
@@ -7776,9 +7801,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.16
@@ -7849,10 +7874,10 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
-  https-proxy-agent@7.0.6(supports-color@10.2.2):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8145,14 +8170,14 @@ snapshots:
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.2(supports-color@10.2.2):
+  mdast-util-from-markdown@2.0.2:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.1.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@10.2.2)
+      micromark: 4.0.2
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -8170,67 +8195,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0(supports-color@10.2.2):
+  mdast-util-gfm-footnote@2.1.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0(supports-color@10.2.2):
+  mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0(supports-color@10.2.2):
+  mdast-util-gfm-table@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0(supports-color@10.2.2):
+  mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0(supports-color@10.2.2):
+  mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0(supports-color@10.2.2)
-      mdast-util-gfm-strikethrough: 2.0.0(supports-color@10.2.2)
-      mdast-util-gfm-table: 2.0.0(supports-color@10.2.2)
-      mdast-util-gfm-task-list-item: 2.0.0(supports-color@10.2.2)
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1(supports-color@10.2.2):
+  mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0(supports-color@10.2.2):
+  mdast-util-mdx-jsx@3.2.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
@@ -8238,7 +8263,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -8247,23 +8272,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0(supports-color@10.2.2):
+  mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
-      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1(supports-color@10.2.2):
+  mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8307,20 +8332,20 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid-isomorphic@3.1.0(playwright@1.62.1)(supports-color@10.2.2):
+  mermaid-isomorphic@3.1.0(playwright@1.62.1):
     dependencies:
       '@fortawesome/fontawesome-free': 6.7.2
       katex: 0.16.22
-      mermaid: 11.6.0(supports-color@10.2.2)
+      mermaid: 11.6.0
     optionalDependencies:
       playwright: 1.62.1
     transitivePeerDependencies:
       - supports-color
 
-  mermaid@11.6.0(supports-color@10.2.2):
+  mermaid@11.6.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.1
-      '@iconify/utils': 2.3.0(supports-color@10.2.2)
+      '@iconify/utils': 2.3.0
       '@mermaid-js/parser': 0.4.0
       '@types/d3': 7.4.3
       cytoscape: 3.32.0
@@ -8584,10 +8609,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@10.2.2):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       decode-named-character-reference: 1.1.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -8642,9 +8667,9 @@ snapshots:
 
   nanoid@3.3.15: {}
 
-  needle@2.9.1(supports-color@10.2.2):
+  needle@2.9.1:
     dependencies:
-      debug: 3.2.7(supports-color@10.2.2)
+      debug: 3.2.7
       iconv-lite: 0.4.24
       sax: 1.6.0
     transitivePeerDependencies:
@@ -8867,11 +8892,11 @@ snapshots:
 
   prismjs@1.30.0: {}
 
-  probe-image-size@7.2.3(supports-color@10.2.2):
+  probe-image-size@7.2.3:
     dependencies:
       lodash.merge: 4.6.2
-      needle: 2.9.1(supports-color@10.2.2)
-      stream-parser: 0.3.1(supports-color@10.2.2)
+      needle: 2.9.1
+      stream-parser: 0.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -8959,11 +8984,11 @@ snapshots:
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
-  rehype-recma@1.0.0(supports-color@10.2.2):
+  rehype-recma@1.0.0:
     dependencies:
       '@types/estree': 1.0.8
       '@types/hast': 3.0.5
-      hast-util-to-estree: 3.1.3(supports-color@10.2.2)
+      hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
 
@@ -8983,28 +9008,28 @@ snapshots:
 
   relateurl@0.2.7: {}
 
-  remark-gfm@4.0.1(supports-color@10.2.2):
+  remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0(supports-color@10.2.2)
+      mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-mdx@3.1.0(supports-color@10.2.2):
+  remark-mdx@3.1.0:
     dependencies:
-      mdast-util-mdx: 3.0.0(supports-color@10.2.2)
+      mdast-util-mdx: 3.0.0
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0(supports-color@10.2.2):
+  remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@10.2.2)
+      mdast-util-from-markdown: 2.0.2
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9031,10 +9056,10 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remark@15.0.1(supports-color@10.2.2):
+  remark@15.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
@@ -9305,9 +9330,9 @@ snapshots:
 
   std-env@4.0.0: {}
 
-  stream-parser@0.3.1(supports-color@10.2.2):
+  stream-parser@0.3.1:
     dependencies:
-      debug: 2.6.9(supports-color@10.2.2)
+      debug: 2.6.9
     transitivePeerDependencies:
       - supports-color
 
@@ -9627,46 +9652,45 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  volar-service-css@0.0.70(@volar/language-service@2.4.28(typescript@6.0.3)):
+  volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-css-languageservice: 6.3.6
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28(typescript@6.0.3)
+      '@volar/language-service': 2.4.28
 
-  volar-service-emmet@0.0.70(@volar/language-service@2.4.28(typescript@6.0.3)):
+  volar-service-emmet@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       '@emmetio/css-parser': 0.4.1
       '@emmetio/html-matcher': 1.3.0
       '@vscode/emmet-helper': 2.11.0
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28(typescript@6.0.3)
+      '@volar/language-service': 2.4.28
 
-  volar-service-html@0.0.70(@volar/language-service@2.4.28(typescript@6.0.3)):
+  volar-service-html@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-html-languageservice: 5.6.2
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28(typescript@6.0.3)
+      '@volar/language-service': 2.4.28
 
-  volar-service-prettier@0.0.70(@volar/language-service@2.4.28(typescript@6.0.3))(prettier@3.6.2):
+  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.6.2):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28(typescript@6.0.3)
+      '@volar/language-service': 2.4.28
       prettier: 3.6.2
 
-  volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28(typescript@6.0.3))(typescript@6.0.3):
+  volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28(typescript@6.0.3)
-      typescript: 6.0.3
+      '@volar/language-service': 2.4.28
 
-  volar-service-typescript@0.0.70(@volar/language-service@2.4.28(typescript@6.0.3))(typescript@6.0.3):
+  volar-service-typescript@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       path-browserify: 1.0.1
       semver: 7.8.5
@@ -9675,15 +9699,14 @@ snapshots:
       vscode-nls: 5.2.0
       vscode-uri: 3.1.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28(typescript@6.0.3)
-      typescript: 6.0.3
+      '@volar/language-service': 2.4.28
 
-  volar-service-yaml@0.0.70(@volar/language-service@2.4.28(typescript@6.0.3)):
+  volar-service-yaml@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-uri: 3.1.0
       yaml-language-server: 1.20.0
     optionalDependencies:
-      '@volar/language-service': 2.4.28(typescript@6.0.3)
+      '@volar/language-service': 2.4.28
 
   vscode-css-languageservice@6.3.6:
     dependencies:


### PR DESCRIPTION
- Add createFaviconRoutes to @kkhys/og: one [file].ts route per app, with the PROD guard moved into getStaticPaths so static builds emit no favicon routes at all (previously dist/api/favicon/ shipped five "Not Found" bodies served as 200)
- Replace 15 identical per-app route files and 3 favicon wrappers with a 3-line route per app
- Split generateIcon into SVG/PNG variants, removing the union return type and five as casts
- Give packages/og a tsconfig, check/test scripts, and its first tests so recursive CI now covers it
- Update the affected CLAUDE.md sections