### PR TITLE
[main] docs: align READMEs with reality and document packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@ A pnpm monorepo for kkhys's personal sites, built with [Astro](https://astro.bui
 
 ### Apps
 
-| Package                        | Site                                     | Description                          |
-| ------------------------------ | ---------------------------------------- | ------------------------------------ |
-| [`@kkhys/me`](./apps/me)       | [kkhys.me](https://kkhys.me)             | Personal website and blog            |
-| [`@kkhys/memo`](./apps/memo)   | [memo.kkhys.me](https://memo.kkhys.me)   | Short threaded memos (max 500 chars) |
-| [`@kkhys/lgtm`](./apps/lgtm)   | [lgtm.kkhys.me](https://lgtm.kkhys.me)   | LGTM images for GitHub Pull Requests |
-| [`@kkhys/diary`](./apps/diary) | [diary.kkhys.me](https://diary.kkhys.me) | Photo diary                          |
+| Package                          | Site                                     | Description                          |
+| -------------------------------- | ---------------------------------------- | ------------------------------------ |
+| [`@kkhys/me`](./apps/me)         | [kkhys.me](https://kkhys.me)             | Personal website and blog            |
+| [`@kkhys/memo`](./apps/memo)     | [memo.kkhys.me](https://memo.kkhys.me)   | Short threaded memos (max 500 chars) |
+| [`@kkhys/lgtm`](./apps/lgtm)     | [lgtm.kkhys.me](https://lgtm.kkhys.me)   | LGTM images for GitHub Pull Requests |
+| [`@kkhys/diary`](./apps/diary)   | [diary.kkhys.me](https://diary.kkhys.me) | Photo diary                          |
+| [`@kkhys/studio`](./apps/studio) | (local only)                             | Memo composer for memo-content       |
 
 ### Packages
 
@@ -64,7 +65,7 @@ Run from the repo root:
 | `pnpm --filter @kkhys/memo <script>`               | Target a single app                            |
 | `pnpm release`                                     | Tag a repo-wide release                        |
 
-Per-app commands are documented in each app's README ([me](./apps/me/README.md), [memo](./apps/memo/README.md)).
+Per-app commands are documented in each app's README ([me](./apps/me/README.md), [memo](./apps/memo/README.md), [lgtm](./apps/lgtm/README.md), [diary](./apps/diary/README.md)).
 
 ## CI / Deploy
 

--- a/apps/memo/README.md
+++ b/apps/memo/README.md
@@ -1,161 +1,47 @@
 # Memo
 
-A simple memo posting site that displays short memos (max 500 characters) in a social media thread-like layout.
+Short memos (max 500 characters, counted on rendered text) in a threaded
+social media layout, part of the [kkhys monorepo](../../README.md).
 
 **Live Site**: [memo.kkhys.me](https://memo.kkhys.me)
 
 ## Features
 
-- Short memo posts (up to 500 characters)
-- Up to 4 images per post
-- Light/dark mode support
-- Responsive design
-- Fast static site generation with Astro
-- Optimized images with AVIF format
+- Short memo posts with threaded replies and quotes
+- Up to 4 images per post (JPG/PNG)
+- Bot feeds: blog RSS, Zenn RSS, and OSS projects injected as entries
+- Light/dark mode via `light-dark()`
+- Fully static build with infinite scroll over pre-built pages
 
 ## Tech Stack
 
-- **Framework**: [Astro](https://astro.build/)
-- **Language**: TypeScript (strictest mode)
-- **Styling**: CSS (kiso.css + custom properties)
-- **Testing**: Vitest
-- **Lint/Format**: oxlint + oxfmt
-- **Package Manager**: pnpm
-- **Deployment**: Cloudflare Pages
+Astro 7 static site, TypeScript (strictest), vanilla CSS (kiso.css +
+uchu.css via `@kkhys/styles`), Vitest, oxlint + oxfmt. Deployed to
+Cloudflare Pages by GitHub Actions (`.github/workflows/deploy-memo.yml`)
+on pushes to main.
 
-See `package.json` for specific version requirements.
+## Content
 
-## Setup
+Each memo is a directory in the private `memo-content/` submodule
+(`memo/<YYYYMMDD_HHMMSS>/index.md` + numbered images). Frontmatter:
+`id` (lowercase ULID), `createdAt`, optional `tag`, `comment` (parent
+ULID), `quote`, `isDraft`, `hideLinkCard`, `isPinned`, `hideComments`,
+`isBot`, and `author` (user slug).
 
-### Prerequisites
-
-See `package.json` for required Node.js and pnpm versions (managed via Volta).
-
-### Installation
-
-```bash
-# Clone the repository
-git clone https://github.com/kkhys/memo.git
-cd memo
-
-# Install dependencies
-pnpm install
-```
-
-### Content Setup
-
-This project manages content in a separate repository (Git submodule).
-
-**Development**: Works without submodule (uses fixture data)
-
-**Production Build**: Requires `memo-content/` submodule
-
-```bash
-# Initialize submodule
-git submodule update --init --recursive
-```
+Memos are composed locally with [`@kkhys/studio`](../studio). Without the
+submodule, set `USE_FIXTURE_DATA=true` to build against
+`src/__fixtures__/` (CI does this automatically).
 
 ## Development
 
-```bash
-# Start development server
-pnpm dev
-
-# Open http://localhost:4321 in browser
-```
-
-### Development Commands
+Dev tools come from the Nix Flake at the repo root — run `direnv allow`
+once. Then, from the repo root:
 
 ```bash
-pnpm dev          # Start dev server
-pnpm build        # Production build
-pnpm check        # Type checking
-pnpm lint         # Run linter
-pnpm lint:fix     # Auto-fix lint issues
-pnpm test         # Run tests
-pnpm coverage     # Generate coverage report
-pnpm all          # Run all checks (build + check + lint:fix + test + coverage)
+pnpm dev:memo                       # dev server
+pnpm --filter @kkhys/memo test      # unit tests
+pnpm --filter @kkhys/memo check     # astro check + tsc
+pnpm --filter @kkhys/memo build     # static build
 ```
 
-## Content Management
-
-### Creating Memos
-
-Memos are placed in the `memo-content/memo/` directory.
-
-**Directory Structure**:
-
-```
-memo-content/memo/
-└── <timestamp_id>/          # e.g., 20251001_204021
-    ├── index.md              # Memo content
-    ├── 01.jpg                # Image 1 (optional)
-    ├── 02.jpg                # Image 2 (optional)
-    └── ...                   # Up to 4 images
-```
-
-**index.md Format**:
-
-```markdown
----
-id: 01k6fs5j48ep20vqcvvgh4r4c2 # ULID format
-createdAt: 2025-10-01 20:40:21
-images: # Optional (max 4)
-  - 01.jpg
-  - 02.jpg
-isPublished: true # Publication status
-author: Keisuke Hayashi
----
-
-Write your memo content here (max 500 characters)
-```
-
-### Constraints
-
-- **Character Limit**: Max **499 characters** (validated at build time)
-- **Image Limit**: Max **4 images** per post
-- **Image Formats**: JPG and PNG only
-
-## Deployment
-
-Deployed via [Cloudflare Pages](https://pages.cloudflare.com/) with Git integration.
-
-## Project Structure
-
-```
-memo/
-├── src/
-│   ├── components/       # UI components
-│   ├── layouts/          # Page layouts
-│   ├── pages/            # Page files
-│   │   ├── index.astro   # Memo list
-│   │   └── [id].astro    # Memo detail
-│   ├── utils/            # Utility functions
-│   ├── lib/              # Remark plugins, etc.
-│   └── styles/           # Global styles
-├── memo-content/      # Content (Git submodule)
-├── scripts/              # Build scripts
-└── CLAUDE.md             # AI development assistance doc
-```
-
-For detailed architecture, see [CLAUDE.md](./CLAUDE.md).
-
-## CI/CD
-
-GitHub Actions runs automated tests and build validation:
-
-- Triggered on push and pull requests
-- Build, type checking, linting, testing, coverage
-
-Renovate for automated dependency updates:
-
-- DevDependencies: All versions auto-merged
-- Dependencies: Minor/patch versions auto-merged
-
-## License
-
-MIT License - See [LICENSE.md](./LICENSE.md) for details
-
-## Author
-
-Keisuke Hayashi ([@kkhys](https://github.com/kkhys))
+See [CLAUDE.md](./CLAUDE.md) for the codebase map and conventions.

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -1,0 +1,22 @@
+# Studio
+
+Local-only browser app for composing memos into `apps/memo/memo-content`.
+Never deployed: it runs on the developer's machine and writes directly to
+the content submodule.
+
+## Usage
+
+```bash
+pnpm dev:studio   # from the repo root; binds to 127.0.0.1:5757
+```
+
+The UI provides a compose form (body, tag, reply/quote, draft flag,
+images), a searchable feed of existing memos, and a sync button that
+commits and pushes memo-content (optionally triggering the deploy
+workflow).
+
+Body length is validated like the memo app (rendered text ≤ 500 chars),
+and all API routes are guarded against DNS rebinding / cross-origin
+requests.
+
+See [CLAUDE.md](./CLAUDE.md) for the codebase map and API details.

--- a/packages/og/CLAUDE.md
+++ b/packages/og/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md
+
+`@kkhys/og` — Satori-based OG image and favicon generation, consumed as
+source by me, memo, lgtm, and diary.
+
+## Exports
+
+- `./favicon` — `createFaviconGenerators(gradient)`: five icon
+  generators (SVG + PNGs) bound to one CSS gradient.
+- `./handlers` — `createFaviconRoutes(gradient)`: a `[file].ts` route
+  factory whose `getStaticPaths` emits paths only outside PROD, so
+  favicons are served dynamically in dev and shipped as static files in
+  production (prod builds emit no favicon routes at all).
+  `createOgResponse(generator)`: production OG-image route handler.
+- `./og` — `createSiteOgImage`: the fixed-layout site OG card. me and
+  lgtm keep bespoke Satori layouts app-local instead.
+
+## Notes
+
+- `handlers.test.ts` covers the route table, headers, PNG signature, and
+  prod emptiness; `check`/`test` run in recursive CI.
+- Static favicon assets in each app's `public/` are generated from these
+  generators (see diary's git history for a generation example); the dev
+  routes exist for previewing changes.
+- `astro` is a peer dependency; `react`/`satori`/`sharp` are real
+  dependencies of this package, so consumers need not declare them.

--- a/packages/release/CLAUDE.md
+++ b/packages/release/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md
+
+`@kkhys/release` — date-based release tagging, driven by
+`scripts/release.ts` at the repo root (`pnpm release`).
+
+## Behavior
+
+- Versions are `YYYY.MM.DD`, suffixed `-2`, `-3`, … for same-day
+  re-releases (`version.ts`, anchored matching — tested).
+- `release()` fetches origin tags first, refuses to tag a stale or
+  diverged main (`pull --ff-only`), force-pushes the tag, and creates a
+  GitHub Release; any failure sets a non-zero exit code.
+- `dryRun: true` (CLI: `--dry-run`) previews without git/API mutations
+  and needs no `GITHUB_ACCESS_TOKEN`.
+
+## Constraints
+
+- `index.ts` imports `bun` and can only run under Bun; keep testable
+  logic in bun-free modules (`version.ts`, `github.ts`) so vitest (Node)
+  can cover it.

--- a/packages/seo/CLAUDE.md
+++ b/packages/seo/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+`@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard Astro primitives,
+consumed as source by me, memo, lgtm (via thin app-local adapters in
+`src/components/seo/`) and diary (directly in its layout).
+
+## API notes
+
+- `truncate.ts` holds the shared description clamping; the three
+  components import it.
+- `pathname.ts` normalizes `Astro.url.pathname` before it becomes a
+  canonical / `og:url` value. Every app builds in file format, so Astro
+  reports `/index.html` and `/privacy.html`; emitting those verbatim
+  would contradict the extensionless URLs the sitemap advertises. me
+  also imports it (`@kkhys/seo/pathname`) for nav active-state matching.
+- `truncate.ts` and `pathname.ts` are the unit-tested modules
+  (`pnpm test`); the `.astro` components have no tests.
+- OpenGraph/TwitterCard image props are optional: omit `image` to emit no
+  image block, and use `imageType` / `imageWidth` / `imageHeight` for
+  non-1200×630-PNG images (diary passes variable-height JPEGs).
+- All optional props are `| undefined` (`exactOptionalPropertyTypes`).
+
+## Constraints
+
+- `.astro` files cannot be imported from `.ts` (tsc does not resolve
+  them); the reverse (`.astro` importing `truncate.ts`) is fine.
+- Anything that renders a URL must go through `normalizePathname` — a raw
+  `Astro.url.pathname` reintroduces the `.html` suffix.
+- `check` runs tsc over the `.ts` sources only; the `.astro` components
+  are type-checked by each consuming app's `astro check`.
+- API changes ripple into four apps — grep consumers before changing
+  props.

--- a/packages/styles/CLAUDE.md
+++ b/packages/styles/CLAUDE.md
@@ -1,0 +1,8 @@
+# CLAUDE.md
+
+`@kkhys/styles` — the uchu.css OKLCH color palette, consumed as source by
+every app (`@import "@kkhys/styles/uchu.css"` in each `global.css`).
+
+- Exposes raw palette tokens (`--uchu-*`) only; semantic tokens (`--c-*`)
+  stay app-local so each site can map light/dark differently.
+- No build step, no scripts. Changing this file affects all five apps.


### PR DESCRIPTION
- Rewrite memo's README, which described a standalone Volta-managed repo with a different schema and deploy story
- Add the missing studio README and workspace-table row; link all app READMEs
- Give each shared package a CLAUDE.md covering its API surface and consumer constraints