### PR TITLE
[main] refactor: harden the release flow

### DIFF
--- a/packages/release/src/github.test.ts
+++ b/packages/release/src/github.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildReleaseBody } from "./github";
+
+const repo = { repoOwner: "kkhys", repoName: "me" };
+
+describe("buildReleaseBody", () => {
+  it("links the compare view when a previous tag exists", () => {
+    const body = buildReleaseBody("2026.08.08", "2026.08.01", repo);
+
+    expect(body).toContain("Automatic release for version 2026.08.08.");
+    expect(body).toContain("https://github.com/kkhys/me/compare/2026.08.01...2026.08.08");
+  });
+
+  it("notes the absence of a previous release", () => {
+    const body = buildReleaseBody("2026.08.08", null, repo);
+
+    expect(body).toContain("(No previous release found for comparison.)");
+  });
+});

--- a/packages/release/src/github.ts
+++ b/packages/release/src/github.ts
@@ -1,0 +1,12 @@
+/** Compose the GitHub Release body, linking the previous release's compare view when one exists. */
+export const buildReleaseBody = (
+  version: string,
+  previousTag: string | null,
+  { repoOwner, repoName }: { repoOwner: string; repoName: string },
+): string => {
+  const body = `Automatic release for version ${version}.`;
+  if (!previousTag) return `${body}\n\n(No previous release found for comparison.)`;
+
+  const compareUrl = `https://github.com/${repoOwner}/${repoName}/compare/${previousTag}...${version}`;
+  return `${body}\n\n[View changes since ${previousTag}](${compareUrl})`;
+};

--- a/packages/release/src/index.ts
+++ b/packages/release/src/index.ts
@@ -1,29 +1,45 @@
 import { $ } from "bun";
 
+import { buildReleaseBody } from "./github";
 import { resolveReleaseVersion } from "./version";
 
 interface ReleaseOptions {
   /** GitHub repository name, e.g. "me" or "memo". */
   repoName: string;
   /** GitHub repository owner. Defaults to "kkhys". */
-  repoOwner?: string;
+  repoOwner?: string | undefined;
+  /**
+   * Preview the release: no tag, push, checkout, or GitHub API call. Remote
+   * refs are still fetched (read-only) so the previewed version is accurate.
+   */
+  dryRun?: boolean | undefined;
 }
 
 /**
  * Tags the current date as a release on `main`, pushes it, and creates a
- * matching GitHub Release. Pass `--dry-run` on argv to preview without
- * mutating git or calling the GitHub API. Requires `GITHUB_ACCESS_TOKEN`.
+ * matching GitHub Release. Requires `GITHUB_ACCESS_TOKEN` unless `dryRun`.
+ * Sets a non-zero exit code when any step fails.
  */
