### PR TITLE
[main] ci: align submodule label color with base set

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -7,4 +7,4 @@ extends: kkhys/.github
 labels:
   - name: "type: submodule"
     description: "Submodule update"
-    color: "#f2edfc"
+    color: "#d6e8ff"


### PR DESCRIPTION
- Change the `type: submodule` label color to `#d6e8ff` so it matches the `type:` palette inherited from the shared kkhys/.github base label set