### PR TITLE
[main] fix: align JSON-LD url with the canonical tag

### DIFF
--- a/apps/lgtm/src/components/seo/json-ld.astro
+++ b/apps/lgtm/src/components/seo/json-ld.astro
@@ -1,4 +1,6 @@
 ---
+import { normalizePathname } from "@kkhys/seo/pathname";
+
 interface Props {
   type: "WebSite" | "BlogPosting" | "Article" | "Person" | "Organization";
   data: Record<string, unknown>;
@@ -6,7 +8,9 @@ interface Props {
 
 const { type, data } = Astro.props;
 
-const canonicalURL = new URL(Astro.url.pathname, Astro.site).href;
+// Must match BaseSEO's canonical: a raw pathname keeps the `.html` suffix the
+// site is not served under, contradicting the canonical tag on the same page.
+const canonicalURL = new URL(normalizePathname(Astro.url.pathname), Astro.site).href;
 
 const jsonLd = {
   "@context": "https://schema.org",

--- a/apps/memo/src/components/seo/json-ld.astro
+++ b/apps/memo/src/components/seo/json-ld.astro
@@ -1,4 +1,6 @@
 ---
+import { normalizePathname } from "@kkhys/seo/pathname";
+
 interface Props {
   type: "WebSite" | "BlogPosting" | "Article" | "Person" | "Organization";
   data: Record<string, unknown>;
@@ -6,7 +8,9 @@ interface Props {
 
 const { type, data } = Astro.props;
 
-const canonicalURL = new URL(Astro.url.pathname, Astro.site).href;
+// Must match BaseSEO's canonical: a raw pathname keeps the `.html` suffix the
+// site is not served under, contradicting the canonical tag on the same page.
+const canonicalURL = new URL(normalizePathname(Astro.url.pathname), Astro.site).href;
 
 const jsonLd = {
   "@context": "https://schema.org",


### PR DESCRIPTION
#787 taught `BaseSEO` to strip the `.html` suffix that `build.format: "file"` leaves on `Astro.url.pathname`, but the app-local `json-ld.astro` in memo and lgtm kept building its url from the raw pathname. Every page then advertised two different URLs for itself.

```
memo /23.html →  canonical: https://memo.kkhys.me/23
                  JSON-LD url: https://memo.kkhys.me/23.html
```

Both now go through `normalizePathname`. me is unaffected (its `json-ld.astro` takes the schema from the caller), and diary emits no JSON-LD.

## Verification

Built both apps against real content and compared the two tags on the same page:

| page | canonical | JSON-LD `url` |
| --- | --- | --- |
| `memo/23.html` | `https://memo.kkhys.me/23` | `https://memo.kkhys.me/23` |
| `memo/index.html` | `https://memo.kkhys.me/` | `https://memo.kkhys.me/` |
| `lgtm/01kdg0yw2eektjz3wgpjhehw90.html` | `…/01kdg0yw2eektjz3wgpjhehw90` | `…/01kdg0yw2eektjz3wgpjhehw90` |
| `lgtm/index.html` | `https://lgtm.kkhys.me/` | `https://lgtm.kkhys.me/` |

`pnpm lint` / `pnpm test` (506 tests) / `pnpm check` all pass. The `.html`-stripping logic itself is already covered by `packages/seo/src/pathname.test.ts`.