### PR TITLE
[main] refactor: unify fixture switching on USE_FIXTURE_DATA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
     # Verify the code against fixtures and skip the heavy content submodules.
-    # me reads CONTENT_DIR, memo reads USE_FIXTURE_DATA; both are set so the
-    # workspace-wide `pnpm -r` scripts pick up fixtures for each app. Real
-    # content errors are caught at deploy time. See src/__fixtures__.
+    # Every app reads USE_FIXTURE_DATA, so one env var switches the whole
+    # workspace to fixtures. Real content errors are caught at deploy time.
+    # See src/__fixtures__.
     env:
-      CONTENT_DIR: src/__fixtures__/content
       USE_FIXTURE_DATA: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Run from the repo root:
 
 ## CI / Deploy
 
-- `.github/workflows/ci.yml` — runs on PRs and the merge queue. Lint → test → type check → build across the workspace against fixtures (me/memo read `CONTENT_DIR` / `USE_FIXTURE_DATA`; lgtm uses the auto-set `GITHUB_ACTIONS`); content submodules are skipped. The `skip-ci` label opts out.
+- `.github/workflows/ci.yml` — runs on PRs and the merge queue. Lint → test → type check → build across the workspace against fixtures (all apps read `USE_FIXTURE_DATA`); content submodules are skipped. The `skip-ci` label opts out.
 - `.github/workflows/deploy-memo.yml` — on push to main touching `apps/memo/**` or `packages/**`, re-runs memo's checks then deploys to Cloudflare Pages.
 - me, lgtm, and diary are built and deployed locally (`pnpm deploy:me` / `pnpm deploy:lgtm` / `pnpm deploy:diary`), not from CI.
 

--- a/apps/diary/CLAUDE.md
+++ b/apps/diary/CLAUDE.md
@@ -28,7 +28,7 @@ Consumed as source (no build step).
 ## Key Design Decisions
 
 - Photos load via `import.meta.glob("../../diary-content/diary/**/*.jpg", { eager: true })`; entries sort by date then file number, newest first.
-- CI builds with the submodule absent → an empty gallery. The image service switches to `astro/assets/services/noop` when `GITHUB_ACTIONS` is set; locally it uses sharp.
+- CI builds with the submodule absent → an empty gallery. The image service switches to `astro/assets/services/noop` when `USE_FIXTURE_DATA` is set; locally it uses sharp.
 - The first (newest) entry is eager / high-priority and supplies the OG image; the rest lazy-load with a blurred placeholder.
 
 ## How to Work

--- a/apps/diary/astro.config.ts
+++ b/apps/diary/astro.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   image: {
     service:
-      process.env.GITHUB_ACTIONS === "true"
+      process.env.USE_FIXTURE_DATA === "true"
         ? { entrypoint: "astro/assets/services/noop" }
         : { entrypoint: "astro/assets/services/sharp" },
   },

--- a/apps/lgtm/CLAUDE.md
+++ b/apps/lgtm/CLAUDE.md
@@ -22,7 +22,7 @@ src/
     api/og/                       # OG images: default.png (shared handler) + [id].png (per-image, app-local)
     api/favicon/                  # Dev-only favicon endpoints (omitted from prod builds)
   __tests__/                      # Vitest unit tests
