### PR TITLE
[main] fix: correct link card encoding and stuck image blur placeholders

### DIFF
--- a/apps/me/src/__tests__/lib/api/metadata.test.ts
+++ b/apps/me/src/__tests__/lib/api/metadata.test.ts
@@ -320,6 +320,39 @@ describe("getMetadata", () => {
       expect(result.image).toBeUndefined();
     });
 
+    it("upgrades an http og:image to https so it isn't blocked as mixed content", async () => {
+      const spy = mockFetchByUrl(
+        () => new Response(PNG_BYTES as unknown as BodyInit, { status: 200 }),
+      );
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "Insecure image site",
+        description: "desc",
+        image: { src: "http://example.com/og.png", width: "1", height: "1" },
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://insecure-image-example.com");
+      expect(result.image).toEqual({
+        src: "https://example.com/og.png",
+        width: "1",
+        height: "1",
+      });
+      expect(spy).toHaveBeenCalledWith("https://example.com/og.png", expect.anything());
+    });
+
+    it("drops an http og:image that isn't served over https", async () => {
+      mockFetchByUrl(() => new Response(null, { status: 404 }));
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "Http only site",
+        description: "desc",
+        image: { src: "http://example.com/og.png", width: "1", height: "1" },
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://http-only-image-example.com");
+      expect(result.image).toBeUndefined();
+    });
+
     it("re-extracts garbled text using the charset the page declares", async () => {
       mockFetchByUrl(
         () =>

--- a/apps/me/src/__tests__/lib/api/metadata.test.ts
+++ b/apps/me/src/__tests__/lib/api/metadata.test.ts
@@ -19,6 +19,39 @@ const mockImageResponse = (bytes: Uint8Array) => {
   );
 };
 
+/** Routes each fetch by URL so a test can serve a page and an image at once. */
+const mockFetchByUrl = (routes: (url: string) => Response) => {
+  const spy = vi
+    .fn<typeof fetch>()
+    .mockImplementation((input) => Promise.resolve(routes(String(input))));
+  vi.stubGlobal("fetch", spy);
+  return spy;
+};
+
+const concatBytes = (...parts: Uint8Array[]) => {
+  const merged = new Uint8Array(parts.reduce((total, part) => total + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    merged.set(part, offset);
+    offset += part.length;
+  }
+  return merged;
+};
+
+/** 「楽天」 in EUC-JP, the encoding item.rakuten.co.jp still serves. */
+const RAKUTEN_EUC_JP = new Uint8Array([0xb3, 0xda, 0xc5, 0xb7]);
+const ascii = (text: string) => new TextEncoder().encode(text);
+
+/** Builds an EUC-JP page whose og:title / og:description are 「楽天」. */
+const eucJpPage = () =>
+  concatBytes(
+    ascii('<html><head><meta charset="EUC-JP"><meta property="og:title" content="'),
+    RAKUTEN_EUC_JP,
+    ascii('"><meta property="og:description" content="'),
+    RAKUTEN_EUC_JP,
+    ascii('"></head><body></body></html>'),
+  );
+
 describe("getMetadata", () => {
   let getMetadata: (url: string) => Promise<SiteMetadata>;
 
@@ -285,6 +318,115 @@ describe("getMetadata", () => {
 
       const result = await getMetadata("https://unreachable-image-example.com");
       expect(result.image).toBeUndefined();
+    });
+
+    it("re-extracts garbled text using the charset the page declares", async () => {
+      mockFetchByUrl(
+        () =>
+          new Response(eucJpPage() as unknown as BodyInit, {
+            status: 200,
+            headers: { "content-type": "text/html;charset=EUC-JP" },
+          }),
+      );
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "����",
+        description: "����",
+        image: undefined,
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://euc-jp-example.com");
+      expect(result.title).toBe("楽天");
+      expect(result.description).toBe("楽天");
+    });
+
+    it("falls back to the <title> element when the page has no og:title", async () => {
+      mockFetchByUrl(
+        () =>
+          new Response(
+            concatBytes(
+              ascii('<html><head><meta charset="euc-jp"><title>'),
+              RAKUTEN_EUC_JP,
+              ascii("</title></head></html>"),
+            ) as unknown as BodyInit,
+            { status: 200, headers: { "content-type": "text/html" } },
+          ),
+      );
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "����",
+        description: undefined,
+        image: undefined,
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://euc-jp-title-example.com");
+      expect(result.title).toBe("楽天");
+    });
+
+    it("keeps garbled text as-is when the page declares UTF-8", async () => {
+      mockFetchByUrl(
+        () =>
+          new Response("<html><head><title>ok</title></head></html>", {
+            status: 200,
+            headers: { "content-type": "text/html; charset=utf-8" },
+          }),
+      );
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "� broken bytes",
+        description: undefined,
+        image: undefined,
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://utf8-broken-example.com");
+      expect(result.title).toBe("� broken bytes");
+    });
+
+    it("keeps garbled text as-is when the charset label is unknown", async () => {
+      mockFetchByUrl(
+        () =>
+          new Response("<html><head><title>ok</title></head></html>", {
+            status: 200,
+            headers: { "content-type": "text/html; charset=x-nonsense" },
+          }),
+      );
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "� unknown charset",
+        description: undefined,
+        image: undefined,
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://unknown-charset-example.com");
+      expect(result.title).toBe("� unknown charset");
+    });
+
+    it("keeps garbled text as-is when the page can't be re-fetched", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")));
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "� unreachable",
+        description: undefined,
+        image: undefined,
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://unreachable-page-example.com");
+      expect(result.title).toBe("� unreachable");
+    });
+
+    it("skips the repair fetch entirely when the text is clean", async () => {
+      const spy = mockFetchByUrl(
+        () => new Response(PNG_BYTES as unknown as BodyInit, { status: 200 }),
+      );
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "Clean title",
+        description: "Clean description",
+        image: undefined,
+        icon: undefined,
+      });
+
+      await getMetadata("https://clean-example.com");
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/me/src/__tests__/utils/blur-load.test.ts
+++ b/apps/me/src/__tests__/utils/blur-load.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { blurLoadHandlers } from "#/utils/blur-load";
+
+describe("blurLoadHandlers", () => {
+  it("targets the given ancestor selector", () => {
+    expect(blurLoadHandlers(".blur-load").onload).toBe(
+      "this.closest('.blur-load')?.classList.add('image-loaded')",
+    );
+  });
+
+  it("reveals on error too, so a broken image doesn't stay blurred", () => {
+    const { onload, onerror } = blurLoadHandlers("[data-blur-load]");
+    expect(onerror).toBe(onload);
+  });
+});

--- a/apps/me/src/components/ui/image/image.astro
+++ b/apps/me/src/components/ui/image/image.astro
@@ -2,6 +2,7 @@
 import { Picture as AstroPicture, getImage, type Picture } from "astro:assets";
 import type { UnresolvedImageTransform } from "astro";
 
+import { blurLoadHandlers } from "#/utils/blur-load";
 import type { CustomImageProps } from "./types";
 
 type Props = CustomImageProps;
@@ -38,7 +39,7 @@ const pictureProps = {
   quality: 80,
   widths,
   sizes,
-  onload: "this.closest('.blur-load')?.classList.add('image-loaded')",
+  ...blurLoadHandlers(".blur-load"),
   ...rest,
 } as Parameters<typeof Picture>[0];
 

--- a/apps/me/src/features/blog/components/ui/blocks/link-card.astro
+++ b/apps/me/src/features/blog/components/ui/blocks/link-card.astro
@@ -4,6 +4,7 @@ import type { HTMLAttributes } from "astro/types";
 import GlobeIcon from "#/components/icons/globe.svg";
 import { getMetadata } from "#/lib/api/metadata";
 import { BASE_URL } from "#/utils/base-url";
+import { blurLoadHandlers } from "#/utils/blur-load";
 
 interface Props extends HTMLAttributes<"a"> {
   href: string;
@@ -56,7 +57,7 @@ const blurryImage = image
                 sizes="(max-width: 639.98px) 100vw, 230px"
                 format="avif"
                 class="link-card-img"
-                onload="this.closest('.link-card-blur-load')?.classList.add('image-loaded')"
+                {...blurLoadHandlers(".link-card-blur-load")}
             />
           </div>
       )}

--- a/apps/me/src/features/blog/components/ui/blocks/memo-card.astro
+++ b/apps/me/src/features/blog/components/ui/blocks/memo-card.astro
@@ -4,6 +4,7 @@ import type { HTMLAttributes } from "astro/types";
 import Budoux from "#/components/budoux.astro";
 import MemoIcon from "#/components/icons/memo.svg";
 import { extractMemoId, getMemoPost } from "#/lib/api/memo";
+import { blurLoadHandlers } from "#/utils/blur-load";
 import { convertDateToString } from "#/utils/date";
 
 interface Props extends HTMLAttributes<"a"> {
@@ -108,7 +109,7 @@ const blurryImages = hasImages
                       format="avif"
                       alt={`Image ${i + 1}`}
                       class="memo-img"
-                      onload="this.closest('[data-blur-load]')?.classList.add('image-loaded')"
+                      {...blurLoadHandlers("[data-blur-load]")}
                     />
                   </div>
                 ))}

--- a/apps/me/src/lib/api/metadata.ts
+++ b/apps/me/src/lib/api/metadata.ts
@@ -67,12 +67,22 @@ const isProcessableImage = async (src: string): Promise<boolean> => {
   }
 };
 