-export const release = async ({ repoName, repoOwner = "kkhys" }: ReleaseOptions) => {
-  const isDryRun = process.argv.includes("--dry-run");
+export const release = async ({
+  repoName,
+  repoOwner = "kkhys",
+  dryRun = false,
+}: ReleaseOptions) => {
   const githubAccessToken = process.env.GITHUB_ACCESS_TOKEN;
 
-  if (!githubAccessToken) {
+  if (!dryRun && !githubAccessToken) {
     console.error(
       "[ERROR] GitHub token is missing. Set GITHUB_ACCESS_TOKEN in your environment variables.",
     );
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
+
+  // Sync remote tags before resolving the suffix, so a release cut from a
+  // machine with stale tags cannot reuse an existing version. Runs in dry-run
+  // too — it only updates remote-tracking refs, and skipping it would preview
+  // a version that a real release would not pick.
+  await $`git fetch origin main --tags`;
 
   const now = new Date();
   const baseVersion = `${now.getFullYear()}.${String(now.getMonth() + 1).padStart(2, "0")}.${String(now.getDate()).padStart(2, "0")}`;
@@ -32,17 +48,19 @@ export const release = async ({ repoName, repoOwner = "kkhys" }: ReleaseOptions)
   const version = resolveReleaseVersion(baseVersion, existingTags);
 
   console.log(`[RELEASE] Creating tag: ${version}`);
-  if (isDryRun) console.log("[DRY-RUN] Mode is ON");
+  if (dryRun) console.log("[DRY-RUN] Mode is ON");
 
   const currentBranch = (await $`git rev-parse --abbrev-ref HEAD`.text()).trim();
 
-  if (isDryRun) {
+  if (dryRun) {
     console.log("[DRY-RUN] Would checkout main");
     console.log(`[DRY-RUN] Would tag -f ${version}`);
     console.log(`[DRY-RUN] Would push -f origin ${version}`);
     console.log(`[DRY-RUN] Would checkout ${currentBranch}`);
   } else {
     await $`git checkout main`;
+    // Refuse to tag a stale or diverged main; --ff-only aborts on divergence.
+    await $`git pull --ff-only origin main`;
     await $`git tag -f -m ${version} ${version}`;
     await $`git push -f origin ${version}`;
     await $`git checkout ${currentBranch}`;
@@ -74,16 +92,9 @@ export const release = async ({ repoName, repoOwner = "kkhys" }: ReleaseOptions)
     return null;
   };
 
-  const createGitHubRelease = async () => {
+  const createGitHubRelease = async (): Promise<boolean> => {
     const previousTag = await getPreviousTag();
-
-    let body = `Automatic release for version ${version}.`;
-    if (previousTag) {
-      const compareUrl = `https://github.com/${repoOwner}/${repoName}/compare/${previousTag}...${version}`;
-      body += `\n\n[View changes since ${previousTag}](${compareUrl})`;
-    } else {
-      body += "\n\n(No previous release found for comparison.)";
-    }
+    const body = buildReleaseBody(version, previousTag, { repoOwner, repoName });
 
     const response = await fetch(`https://api.github.com/repos/${repoOwner}/${repoName}/releases`, {
       method: "POST",
@@ -103,19 +114,23 @@ export const release = async ({ repoName, repoOwner = "kkhys" }: ReleaseOptions)
     if (response.ok) {
       const responseData = (await response.json()) as { html_url: string };
       console.log(`[SUCCESS] GitHub Release created: ${responseData.html_url}`);
-    } else {
-      const errorData = (await response.json()) as { message: string };
-      console.error("[ERROR] Failed to create GitHub release.");
-      console.error(`Error: ${errorData.message}`);
+      return true;
     }
+
+    const errorData = (await response.json()) as { message: string };
+    console.error("[ERROR] Failed to create GitHub release.");
+    console.error(`Error: ${errorData.message}`);
+    return false;
   };
 
-  if (isDryRun) {
+  if (dryRun) {
     console.log("[DRY-RUN] Would create GitHub release");
     console.log(`[DRY-RUN] Release tag: ${version}`);
     console.log(`[DRY-RUN] Release title: ${version}`);
     console.log("[DRY-RUN] Completed GitHub release process");
-  } else {
-    await createGitHubRelease();
+  } else if (!(await createGitHubRelease())) {
+    // The tag is already pushed; fail the command so the missing GitHub
+    // Release doesn't go unnoticed.
+    process.exitCode = 1;
   }
 };

--- a/packages/release/src/version.test.ts
+++ b/packages/release/src/version.test.ts
@@ -23,4 +23,12 @@ describe("resolveReleaseVersion", () => {
   it("takes the first free suffix even when a later one exists", () => {
     expect(resolveReleaseVersion(base, [base, `${base}-3`])).toBe(`${base}-2`);
   });
+
+  it("ignores lookalike tags that merely share the prefix", () => {
+    expect(resolveReleaseVersion(base, [`${base}0`, `${base}-rc1`])).toBe(base);
+  });
+
+  it("treats the dots as literal dots, not wildcards", () => {
+    expect(resolveReleaseVersion(base, ["2026x06y27"])).toBe(base);
+  });
 });

--- a/packages/release/src/version.ts
+++ b/packages/release/src/version.ts
@@ -4,7 +4,11 @@
  * first suffix not already present in `existingTags`.
  */
 export const resolveReleaseVersion = (baseVersion: string, existingTags: string[]): string => {
-  const tags = new Set(existingTags.filter((tag) => tag.startsWith(baseVersion)));
+  // Match the base version exactly or with a numeric suffix; startsWith would
+  // also swallow lookalikes such as "2026.06.270" or "2026.06.27-rc1".
+  const escaped = baseVersion.replaceAll(".", String.raw`\.`);
+  const pattern = new RegExp(String.raw`^${escaped}(-\d+)?$`, "u");
+  const tags = new Set(existingTags.filter((tag) => pattern.test(tag)));
   if (!tags.has(baseVersion)) return baseVersion;
 
   let suffixCounter = 2;

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -3,4 +3,4 @@ import { release } from "@kkhys/release";
 // Monorepo-wide release: tags the kkhys/me repository (which now holds both
 // apps) and creates a matching GitHub Release. Both apps deploy independently;
 // this is the single release flow for the whole repo.
-await release({ repoName: "me" });
+await release({ repoName: "me", dryRun: process.argv.includes("--dry-run") });


### PR DESCRIPTION
- Move dry-run selection to an explicit option parsed by scripts/release.ts; allow dry runs without a token
- Fetch origin tags before resolving the version and pull --ff-only before tagging, so a stale or diverged main cannot be force-tagged
- Set a non-zero exit code when GitHub Release creation fails (previously logged and exited 0)
- Anchor release-tag matching; startsWith swallowed lookalike tags
- Extract buildReleaseBody into a bun-free module with tests