### PR TITLE
[main] ci: share setup, freeze installs, tighten permissions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,15 @@
+name: Setup workspace
+description: Install pnpm (version from the root packageManager field), Node.js with the pnpm store cache, and dependencies.
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: "24"
+        cache: "pnpm"
+
+    - run: pnpm install --frozen-lockfile
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Lint, Test, Type check & Build
@@ -27,15 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # pnpm version comes from the root package.json packageManager field
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/deploy-memo.yml
+++ b/.github/workflows/deploy-memo.yml
@@ -20,6 +20,9 @@ concurrency:
   group: deploy-memo
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Lint, Test, Type check & Build
@@ -29,15 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # pnpm version comes from the root package.json packageManager field
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: Lint
         run: pnpm --filter @kkhys/memo lint
@@ -74,17 +69,9 @@ jobs:
           git fetch origin main
           git reset --hard origin/main
 
-      # pnpm version comes from the root package.json packageManager field
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+      # The content submodules are not workspace members, so their presence
+      # does not change the lockfile; a frozen install is always valid here.
+      - uses: ./.github/actions/setup
 
       - name: Build
         working-directory: apps/memo

--- a/.github/workflows/github-label-sync.yml
+++ b/.github/workflows/github-label-sync.yml
@@ -7,8 +7,13 @@ on:
       - .github/labels.yml
       - .github/workflows/github-label-sync.yml
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
-      - uses: r7kamura/github-label-sync-action@v0
+      - uses: r7kamura/github-label-sync-action@061649dd3b80eb5bafad0316466f72962e62c300 # v0.1.0

--- a/.github/workflows/sync-submodule.yml
+++ b/.github/workflows/sync-submodule.yml
@@ -22,15 +22,6 @@ jobs:
           submodules: true
           token: ${{ secrets.SUBMODULE_TOKEN }}
 
-      # pnpm version comes from the root package.json packageManager field
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: "24"
-          cache: "pnpm"
-
       - name: Update submodule
         id: update
         run: |
@@ -65,11 +56,11 @@ jobs:
           TITLE="[main] chore: update memo submodule"
           COMMIT_MSG="chore(memo): update submodule at ${TIMESTAMP}"
 
-          pnpm install --no-frozen-lockfile
-
+          # The submodule is not a workspace member, so the lockfile never
+          # changes here; only the gitlink needs committing.
           BRANCH="update-memo-submodule-$(TZ=Asia/Tokyo date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"
-          git add apps/memo/memo-content pnpm-lock.yaml
+          git add apps/memo/memo-content
           git commit -m "$COMMIT_MSG"
           git push origin "$BRANCH"
 


### PR DESCRIPTION
- Extract the pnpm/node/install steps into a composite action used by ci.yml and both deploy-memo jobs
- Switch the deploy install to --frozen-lockfile and drop the install from sync-submodule entirely; content submodules are not workspace members, so the daily job was installing everything to commit a lockfile no-op
- Add least-privilege permissions blocks to every workflow and digest-pin the label-sync action