+// Astro only optimizes remote images matching `image.remotePatterns` (https
+// only), so an `http:` og:image is emitted verbatim and then blocked as mixed
+// content on our https pages: the `<img>` never fires `load`, so the blur
+// placeholder never clears. Most such hosts also serve https.
+const toHttps = (src: string): string =>
+  src.startsWith("http://") ? `https://${src.slice("http://".length)}` : src;
+
 const dropUnprocessableImage = async (metadata: Metadata): Promise<Metadata> => {
-  const src = metadata.image?.src;
-  if (!src || isSvgSrc(src)) {
-    return src ? { ...metadata, image: undefined } : metadata;
-  }
-  return (await isProcessableImage(src)) ? metadata : { ...metadata, image: undefined };
+  const image = metadata.image;
+  if (!image?.src) return metadata;
+  if (isSvgSrc(image.src)) return { ...metadata, image: undefined };
+
+  const src = toHttps(image.src);
+  return (await isProcessableImage(src))
+    ? { ...metadata, image: { ...image, src } }
+    : { ...metadata, image: undefined };
 };
 
 // `fetch-site-metadata` streams the raw response bytes into an HTMLRewriter

--- a/apps/me/src/lib/api/metadata.ts
+++ b/apps/me/src/lib/api/metadata.ts
@@ -1,8 +1,14 @@
 import { NODE_ENV } from "astro:env/client";
 import fetchSiteMetadata, { type Metadata } from "fetch-site-metadata";
