### PR TITLE
[main] refactor: preserve literal types through me blog config

### DIFF
--- a/apps/me/public/manifest.webmanifest
+++ b/apps/me/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Keisuke Hayashi",
   "short_name": "Keisuke Hayashi",
-  "description": "Keisuke Hayashiの 個人サイト",
+  "description": "Keisuke Hayashiの個人サイト",
   "start_url": "/",
   "scope": "/",
   "icons": [

--- a/apps/me/src/__tests__/lib/json-ld.test.ts
+++ b/apps/me/src/__tests__/lib/json-ld.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { TagTitle } from "#/features/blog/config/tag";
 import { getBlogPostingSchema, websiteSchema } from "#/lib/json-ld";
 
 describe("websiteSchema", () => {
@@ -43,7 +44,8 @@ describe("getBlogPostingSchema", () => {
   });
 
   it("throws error for invalid category", () => {
-    const invalidData = { ...baseData, category: "Invalid" };
+    // Cast past the literal type: the guard under test is runtime behavior.
+    const invalidData = { ...baseData, category: "Invalid" as typeof baseData.category };
     expect(() =>
       getBlogPostingSchema({
         id: "test123",
@@ -67,7 +69,8 @@ describe("getBlogPostingSchema", () => {
   it("falls back to raw tag title when tag is not found in config", () => {
     const schema = getBlogPostingSchema({
       id: "test123",
-      data: { ...baseData, tags: ["NonExistentTag"] },
+      // Cast past the literal type: the fallback under test is runtime behavior.
+      data: { ...baseData, tags: ["NonExistentTag" as TagTitle] },
       description: "test",
     });
 

--- a/apps/me/src/components/ui/site-nav.astro
+++ b/apps/me/src/components/ui/site-nav.astro
@@ -1,10 +1,9 @@
 ---
 import MoveUpRightIcon from "#/components/icons/move-up-right.svg";
 import { navItems } from "#/config/navigation";
+import { normalizePathname } from "@kkhys/seo/pathname";
 
-// Static builds can serve `/blog/2` as `/blog/2/` or `/blog/2.html` depending
-// on the build format, so normalize before matching.
-const pathname = Astro.url.pathname.replace(/\.html$/u, "").replace(/(?<=.)\/$/u, "");
+const pathname = normalizePathname(Astro.url.pathname);
 
 const isActive = (href: string) =>
   href === "/" ? pathname === "/" : pathname === href || pathname.startsWith(`${href}/`);

--- a/apps/me/src/content.config.ts
+++ b/apps/me/src/content.config.ts
@@ -17,13 +17,11 @@ const blog = defineCollection({
   schema: z.object({
     title: z.string(),
     emoji: z.string(),
-    category: z.enum(categoryTitles as [string, ...string[]]),
-    tags: z.array(z.enum(allTagTitles as [string, ...string[]])).optional(),
+    category: z.enum(categoryTitles),
+    tags: z.array(z.enum(allTagTitles)).optional(),
     status: z.enum(["draft", "published"]).default("draft"),
     publishedAt: z.date(),
-    publishedAtString: z.string().optional(),
     updatedAt: z.date().optional(),
-    updatedAtString: z.string().optional(),
   }),
 });
 
@@ -56,9 +54,9 @@ const externalPost = defineCollection({
   schema: z.object({
     title: z.string(),
     url: z.url(),
-    siteName: z.enum(externalSites as [string, ...string[]]),
-    category: z.enum(categoryTitles as [string, ...string[]]),
-    tags: z.array(z.enum(allTagTitles as [string, ...string[]])).optional(),
+    siteName: z.enum(externalSites),
+    category: z.enum(categoryTitles),
+    tags: z.array(z.enum(allTagTitles)).optional(),
     publishedAt: z.date(),
   }),
 });

--- a/apps/me/src/features/blog/components/ui/category-navigation.astro
+++ b/apps/me/src/features/blog/components/ui/category-navigation.astro
@@ -1,16 +1,18 @@
 ---
 import type { HTMLAttributes } from "astro/types";
 import { categories } from "#/features/blog/config/category";
+import { normalizePathname } from "@kkhys/seo/pathname";
 
 interface Props extends HTMLAttributes<"div"> {}
 
 const { class: className, ...rest } = Astro.props;
 
-const pathname = Astro.url.pathname;
+const pathname = normalizePathname(Astro.url.pathname);
+const isBlogRoot = /^\/blog(\/\d+)?$/u.test(pathname);
 ---
 
 <nav class:list={['category-scroll palt', className]} {...rest}>
-  {/^\/blog(\/\d+)?(\.html)?\/?$/.test(pathname) ? (
+  {isBlogRoot ? (
       <span class="cat-link cat-link--active">
       すべて
     </span>
@@ -20,7 +22,7 @@ const pathname = Astro.url.pathname;
       </a>
   )}
   {categories.map(({ slug, label }) => (
-    pathname?.startsWith(`/blog/categories/${slug}`) ? (
+    pathname.startsWith(`/blog/categories/${slug}`) ? (
         <span class="cat-link cat-link--active">
       {label}
     </span>

--- a/apps/me/src/features/blog/components/ui/div-handler.astro
+++ b/apps/me/src/features/blog/components/ui/div-handler.astro
@@ -1,4 +1,3 @@
-
 ---
 import type { HTMLAttributes } from "astro/types";
 import type { AlertType } from "#/features/blog/components/ui/blocks/alert-block.astro";

--- a/apps/me/src/features/blog/config/category.ts
+++ b/apps/me/src/features/blog/config/category.ts
@@ -28,7 +28,11 @@ export const categories = [
   },
 ] as const satisfies Category[];
 
-export const categoryTitles = categories.map(({ title }) => title);
+// Restore the tuple shape map() erases so z.enum keeps the literal types.
+export const categoryTitles = categories.map(({ title }) => title) as [
+  CategoryTitle,
+  ...CategoryTitle[],
+];
 
 export const getCategoryBySlug = (slug: string) =>
   categories.find((category) => category.slug === slug);

--- a/apps/me/src/features/blog/config/external-site.ts
+++ b/apps/me/src/features/blog/config/external-site.ts
@@ -1,3 +1,2 @@
-const externalSitesConst = ["Hatena", "note", "Zenn"] as const;
-export type ExternalSite = (typeof externalSitesConst)[number];
-export const externalSites: ExternalSite[] = [...externalSitesConst];
+export const externalSites = ["Hatena", "note", "Zenn"] as const;
+export type ExternalSite = (typeof externalSites)[number];

--- a/apps/me/src/features/blog/config/tag.ts
+++ b/apps/me/src/features/blog/config/tag.ts
@@ -225,7 +225,10 @@ export const tags = [
   },
 ] as const satisfies Tag[];
 
-export const allTagTitles = tags.map(({ title }) => title);
+export type TagTitle = (typeof tags)[number]["title"];
+
+// Restore the tuple shape map() erases so z.enum keeps the literal types.
+export const allTagTitles = tags.map(({ title }) => title) as [TagTitle, ...TagTitle[]];
 
 export const getTagBySlug = (slug: string) => tags.find((tag) => tag.slug === slug);
 

--- a/apps/me/src/features/blog/utils/entry.ts
+++ b/apps/me/src/features/blog/utils/entry.ts
@@ -53,7 +53,7 @@ export const toListEntries = (blogEntries: CollectionEntry<"blog">[]): ListEntry
 const toExternalEntry = (data: {
   title: string;
   url: string;
-  siteName: string;
+  siteName: ExternalSite;
   category: string;
   tags?: string[] | undefined;
   publishedAt: Date;
@@ -61,7 +61,7 @@ const toExternalEntry = (data: {
   type: "external",
   title: data.title,
   url: data.url,
-  siteName: data.siteName as ExternalSite,
+  siteName: data.siteName,
   category: data.category,
   tags: data.tags,
   publishedAt: data.publishedAt,

--- a/apps/me/src/layouts/blog-layout.astro
+++ b/apps/me/src/layouts/blog-layout.astro
@@ -11,7 +11,7 @@ import EntryList from "#/features/blog/components/ui/entry-list.astro";
 import PostNavigation from "#/features/blog/components/ui/post-navigation.astro";
 import TagCloud from "#/features/blog/components/ui/tag-cloud.astro";
 import Toc from "#/features/blog/components/ui/toc.astro";
-import { getCategoryBySlug } from "#/features/blog/config/category";
+import { getCategoryByTitle } from "#/features/blog/config/category";
 import { tags as allTags } from "#/features/blog/config/tag";
 import { getRelatedPosts, type PostNavItem, toListEntries } from "#/features/blog/utils/entry";
 import BaseLayout from "#/layouts/base-layout.astro";
@@ -20,6 +20,8 @@ import { BASE_URL } from "#/utils/base-url";
 interface Props extends InferEntrySchema<"blog"> {
   id: string;
   description: string;
+  publishedAtString: string;
+  updatedAtString?: string | undefined;
   headings: MarkdownHeading[];
   newerPost: PostNavItem | undefined;
   olderPost: PostNavItem | undefined;
@@ -45,11 +47,10 @@ const {
 const updatedInfo =
   updatedAt && updatedAtString ? { date: updatedAt, label: updatedAtString } : undefined;
 
-const categorySlug = category.toLowerCase();
-const categoryObject = getCategoryBySlug(categorySlug);
+const categoryObject = getCategoryByTitle(category);
 
 if (!categoryObject) {
-  throw new Error(`Category "${categorySlug}" not found`);
+  throw new Error(`Category "${category}" not found`);
 }
 
 const allTagCloudItems = await Promise.all(
@@ -63,7 +64,7 @@ const allTagCloudItems = await Promise.all(
 );
 
 const tagCloudItems = allTagCloudItems.filter(({ title: tagTitle }) =>
-  tags?.includes(tagTitle as (typeof tags)[number]),
+  tags?.includes(tagTitle),
 );
 
 const relatedPosts = await getRelatedPosts({ id, category, tags });

--- a/apps/me/src/lib/json-ld.ts
+++ b/apps/me/src/lib/json-ld.ts
@@ -1,7 +1,8 @@
 import type { CollectionEntry } from "astro:content";
 import type { BlogPosting, Person, WebSite, WithContext } from "schema-dts";
 
-import { me, siteConfig } from "#/config/site.ts";
+import { me, siteConfig } from "#/config/site";
+import { BASE_URL } from "#/utils/base-url";
 import { getCategoryByTitle } from "#/features/blog/config/category";
 import { getTagByTitle } from "#/features/blog/config/tag";
 
@@ -9,8 +10,8 @@ const personSchema: WithContext<Person> = {
   "@context": "https://schema.org",
   "@type": "Person",
   name: me.name,
-  url: import.meta.env.SITE,
-  image: `${import.meta.env.SITE}/images/avatar.jpg`,
+  url: BASE_URL,
+  image: `${BASE_URL}/images/avatar.jpg`,
   sameAs: [me.memo],
   jobTitle: "Software engineer",
   worksFor: {
@@ -23,7 +24,7 @@ const personSchema: WithContext<Person> = {
 export const websiteSchema: WithContext<WebSite> = {
   "@context": "https://schema.org",
   "@type": "WebSite",
-  url: import.meta.env.SITE,
+  url: BASE_URL,
   name: siteConfig.title,
   description: siteConfig.description,
   inLanguage: "ja_JP",
@@ -46,14 +47,14 @@ export const getBlogPostingSchema = ({
     "@context": "https://schema.org",
     "@type": "BlogPosting",
     headline: data.title,
-    url: `${import.meta.env.SITE}/blog/posts/${id}`,
+    url: `${BASE_URL}/blog/posts/${id}`,
     mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": `${import.meta.env.SITE}/blog/posts/${id}`,
+      "@id": `${BASE_URL}/blog/posts/${id}`,
     },
     image: {
       "@type": "ImageObject",
-      url: `${import.meta.env.SITE}/api/og/${id}.png`,
+      url: `${BASE_URL}/api/og/${id}.png`,
     },
     description,
     publisher: personSchema,

--- a/apps/me/src/pages/blog/posts/[id].astro
+++ b/apps/me/src/pages/blog/posts/[id].astro
@@ -8,6 +8,7 @@ import { getCategoryByTitle } from "#/features/blog/config/category";
 import { getPublicBlogEntries, toPostNavItem } from "#/features/blog/utils/entry";
 import BlogLayout from "#/layouts/blog-layout.astro";
 import { getBlogPostingSchema } from "#/lib/json-ld";
+import { BASE_URL } from "#/utils/base-url";
 import { convertDateToString } from "#/utils/date";
 import { extractDescription } from "#/utils/extract-description";
 
@@ -56,19 +57,19 @@ const breadcrumbSchema: WithContext<BreadcrumbList> = {
       "@type": "ListItem",
       position: 1,
       name: "Blog",
-      item: `${import.meta.env.SITE}/blog`,
+      item: `${BASE_URL}/blog`,
     },
     {
       "@type": "ListItem",
       position: 2,
       name: categoryObject.label,
-      item: `${import.meta.env.SITE}/blog/categories/${categoryObject.slug}`,
+      item: `${BASE_URL}/blog/categories/${categoryObject.slug}`,
     },
     {
       "@type": "ListItem",
       position: 3,
       name: entry.data.title,
-      item: `${import.meta.env.SITE}/blog/posts/${entry.id}`,
+      item: `${BASE_URL}/blog/posts/${entry.id}`,
     },
   ],
 };

--- a/apps/me/src/pages/blog/tags/[tag]/[...page].astro
+++ b/apps/me/src/pages/blog/tags/[tag]/[...page].astro
@@ -6,6 +6,7 @@ import { countPerPage } from "#/config/constant";
 import BlogIndex from "#/features/blog/components/ui/blog-index.astro";
 import { getTagBySlug } from "#/features/blog/config/tag";
 import { getPublicListEntries } from "#/features/blog/utils/entry";
+import { BASE_URL } from "#/utils/base-url";
 
 export const getStaticPaths = async ({
   paginate,
@@ -42,13 +43,13 @@ const breadcrumbSchema: WithContext<BreadcrumbList> = {
       "@type": "ListItem",
       position: 1,
       name: "Blog",
-      item: `${import.meta.env.SITE}/blog`,
+      item: `${BASE_URL}/blog`,
     },
     {
       "@type": "ListItem",
       position: 2,
       name: tag.label,
-      item: `${import.meta.env.SITE}/blog/tags/${tag.slug}`,
+      item: `${BASE_URL}/blog/tags/${tag.slug}`,
     },
   ],
 };

--- a/apps/me/src/pages/llms.txt.ts
+++ b/apps/me/src/pages/llms.txt.ts
@@ -9,11 +9,11 @@ const getLlmsTxt = () => `# ${siteConfig.title}'s website
 
 ## Blog
 
-${blogEntries.map((entry) => `- [${entry.data.title}](${import.meta.env.SITE}/blog/posts/${entry.id})`).join("\n")}
+${blogEntries.map((entry) => `- [${entry.data.title}](${BASE_URL}/blog/posts/${entry.id})`).join("\n")}
 
 ## Other
 
-- [About me](${import.meta.env.SITE}/about)
+- [About me](${BASE_URL}/about)
 
 ## Contact & Social
 

--- a/apps/me/src/pages/rss.xml.ts
+++ b/apps/me/src/pages/rss.xml.ts
@@ -2,7 +2,7 @@ import rss from "@astrojs/rss";
 
 import type { APIContext } from "astro";
 import { siteConfig } from "#/config/site";
-import { getCategoryBySlug } from "#/features/blog/config/category";
+import { getCategoryByTitle } from "#/features/blog/config/category";
 import { getPublicBlogEntries } from "#/features/blog/utils/entry";
 import { extractDescription } from "#/utils/extract-description";
 
@@ -17,6 +17,6 @@ export const GET = async (context: APIContext) =>
       description: extractDescription(body ?? ""),
       pubDate: data.publishedAt,
       link: `/blog/posts/${id}`,
-      categories: [getCategoryBySlug(data.category.toLowerCase())?.label ?? ""],
+      categories: [getCategoryByTitle(data.category)?.label ?? ""],
     })),
   });


### PR DESCRIPTION
- Publish categoryTitles/allTagTitles/externalSites as literal tuples so the z.enum casts and every downstream as-cast (siteName, tag titles) fall away; category/tags now infer as literal unions
- Drop the display-only publishedAtString/updatedAtString fields from the blog schema; the post page computes them locally
- Look up categories by title instead of assuming slug == lowercased title
- Extract a tested normalizePathname shared by site-nav and category-navigation, moving the latter's regex out of the template (now linted, with the u flag)
- Route JSON-LD and llms.txt URLs through BASE_URL; fix the one extension-suffixed import and two cosmetic strays