### PR TITLE
[main] refactor: extract seo truncation and parameterize images

### DIFF
--- a/packages/seo/package.json
+++ b/packages/seo/package.json
@@ -7,7 +7,19 @@
   "exports": {
     "./base-seo.astro": "./src/base-seo.astro",
     "./open-graph.astro": "./src/open-graph.astro",
+    "./pathname": "./src/pathname.ts",
+    "./truncate": "./src/truncate.ts",
     "./twitter-card.astro": "./src/twitter-card.astro"
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "vitest run",
+    "coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "astro": "^7.0.0"

--- a/packages/seo/src/base-seo.astro
+++ b/packages/seo/src/base-seo.astro
@@ -1,4 +1,7 @@
 ---
+import { normalizePathname } from "./pathname";
+import { truncateDescription } from "./truncate";
+
 interface Props {
   /** Final document title, emitted verbatim. */
   title: string;
@@ -23,11 +26,8 @@ const {
   ellipsis = false,
 } = Astro.props;
 
-const resolvedDescription =
-  ellipsis && description.length > descriptionMaxLength
-    ? `${description.slice(0, descriptionMaxLength - 3)}...`
-    : description.slice(0, descriptionMaxLength);
-const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
+const resolvedDescription = truncateDescription(description, descriptionMaxLength, ellipsis);
+const canonicalUrl = new URL(normalizePathname(Astro.url.pathname), Astro.site).href;
 const robotsContent = noindex
   ? robotsNofollow
     ? "noindex, nofollow"

--- a/packages/seo/src/open-graph.astro
+++ b/packages/seo/src/open-graph.astro
@@ -1,10 +1,20 @@
 ---
+import { normalizePathname } from "./pathname";
+import { truncateDescription } from "./truncate";
+
 interface Props {
   type?: "website" | "article" | "profile" | undefined;
   title: string;
   description: string;
-  image: string;
-  imageAlt: string;
+  /** Omit to emit no og:image block at all. */
+  image?: string | undefined;
+  imageAlt?: string | undefined;
+  /** og:image:type value. Defaults to "image/png". */
+  imageType?: string | undefined;
+  /** og:image:width value. Defaults to 1200. */
+  imageWidth?: number | undefined;
+  /** og:image:height value. Defaults to 630. */
+  imageHeight?: number | undefined;
   /** og:site_name value. */
   siteName: string;
   /** og:locale value. Defaults to "ja_JP". */
@@ -33,6 +43,9 @@ const {
   description,
   image,
   imageAlt,
+  imageType = "image/png",
+  imageWidth = 1200,
+  imageHeight = 630,
   siteName,
   locale = "ja_JP",
   descriptionMaxLength = 200,
@@ -41,29 +54,32 @@ const {
   article,
 } = Astro.props;
 
-const resolvedDescription =
-  ellipsis && description.length > descriptionMaxLength
-    ? `${description.slice(0, descriptionMaxLength - 3)}...`
-    : description.slice(0, descriptionMaxLength);
-const ogUrl = new URL(Astro.url.pathname, Astro.site).href;
+const resolvedDescription = truncateDescription(description, descriptionMaxLength, ellipsis);
+const ogUrl = new URL(normalizePathname(Astro.url.pathname), Astro.site).href;
 const secureUrl =
-  secureUrlMode === "always"
-    ? image
-    : image.startsWith("https://")
+  image === undefined
+    ? undefined
+    : secureUrlMode === "always"
       ? image
-      : undefined;
+      : image.startsWith("https://")
+        ? image
+        : undefined;
 ---
 
 <meta property="og:type" content={type} />
 <meta property="og:url" content={ogUrl} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={resolvedDescription} />
-<meta property="og:image" content={image} />
-{secureUrl && <meta property="og:image:secure_url" content={secureUrl} />}
-<meta property="og:image:type" content="image/png" />
-<meta property="og:image:width" content="1200" />
-<meta property="og:image:height" content="630" />
-<meta property="og:image:alt" content={imageAlt} />
+{image && (
+  <>
+    <meta property="og:image" content={image} />
+    {secureUrl && <meta property="og:image:secure_url" content={secureUrl} />}
+    <meta property="og:image:type" content={imageType} />
+    <meta property="og:image:width" content={String(imageWidth)} />
+    <meta property="og:image:height" content={String(imageHeight)} />
+    <meta property="og:image:alt" content={imageAlt ?? title} />
+  </>
+)}
 <meta property="og:site_name" content={siteName} />
 <meta property="og:locale" content={locale} />
 {type === "article" && article?.publishedTime && (

--- a/packages/seo/src/pathname.test.ts
+++ b/packages/seo/src/pathname.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { normalizePathname } from "./pathname";
+
+describe("normalizePathname", () => {
+  it("maps the built index page back to the site root", () => {
+    expect(normalizePathname("/index.html")).toBe("/");
+  });
+
+  it("maps a nested index page back to its directory", () => {
+    expect(normalizePathname("/blog/index.html")).toBe("/blog");
+  });
+
+  it("strips a .html suffix", () => {
+    expect(normalizePathname("/privacy.html")).toBe("/privacy");
+    expect(normalizePathname("/privacy/ja.html")).toBe("/privacy/ja");
+  });
+
+  it("strips a trailing slash", () => {
+    expect(normalizePathname("/blog/2/")).toBe("/blog/2");
+  });
+
+  it("keeps the root slash", () => {
+    expect(normalizePathname("/")).toBe("/");
+  });
+
+  it("leaves clean paths untouched", () => {
+    expect(normalizePathname("/blog")).toBe("/blog");
+  });
+});

--- a/packages/seo/src/pathname.ts
+++ b/packages/seo/src/pathname.ts
@@ -1,0 +1,11 @@
+/**
+ * Normalize an `Astro.url.pathname` to the URL the site is actually served
+ * under. Every app builds with `build.format: "file"`, so Astro reports
+ * `/index.html` and `/privacy.html` — emitting those verbatim in canonical /
+ * og:url tags contradicts the extensionless URLs the sitemap advertises.
+ */
+export const normalizePathname = (pathname: string): string => {
+  const withoutHtml = pathname.replace(/(?:index)?\.html$/u, "");
+  const withoutTrailingSlash = withoutHtml.replace(/(?<=.)\/$/u, "");
+  return withoutTrailingSlash === "" ? "/" : withoutTrailingSlash;
+};

--- a/packages/seo/src/truncate.test.ts
+++ b/packages/seo/src/truncate.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { truncateDescription } from "./truncate";
+
+describe("truncateDescription", () => {
+  it("returns short descriptions unchanged", () => {
+    expect(truncateDescription("hello", 200, false)).toBe("hello");
+    expect(truncateDescription("hello", 200, true)).toBe("hello");
+  });
+
+  it("keeps text exactly at the limit unchanged", () => {
+    expect(truncateDescription("abcde", 5, true)).toBe("abcde");
+  });
+
+  it("hard-slices without ellipsis", () => {
+    expect(truncateDescription("abcdefgh", 5, false)).toBe("abcde");
+  });
+
+  it("reserves room for the ellipsis", () => {
+    const result = truncateDescription("abcdefgh", 5, true);
+    expect(result).toBe("ab...");
+    expect(result).toHaveLength(5);
+  });
+
+  it("never slices with a negative index for tiny limits", () => {
+    expect(truncateDescription("abcdefgh", 2, true)).toBe("...");
+  });
+});

--- a/packages/seo/src/truncate.ts
+++ b/packages/seo/src/truncate.ts
@@ -1,0 +1,12 @@
+/**
+ * Clamp a meta description. With `ellipsis`, over-long text is cut to leave
+ * room for a trailing "..."; otherwise it is hard-sliced at `maxLength`.
+ */
+export const truncateDescription = (
+  description: string,
+  maxLength: number,
+  ellipsis: boolean,
+): string =>
+  ellipsis && description.length > maxLength
+    ? `${description.slice(0, Math.max(0, maxLength - 3))}...`
+    : description.slice(0, maxLength);

--- a/packages/seo/src/twitter-card.astro
+++ b/packages/seo/src/twitter-card.astro
@@ -1,8 +1,11 @@
 ---
+import { truncateDescription } from "./truncate";
+
 interface Props {
   title: string;
   description: string;
-  image: string;
+  /** Omit to emit a card without an image (e.g. a "summary" text card). */
+  image?: string | undefined;
   /** Defaults to `title`. */
   imageAlt?: string | undefined;
   /** twitter:site handle, e.g. "@kkhys_". */
@@ -10,7 +13,7 @@ interface Props {
   /** twitter:creator handle. Defaults to `site`. */
   creator?: string | undefined;
   /** twitter:card type. Defaults to "summary_large_image". */
-  card?: string | undefined;
+  card?: "summary" | "summary_large_image" | undefined;
   descriptionMaxLength?: number | undefined;
   ellipsis?: boolean | undefined;
 }
@@ -29,10 +32,7 @@ const {
 
 const resolvedImageAlt = imageAlt ?? title;
 const resolvedCreator = creator ?? site;
-const resolvedDescription =
-  ellipsis && description.length > descriptionMaxLength
-    ? `${description.slice(0, descriptionMaxLength - 3)}...`
-    : description.slice(0, descriptionMaxLength);
+const resolvedDescription = truncateDescription(description, descriptionMaxLength, ellipsis);
 ---
 
 <meta name="twitter:card" content={card} />
@@ -40,5 +40,9 @@ const resolvedDescription =
 <meta name="twitter:creator" content={resolvedCreator} />
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={resolvedDescription} />
-<meta name="twitter:image" content={image} />
-<meta name="twitter:image:alt" content={resolvedImageAlt} />
+{image && (
+  <>
+    <meta name="twitter:image" content={image} />
+    <meta name="twitter:image:alt" content={resolvedImageAlt} />
+  </>
+)}

--- a/packages/seo/tsconfig.json
+++ b/packages/seo/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext"],
+    "types": [],
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,7 +511,17 @@ importers:
     dependencies:
       astro:
         specifier: ^7.0.0
-        version: 7.0.7(@astrojs/markdown-remark@7.2.1)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
 
   packages/styles: {}
 
@@ -597,9 +607,6 @@ packages:
   '@astrojs/compiler@2.13.1':
     resolution: {integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==}
 
-  '@astrojs/internal-helpers@0.10.1':
-    resolution: {integrity: sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==}
-
   '@astrojs/internal-helpers@0.10.2':
     resolution: {integrity: sha512-yt7fMgPYqSM4Tmr+taTW6Per+hjJ8Pk6lA1PAcDyqzOt8HzJ6Kje5WzCxA2Sd+9wsUW7uhkLeoTMK0cXPwH9rQ==}
 
@@ -615,14 +622,8 @@ packages:
       prettier-plugin-astro:
         optional: true
 
-  '@astrojs/markdown-remark@7.2.1':
-    resolution: {integrity: sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==}
-
   '@astrojs/markdown-remark@7.2.2':
     resolution: {integrity: sha512-FGfmK84zSNcrsBd0dl1gXE9JvZYElp8EXQa2jpHVAxG4deGKAp43wspxFupjADJX7MSsMRHwYCnfT6EyVmgeFQ==}
-
-  '@astrojs/markdown-satteri@0.3.3':
-    resolution: {integrity: sha512-Lje33Ittd8UQGgbIIWQvhPkj5X5c4b1sZnZWX3JQV/AWpfbuQGxVi2ONt6+ScydcwfR4egilslEWyczMclrJ1g==}
 
   '@astrojs/markdown-satteri@0.3.5':
     resolution: {integrity: sha512-CvWVEFAbay7YO+i9SaqDJubipA5ckiVB89QWoMJ5XC0m5CtFg8JwZ7Kau6X9sYY7FZURH0w2l03ISH2jOS/RDQ==}
@@ -1834,15 +1835,6 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@rollup/pluginutils@5.3.0':
-    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
     engines: {node: '>=20'}
@@ -2232,16 +2224,6 @@ packages:
     resolution: {integrity: sha512-DT1LnCqbHasBKlvzJ3m6LR4VI94wwx3W9EV/YbP1te4rqjOHsvsezHYuqb5MeLWLftXms/1FA9QBbwCo43DnJQ==}
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta || ^7.0.0
-
-  astro@7.0.7:
-    resolution: {integrity: sha512-swqrKDSI/B83GFroYPZYMFcxqbSe9+tkynu1WDBk3GLgBfV9++qVM4Z+2uFT6uu9A53Q0TROnxLketfMEENuqQ==}
-    engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
-    hasBin: true
-    peerDependencies:
-      '@astrojs/markdown-remark': 7.2.1
-    peerDependenciesMeta:
-      '@astrojs/markdown-remark':
-        optional: true
 
   astro@7.2.0:
     resolution: {integrity: sha512-lLTYzx3fOvCmtwD3JVBLQcbORbIOW1/j0R+3IvJx/XKwMGrk7mFnF0BYSOeRiNw1qHUR5mdA6+hRnyvyDfqrWQ==}
@@ -2845,9 +2827,6 @@ packages:
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
-  estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -3148,10 +3127,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
@@ -3560,10 +3535,6 @@ packages:
     resolution: {integrity: sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==}
     engines: {node: '>= 4.4.x'}
     hasBin: true
-
-  neotraverse@0.6.18:
-    resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
-    engines: {node: '>= 10'}
 
   neotraverse@1.0.1:
     resolution: {integrity: sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==}
@@ -4059,11 +4030,6 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  svgo@4.0.1:
-    resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
-    engines: {node: '>=16'}
-    hasBin: true
 
   svgo@4.0.2:
     resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
@@ -4694,17 +4660,6 @@ snapshots:
 
   '@astrojs/compiler@2.13.1': {}
 
-  '@astrojs/internal-helpers@0.10.1':
-    dependencies:
-      '@types/hast': 3.0.5
-      '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
-      picomatch: 4.0.4
-      retext-smartypants: 6.2.0
-      shiki: 4.0.2
-      smol-toml: 1.6.0
-      unified: 11.0.5
-
   '@astrojs/internal-helpers@0.10.2':
     dependencies:
       '@types/hast': 3.0.5
@@ -4741,29 +4696,6 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@astrojs/markdown-remark@7.2.1':
-    dependencies:
-      '@astrojs/internal-helpers': 0.10.1
-      '@astrojs/prism': 4.0.2
-      github-slugger: 2.0.0
-      hast-util-from-html: 2.0.3
-      hast-util-to-text: 4.0.2
-      mdast-util-definitions: 6.0.0
-      rehype-raw: 7.0.0
-      rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      remark-smartypants: 3.0.2
-      unified: 11.0.5
-      unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.1.0
-      unist-util-visit-parents: 6.0.2
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@astrojs/markdown-remark@7.2.2':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
@@ -4785,13 +4717,6 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  '@astrojs/markdown-satteri@0.3.3':
-    dependencies:
-      '@astrojs/internal-helpers': 0.10.1
-      '@astrojs/prism': 4.0.2
-      github-slugger: 2.0.0
-      satteri: 0.9.3
 
   '@astrojs/markdown-satteri@0.3.5':
     dependencies:
@@ -5806,12 +5731,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/pluginutils@5.3.0':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.4
-
   '@shikijs/core@4.0.2':
     dependencies:
       '@shikijs/primitive': 4.0.2
@@ -6265,99 +6184,6 @@ snapshots:
       astro: 7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
       rehype-expressive-code: 0.44.1
       url-extras: 0.1.0
-
-  astro@7.0.7(@astrojs/markdown-remark@7.2.1)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2):
-    dependencies:
-      '@astrojs/compiler-rs': 0.3.2
-      '@astrojs/internal-helpers': 0.10.1
-      '@astrojs/markdown-satteri': 0.3.3
-      '@astrojs/telemetry': 3.3.3
-      '@capsizecss/unpack': 4.0.0
-      '@clack/prompts': 1.1.0
-      '@oslojs/encoding': 1.1.0
-      '@rollup/pluginutils': 5.3.0
-      am-i-vibing: 0.4.0
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      ci-info: 4.4.0
-      clsx: 2.1.1
-      common-ancestor-path: 2.0.0
-      cookie: 1.1.1
-      devalue: 5.8.1
-      diff: 8.0.3
-      dset: 3.1.4
-      es-module-lexer: 2.0.0
-      esbuild: 0.28.1
-      flattie: 1.1.1
-      fontace: 0.4.1
-      get-tsconfig: 5.0.0-beta.4
-      github-slugger: 2.0.0
-      html-escaper: 3.0.3
-      http-cache-semantics: 4.2.0
-      js-yaml: 4.1.1
-      jsonc-parser: 3.3.1
-      magic-string: 0.30.21
-      magicast: 0.5.2
-      mrmime: 2.0.1
-      neotraverse: 0.6.18
-      obug: 2.1.1
-      p-limit: 7.3.0
-      p-queue: 9.1.0
-      package-manager-detector: 1.6.0
-      piccolore: 0.1.3
-      picomatch: 4.0.4
-      semver: 7.8.5
-      shiki: 4.0.2
-      smol-toml: 1.6.0
-      svgo: 4.0.1
-      tinyclip: 0.1.12
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.17
-      ultrahtml: 1.6.0
-      unifont: 0.7.4
-      unstorage: 1.17.5
-      vite: 8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2)
-      vitefu: 1.1.2(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
-      xxhash-wasm: 1.1.0
-      yargs-parser: 22.0.0
-      zod: 4.3.6
-    optionalDependencies:
-      '@astrojs/markdown-remark': 7.2.1
-      sharp: 0.35.3(@types/node@26.1.2)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@types/node'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - aws4fetch
-      - db0
-      - idb-keyval
-      - ioredis
-      - jiti
-      - less
-      - rollup
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - uploadthing
-      - yaml
 
   astro@7.2.0(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2):
     dependencies:
@@ -7139,8 +6965,6 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
-  estree-walker@2.0.2: {}
-
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -7556,10 +7380,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.3.0:
     dependencies:
@@ -8240,8 +8060,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  neotraverse@0.6.18: {}
-
   neotraverse@1.0.1: {}
 
   nlcst-to-string@4.0.0:
@@ -8911,16 +8729,6 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
-
-  svgo@4.0.1:
-    dependencies:
-      commander: 11.1.0
-      css-select: 5.1.0
-      css-tree: 3.1.0
-      css-what: 6.1.0
-      csso: 5.0.5
-      picocolors: 1.1.1
-      sax: 1.6.0
 
   svgo@4.0.2:
     dependencies:


### PR DESCRIPTION
- Extract the truncation expression duplicated across all three seo components into truncateDescription, guarding the negative-slice edge for limits under 3
- Make image props optional and og:image type/width/height configurable so non-1200x630-PNG consumers can adopt the shared primitives
- Add the package's first tests plus check/test scripts so recursive CI covers it