+import { parseHTML } from "linkedom";
 import { createResolvedCache } from "#/lib/api/cache";
 
 const cache = createResolvedCache<Metadata>();
+
+const REQUEST_HEADERS = {
+  accept: "text/html",
+  "accept-language": "ja,en-US;q=0.7,en;q=0.3",
+} as const;
 
 // Astro's sharp service refuses SVG inputs unless `image.dangerouslyProcessSVG`
 // is enabled, so drop SVG og:images here to keep `<Image>` from crashing the build.
@@ -69,6 +75,91 @@ const dropUnprocessableImage = async (metadata: Metadata): Promise<Metadata> => 
   return (await isProcessableImage(src)) ? metadata : { ...metadata, image: undefined };
 };
 
+// `fetch-site-metadata` streams the raw response bytes into an HTMLRewriter
+// that always decodes as UTF-8, ignoring both `Content-Type: charset=` and
+// `<meta charset>`. Legacy Japanese shops (item.rakuten.co.jp is EUC-JP) come
+// back as U+FFFD soup, so re-extract the text fields with the declared charset.
+const REPLACEMENT_CHAR = "�";
+const CHARSET_SNIFF_BYTES = 4096;
+
+const isGarbled = ({ title, description }: Metadata): boolean =>
+  Boolean(title?.includes(REPLACEMENT_CHAR) ?? false) ||
+  Boolean(description?.includes(REPLACEMENT_CHAR) ?? false);
+
+const charsetFromContentType = /charset\s*=\s*"?([^";,\s]+)/iu;
+const charsetFromMeta = /<meta[^>]+charset\s*=\s*["']?([\w.:-]+)/iu;
+
+const decodeWithDeclaredCharset = (
+  bytes: ArrayBuffer,
+  contentType: string | null,
+): string | undefined => {
+  // Charset declarations are pure ASCII, so a latin1 pass over the head of the
+  // document is enough to find one without knowing the encoding yet.
+  const head = new TextDecoder("latin1").decode(bytes.slice(0, CHARSET_SNIFF_BYTES));
+  const charset =
+    charsetFromContentType.exec(contentType ?? "")?.[1] ?? charsetFromMeta.exec(head)?.[1];
+  if (!charset || /^utf-?8$/iu.test(charset)) return undefined;
+
+  try {
+    return new TextDecoder(charset).decode(bytes);
+  } catch {
+    // Unknown encoding label; the UTF-8 reading is the best we have.
+    return undefined;
+  }
+};
+
+// Same precedence as fetch-site-metadata's own rules, minus the case-insensitive
+// attribute matching linkedom's selector engine doesn't support.
+const TITLE_SELECTORS = [
+  'meta[property="og:title"]',
+  'meta[name="twitter:title"]',
+  'meta[property="twitter:title"]',
+] as const;
+
+const DESCRIPTION_SELECTORS = [
+  'meta[property="og:description"]',
+  'meta[name="description"]',
+  'meta[name="twitter:description"]',
+] as const;
+
+const firstContent = (
+  document: ReturnType<typeof parseHTML>["document"],
+  selectors: readonly string[],
+): string | undefined => {
+  for (const selector of selectors) {
+    const content = document.querySelector(selector)?.getAttribute("content")?.trim();
+    if (content) return content;
+  }
+  return undefined;
+};
+
+const reextractText = (html: string, metadata: Metadata): Metadata => {
+  const { document } = parseHTML(html);
+  const title = firstContent(document, TITLE_SELECTORS) ?? document.title.trim();
+  return {
+    ...metadata,
+    title: title || metadata.title,
+    description: firstContent(document, DESCRIPTION_SELECTORS) ?? metadata.description,
+  };
+};
+
+const repairGarbledText = async (url: string, metadata: Metadata): Promise<Metadata> => {
+  if (!isGarbled(metadata)) return metadata;
+
+  try {
+    const response = await fetch(url, { headers: REQUEST_HEADERS });
+    if (!response.ok) return metadata;
+
+    const html = decodeWithDeclaredCharset(
+      await response.arrayBuffer(),
+      response.headers.get("content-type"),
+    );
+    return html ? reextractText(html, metadata) : metadata;
+  } catch {
+    return metadata;
+  }
+};
+
 export const getMetadata = (url: string) =>
   cache(url, async () => {
     if (NODE_ENV !== "production" || process.env.CI) {
@@ -82,11 +173,9 @@ export const getMetadata = (url: string) =>
 
     return await fetchSiteMetadata(url, {
       suppressAdditionalRequest: true,
-      headers: {
-        accept: "text/html",
-        "accept-language": "ja,en-US;q=0.7,en;q=0.3",
-      },
+      headers: REQUEST_HEADERS,
     })
+      .then((metadata) => repairGarbledText(url, metadata))
       .then(dropUnprocessableImage)
       .catch(() => ({
         title: "Not Found",

--- a/apps/me/src/utils/blur-load.ts
+++ b/apps/me/src/utils/blur-load.ts
@@ -1,0 +1,14 @@
+/**
+ * Inline handlers that clear the blurred placeholder wrapping an image.
+ *
+ * `error` matters as much as `load`: an image that never decodes (blocked
+ * mixed content, 404, unsupported format) would otherwise leave the blur on
+ * screen forever. Inline attributes rather than a script so the reveal also
+ * works for images that finish before any bundle is parsed.
+ *
+ * @param selector CSS selector of the ancestor carrying the blur.
+ */
+export const blurLoadHandlers = (selector: string) => {
+  const reveal = `this.closest('${selector}')?.classList.add('image-loaded')`;
+  return { onload: reveal, onerror: reveal };
+};


### PR DESCRIPTION
- Decode link card metadata with the charset the page declares, re-fetching only when the first UTF-8 pass produced replacement characters
- Rewrite `http:` og:image URLs to `https:` before the processability probe so Astro optimizes them instead of emitting blocked mixed content
- Extract `blurLoadHandlers` and wire `error` alongside `load` so images that never decode still clear the blur placeholder
- Apply the shared handlers across content images, link cards, and memo cards
- Add tests for charset repair, the https upgrade, and the blur handler pair