-  __fixtures__/lgtm-sample/       # CI fixtures (used when GITHUB_ACTIONS=true)
+  __fixtures__/lgtm-sample/       # CI fixtures (used when USE_FIXTURE_DATA=true)
 lgtm-content/                     # Git submodule (private) — source images, one media file per ULID dir
 scripts/convert-videos.ts         # Bun + ffmpeg: convert .mov sources to animated WebP
 ```
@@ -37,7 +37,7 @@ Consumed as source (no build step); this app supplies its own config via thin wr
 
 ## Key Design Decisions
 
-- Content loading switches by env: `lgtm-content/` locally, `src/__fixtures__/lgtm-sample/` when `GITHUB_ACTIONS=true` (read from `astro:env/client`)
+- Content loading switches by env: `lgtm-content/` locally, `src/__fixtures__/lgtm-sample/` when `USE_FIXTURE_DATA=true`
 - All images are pre-rendered at build time. Infinite scroll fetches pre-built static HTML pages
 - Text is rendered at 2x via Satori, then downscaled with lanczos3 for anti-aliasing
 - Output format is fixed per entry: still → AVIF, animated → animated WebP. One format URL per ID
@@ -48,7 +48,7 @@ Consumed as source (no build step); this app supplies its own config via thin wr
 
 - Dev tools come from the Nix Flake at the repo root (`flake.nix`, includes ffmpeg). Run `direnv allow` once.
 - Run scripts from this directory, or from the repo root via `pnpm --filter @kkhys/lgtm <script>` (or `pnpm dev:lgtm` / `build:lgtm` / `deploy:lgtm`).
-- CI: lint → test → type check → build against fixtures (auto via `GITHUB_ACTIONS`). Add the `skip-ci` label to PRs to skip.
+- CI: lint → test → type check → build against fixtures (via `USE_FIXTURE_DATA`). Add the `skip-ci` label to PRs to skip.
 - Deploy: built and shipped locally via `pnpm deploy:lgtm`; lgtm is not deployed from CI. The `lgtm-content` submodule must be initialized first.
 - Release: repo-wide from the root (`pnpm release`); lgtm has no separate release.
 

--- a/apps/lgtm/astro.config.ts
+++ b/apps/lgtm/astro.config.ts
@@ -1,6 +1,6 @@
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
-import { defineConfig, envField } from "astro/config";
+import { defineConfig } from "astro/config";
 
 export default defineConfig({
   site: "https://lgtm.kkhys.me",
@@ -19,14 +19,4 @@ export default defineConfig({
       SVG: false,
     }),
   ],
-  env: {
-    schema: {
-      GITHUB_ACTIONS: envField.boolean({
-        context: "client",
-        access: "public",
-        optional: true,
-        default: false,
-      }),
-    },
-  },
 });

--- a/apps/lgtm/src/__tests__/components/lgtm-image.test.tsx
+++ b/apps/lgtm/src/__tests__/components/lgtm-image.test.tsx
@@ -6,9 +6,7 @@ import sharp from "sharp";
 import { describe, expect, it, vi } from "vitest";
 import { formatForEntry, LgtmImage } from "#/components/lgtm-image";
 
-vi.mock("astro:env/client", () => ({
-  GITHUB_ACTIONS: true,
-}));
+vi.stubEnv("USE_FIXTURE_DATA", "true");
 
 const createStillEntry = (
   overrides?: Partial<CollectionEntry<"lgtm">>,

--- a/apps/lgtm/src/__tests__/config/content-path.test.ts
+++ b/apps/lgtm/src/__tests__/config/content-path.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from "vitest";
 import { resolveLgtmBasePath } from "#/config/content-path";
 
 describe("resolveLgtmBasePath", () => {
-  it("uses the fixture path when GITHUB_ACTIONS is true", () => {
+  it("uses the fixture path when fixtures are requested", () => {
     expect(resolveLgtmBasePath(true)).toBe("./src/__fixtures__/lgtm-sample");
   });
 
-  it("uses the lgtm-content path when GITHUB_ACTIONS is false", () => {
+  it("uses the lgtm-content path otherwise", () => {
     expect(resolveLgtmBasePath(false)).toBe("./lgtm-content/lgtm");
   });
 });

--- a/apps/lgtm/src/components/lgtm-image.tsx
+++ b/apps/lgtm/src/components/lgtm-image.tsx
@@ -2,7 +2,6 @@
 /** @jsxRuntime automatic */
 
 import type { CollectionEntry } from "astro:content";
-import { GITHUB_ACTIONS } from "astro:env/client";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import satori from "satori";
@@ -143,7 +142,7 @@ const generateAnimatedWebp = async (baseImage: Buffer, width: number): Promise<B
 };
 
 export const LgtmImage = async (entry: CollectionEntry<"lgtm">, width = 400): Promise<Buffer> => {
-  const lgtmBasePath = resolveLgtmBasePath(GITHUB_ACTIONS);
+  const lgtmBasePath = resolveLgtmBasePath(process.env.USE_FIXTURE_DATA === "true");
 
   const imagePath = join(lgtmBasePath, entry.id, entry.data.image);
   const baseImage = await readFile(imagePath);

--- a/apps/lgtm/src/config/content-path.ts
+++ b/apps/lgtm/src/config/content-path.ts
@@ -1,6 +1,6 @@
 /**
  * CI builds run without the private lgtm-content submodule, so fixture
- * entries stand in whenever GITHUB_ACTIONS is set.
+ * entries stand in whenever USE_FIXTURE_DATA is set.
  */
-export const resolveLgtmBasePath = (githubActions: boolean): string =>
-  githubActions ? "./src/__fixtures__/lgtm-sample" : "./lgtm-content/lgtm";
+export const resolveLgtmBasePath = (useFixtures: boolean): string =>
+  useFixtures ? "./src/__fixtures__/lgtm-sample" : "./lgtm-content/lgtm";

--- a/apps/lgtm/src/content.config.ts
+++ b/apps/lgtm/src/content.config.ts
@@ -1,11 +1,10 @@
 import { defineCollection } from "astro:content";
-import { GITHUB_ACTIONS } from "astro:env/client";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
 import { resolveLgtmBasePath } from "#/config/content-path";
 import { lgtmDirLoader } from "#/loaders/lgtm-dir-loader";
 
-const lgtmBasePath = resolveLgtmBasePath(GITHUB_ACTIONS);
+const lgtmBasePath = resolveLgtmBasePath(process.env.USE_FIXTURE_DATA === "true");
 
 const lgtm = defineCollection({
   loader: lgtmDirLoader({ base: lgtmBasePath }),

--- a/apps/me/src/content.config.ts
+++ b/apps/me/src/content.config.ts
@@ -7,10 +7,11 @@ import { externalSites } from "#/features/blog/config/external-site";
 import { allTagTitles } from "#/features/blog/config/tag";
 import { zennLoader } from "#/lib/loaders/zenn";
 
-// Blog content lives in the `me-content` git submodule. CI overrides this with
-// a lightweight fixture directory so the build can be smoke-tested without
-// fetching the heavy submodule. See `.github/workflows/ci.yml`.
-const contentDir = process.env.CONTENT_DIR ?? "me-content";
+// Blog content lives in the `me-content` git submodule. CI sets
+// USE_FIXTURE_DATA so the build can be smoke-tested against a lightweight
+// fixture directory without fetching the heavy submodule.
+const contentDir =
+  process.env.USE_FIXTURE_DATA === "true" ? "src/__fixtures__/content" : "me-content";
 
 const blog = defineCollection({
   loader: glob({ pattern: "**/*.mdx", base: `./${contentDir}/blog` }),


### PR DESCRIPTION
- Replace the three fixture mechanisms (me's CONTENT_DIR path, lgtm's astro:env GITHUB_ACTIONS, diary's ambient GITHUB_ACTIONS) with the USE_FIXTURE_DATA flag memo already used
- CI now sets a single env var for the whole workspace; lgtm's env schema disappears
- Verified with fixture-mode builds of me, lgtm, and diary