### PR TITLE
[main] refactor: consolidate memo feeds and classify studio errors

### DIFF
--- a/apps/memo/src/components/paginated-feed.astro
+++ b/apps/memo/src/components/paginated-feed.astro
@@ -1,0 +1,35 @@
+---
+import type { Page } from "astro";
+import Feed from "#/components/feed.astro";
+import InfiniteScroll from "#/components/infinite-scroll.astro";
+
+interface Props {
+  page: Page<unknown>;
+  basePath: string;
+  containerId: string;
+}
+
+const { page, basePath, containerId } = Astro.props;
+const isFirstPage = page.currentPage === 1;
+---
+
+{/* Non-first pages exist only as infinite-scroll fetch targets; bounce
+    direct visits back to the first page. */}
+{!isFirstPage && (
+  <script is:inline define:vars={{ basePath }}>
+    if (!document.referrer || !document.referrer.startsWith(window.location.origin)) {
+      window.location.replace(basePath);
+    }
+  </script>
+)}
+
+<Feed
+  id={containerId}
+  data-current-page={page.currentPage}
+  data-total-pages={page.lastPage}
+  data-base-path={basePath}
+>
+  <slot />
+</Feed>
+
+{page.currentPage < page.lastPage && <InfiniteScroll containerId={containerId} />}

--- a/apps/memo/src/pages/@[slug]/[...page].astro
+++ b/apps/memo/src/pages/@[slug]/[...page].astro
@@ -1,7 +1,6 @@
 ---
 import type { GetStaticPaths } from "astro";
-import Feed from "#/components/feed.astro";
-import InfiniteScroll from "#/components/infinite-scroll.astro";
+import PaginatedFeed from "#/components/paginated-feed.astro";
 import ProfileHeader from "#/components/profile-header.astro";
 import BaseSEO from "#/components/seo/base-seo.astro";
 import JsonLd from "#/components/seo/json-ld.astro";
@@ -41,14 +40,6 @@ const profilePath = `/@${slug}`;
 const ogImage = new URL("/api/og/default.png", Astro.site).href;
 ---
 
-{!isFirstPage && (
-  <script is:inline define:vars={{ profilePath }}>
-    if (!document.referrer || !document.referrer.startsWith(window.location.origin)) {
-      window.location.replace(profilePath);
-    }
-  </script>
-)}
-
 <Layout>
   <Fragment slot="seo">
     <BaseSEO
@@ -82,12 +73,7 @@ const ogImage = new URL("/api/og/default.png", Astro.site).href;
     />
   </Fragment>
 
-  <Feed
-    id="profile-memo-container"
-    data-current-page={page.currentPage}
-    data-total-pages={page.lastPage}
-    data-base-path={profilePath}
-  >
+  <PaginatedFeed page={page} basePath={profilePath} containerId="profile-memo-container">
     {isFirstPage && (
       <ProfileHeader user={user} postCount={totalPosts} />
     )}
@@ -108,9 +94,5 @@ const ogImage = new URL("/api/og/default.png", Astro.site).href;
         />
       ))
     }
-  </Feed>
-
-  {page.currentPage < page.lastPage && (
-    <InfiniteScroll containerId="profile-memo-container" />
-  )}
+  </PaginatedFeed>
 </Layout>

--- a/apps/memo/src/pages/[...page].astro
+++ b/apps/memo/src/pages/[...page].astro
@@ -1,7 +1,6 @@
 ---
 import type { GetStaticPaths } from "astro";
-import Feed from "#/components/feed.astro";
-import InfiniteScroll from "#/components/infinite-scroll.astro";
+import PaginatedFeed from "#/components/paginated-feed.astro";
 import BaseSEO from "#/components/seo/base-seo.astro";
 import JsonLd from "#/components/seo/json-ld.astro";
 import OpenGraph from "#/components/seo/open-graph.astro";
@@ -29,14 +28,6 @@ const siteOwner = await getAuthorInfo(SITE_OWNER_SLUG);
 const ogImage = new URL("/api/og/default.png", Astro.site).href;
 ---
 
-{!isFirstPage && (
-  <script is:inline>
-    if (!document.referrer || !document.referrer.startsWith(window.location.origin)) {
-      window.location.replace("/");
-    }
-  </script>
-)}
-
 <Layout>
   <Fragment slot="seo">
     <BaseSEO title={TITLE} description={DESCRIPTION} noindex={!isFirstPage} />
@@ -57,12 +48,7 @@ const ogImage = new URL("/api/og/default.png", Astro.site).href;
       }}
     />
   </Fragment>
-  <Feed
-    id="memo-container"
-    data-current-page={page.currentPage}
-    data-total-pages={page.lastPage}
-    data-base-path="/"
-  >
+  <PaginatedFeed page={page} basePath="/" containerId="memo-container">
     {
       isFirstPage && pinned.map(({ main, comments }) => (
         <ThreadPost
@@ -80,9 +66,5 @@ const ogImage = new URL("/api/og/default.png", Astro.site).href;
         />
       ))
     }
-  </Feed>
-
-  {page.currentPage < page.lastPage && (
-    <InfiniteScroll containerId="memo-container" />
-  )}
+  </PaginatedFeed>
 </Layout>

--- a/apps/memo/src/pages/api/posts/[id].json.ts
+++ b/apps/memo/src/pages/api/posts/[id].json.ts
@@ -1,4 +1,4 @@
-import type { APIRoute, GetStaticPaths, ImageMetadata } from "astro";
+import type { APIRoute, GetStaticPaths, InferGetStaticPropsType } from "astro";
 import { SITE_URL } from "#/config/constants";
 import { getImagesForMemo } from "#/utils/image";
 import { getPublishedMemos } from "#/utils/memo";
@@ -18,16 +18,10 @@ export const getStaticPaths = (async () => {
   );
 }) satisfies GetStaticPaths;
 
-export const GET: APIRoute = ({ props }) => {
-  const { memo, authorName, avatar, images } = props as {
-    memo: {
-      data: { id: string; createdAt: Date; tag?: string; author: string };
-      body: string;
-    };
-    authorName: string;
-    avatar: ImageMetadata;
-    images: ImageMetadata[];
-  };
+type Props = InferGetStaticPropsType<typeof getStaticPaths>;
+
+export const GET: APIRoute<Props> = ({ props }) => {
+  const { memo, authorName, avatar, images } = props;
   return new Response(
     JSON.stringify({
       id: memo.data.id,

--- a/apps/memo/src/pages/tag/[tag]/[...page].astro
+++ b/apps/memo/src/pages/tag/[tag]/[...page].astro
@@ -1,7 +1,6 @@
 ---
 import type { GetStaticPaths } from "astro";
-import Feed from "#/components/feed.astro";
-import InfiniteScroll from "#/components/infinite-scroll.astro";
+import PaginatedFeed from "#/components/paginated-feed.astro";
 import BaseSEO from "#/components/seo/base-seo.astro";
 import JsonLd from "#/components/seo/json-ld.astro";
 import OpenGraph from "#/components/seo/open-graph.astro";
@@ -40,14 +39,6 @@ const tagPath = `/tag/${tag}`;
 const ogImage = new URL("/api/og/default.png", Astro.site).href;
 ---
 
-{!isFirstPage && (
-  <script is:inline define:vars={{ tagPath }}>
-    if (!document.referrer || !document.referrer.startsWith(window.location.origin)) {
-      window.location.replace(tagPath);
-    }
-  </script>
-)}
-
 <Layout>
   <Fragment slot="seo">
     <BaseSEO
@@ -84,12 +75,7 @@ const ogImage = new URL("/api/og/default.png", Astro.site).href;
     />
   </Fragment>
 
-  <Feed
-    id="tag-memo-container"
-    data-current-page={page.currentPage}
-    data-total-pages={page.lastPage}
-    data-base-path={tagPath}
-  >
+  <PaginatedFeed page={page} basePath={tagPath} containerId="tag-memo-container">
     {isFirstPage && (
       <div class="tag-header">
         <p>{totalPosts} {totalPosts === 1 ? "post" : "posts"}</p>
@@ -104,11 +90,7 @@ const ogImage = new URL("/api/og/default.png", Astro.site).href;
         />
       ))
     }
-  </Feed>
-
-  {page.currentPage < page.lastPage && (
-    <InfiniteScroll containerId="tag-memo-container" />
-  )}
+  </PaginatedFeed>
 </Layout>
 
 <style>

--- a/apps/memo/src/styles/global.css
+++ b/apps/memo/src/styles/global.css
@@ -2,12 +2,14 @@
 @import "kiso.css";
 
 :root {
-  --c-bg: var(--uchu-yang);
-  --c-gray: var(--uchu-yin-1);
-  --c-text: var(--uchu-yin-9);
+  color-scheme: light dark;
+
+  --c-bg: light-dark(var(--uchu-yang), var(--uchu-yin));
+  --c-gray: light-dark(var(--uchu-yin-1), var(--uchu-yin-9));
+  --c-text: light-dark(var(--uchu-yin-9), var(--uchu-yin-1));
   --c-sub-text: var(--uchu-yin-5);
-  --c-link: var(--uchu-blue-5);
-  --c-scrollbar: var(--uchu-gray-3);
+  --c-link: light-dark(var(--uchu-blue-5), var(--uchu-blue-4));
+  --c-scrollbar: light-dark(var(--uchu-gray-3), var(--uchu-yin-8));
 
   --fs-xs: 0.75rem;
   --fs-sm: 0.875rem;
@@ -18,17 +20,6 @@
   --lh-xs: 1.25;
   --lh-sm: 1.5;
   --lh-base: 1.75;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --c-bg: var(--uchu-yin);
-    --c-gray: var(--uchu-yin-9);
-    --c-text: var(--uchu-yin-1);
-    --c-sub-text: var(--uchu-yin-5);
-    --c-link: var(--uchu-blue-4);
-    --c-scrollbar: var(--uchu-yin-8);
-  }
 }
 
 html {

--- a/apps/studio/src/memo-store.ts
+++ b/apps/studio/src/memo-store.ts
@@ -11,6 +11,9 @@ import { join } from "node:path";
 import { ulid } from "ulid";
 import { countMemoChars, MAX_BODY_LENGTH, MAX_IMAGES, type MemoSummary } from "./memo-format";
 
+/** Invalid input from the client, as opposed to an unexpected server failure. */
+export class MemoValidationError extends Error {}
+
 const DATE_TIME_PATTERN = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})$/u;
 const TAG_PATTERN = /^[a-z0-9_]+$/u;
 const ULID_PATTERN = /^[0-9a-hjkmnp-tv-z]{26}$/u;
@@ -46,7 +49,9 @@ export const formatDateTime = (date: Date): string =>
 const parseDateTime = (dateTimeStr: string): Date => {
   const match = dateTimeStr.match(DATE_TIME_PATTERN);
   if (!match) {
-    throw new Error(`Invalid datetime format (expected YYYY-MM-DD HH:mm:ss): ${dateTimeStr}`);
+    throw new MemoValidationError(
+      `Invalid datetime format (expected YYYY-MM-DD HH:mm:ss): ${dateTimeStr}`,
+    );
   }
 
   const [, year, month, day, hour, minute, second] = match.map(Number) as [
@@ -61,7 +66,7 @@ const parseDateTime = (dateTimeStr: string): Date => {
   const date = new Date(year, month - 1, day, hour, minute, second);
 
   if (formatDateTime(date) !== dateTimeStr) {
-    throw new Error(`Invalid datetime: ${dateTimeStr}`);
+    throw new MemoValidationError(`Invalid datetime: ${dateTimeStr}`);
   }
 
   return date;
@@ -105,18 +110,18 @@ const serializeMemoFile = (
 
 const validateInput = (input: CreateMemoInput): void => {
   if (input.body.trim() === "") {
-    throw new Error("Body is required");
+    throw new MemoValidationError("Body is required");
   }
 
   const charCount = countMemoChars(input.body);
   if (charCount > MAX_BODY_LENGTH) {
-    throw new Error(
+    throw new MemoValidationError(
       `Character count exceeds the limit: ${charCount} characters (limit: ${MAX_BODY_LENGTH} characters)`,
     );
   }
 
   if (input.tag !== undefined && !TAG_PATTERN.test(input.tag)) {
-    throw new Error(`Invalid tag (allowed: a-z, 0-9, _): ${input.tag}`);
+    throw new MemoValidationError(`Invalid tag (allowed: a-z, 0-9, _): ${input.tag}`);
   }
 
   for (const [field, value] of [
@@ -124,12 +129,14 @@ const validateInput = (input: CreateMemoInput): void => {
     ["quote", input.quote],
   ] as const) {
     if (value !== undefined && !ULID_PATTERN.test(value)) {
-      throw new Error(`Invalid ${field} target (expected a lowercase ULID): ${value}`);
+      throw new MemoValidationError(
+        `Invalid ${field} target (expected a lowercase ULID): ${value}`,
+      );
     }
   }
 
   if (input.images !== undefined && input.images.length > MAX_IMAGES) {
-    throw new Error(`Too many images: ${input.images.length} (limit: ${MAX_IMAGES})`);
+    throw new MemoValidationError(`Too many images: ${input.images.length} (limit: ${MAX_IMAGES})`);
   }
 };
 
@@ -148,7 +155,7 @@ export const createMemo = (baseDir: string, input: CreateMemoInput): MemoSummary
   const memoDir = join(baseDir, dirName);
 
   if (existsSync(memoDir)) {
-    throw new Error(`Memo directory already exists: ${dirName}`);
+    throw new MemoValidationError(`Memo directory already exists: ${dirName}`);
   }
 
   const body = input.body.trim();

--- a/apps/studio/src/server.ts
+++ b/apps/studio/src/server.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { $, type BunRequest } from "bun";
 import homepage from "./index.html";
-import { createMemo, listMemos, type MemoImageInput } from "./memo-store";
+import { createMemo, listMemos, type MemoImageInput, MemoValidationError } from "./memo-store";
 import { isAllowedRequest } from "./request-guard";
 
 const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
@@ -92,7 +92,9 @@ const server = Bun.serve({
 
           return Response.json({ memo }, { status: 201 });
         } catch (error) {
-          return errorResponse(error);
+          // Validation problems are the client's fault; anything else (disk
+          // errors, bugs) should surface as a server failure.
+          return errorResponse(error, error instanceof MemoValidationError ? 400 : 500);
         }
       }),
     },


### PR DESCRIPTION
- Extract PaginatedFeed from the referrer-guard script and Feed/InfiniteScroll wiring repeated on all three paginated pages
- Type the post JSON API with InferGetStaticPropsType instead of a hand-written props cast
- Migrate memo's theme tokens to color-scheme + light-dark(), matching the other apps
- Introduce MemoValidationError so studio returns 400 only for client mistakes; disk failures now surface as 500