### PR TITLE
[main] chore: drop the coverage gate from the stop hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,11 +12,6 @@
             "type": "command",
             "command": "OUTPUT=$(pnpm run check 2>&1); RC=$?; if [ $RC -ne 0 ]; then echo \"$OUTPUT\" >&2; exit 1; fi",
             "statusMessage": "Running type check..."
-          },
-          {
-            "type": "command",
-            "command": "OUTPUT=$(pnpm run coverage 2>&1); RC=$?; if [ $RC -ne 0 ]; then echo \"$OUTPUT\" >&2; exit 1; fi; CLEAN=$(echo \"$OUTPUT\" | perl -pe 's/\\e\\[\\d+(?:;\\d+)*m//g'); REPORT=$(echo \"$CLEAN\" | awk -F'|' '/\\|/ && !/File/ && !/All files/ { s=$2; f=$4; l=$5; gsub(/[[:space:]]/,\"\",s); gsub(/[[:space:]]/,\"\",f); gsub(/[[:space:]]/,\"\",l); if((s ~ /^[0-9.]+$/ && s+0!=100) || (f ~ /^[0-9.]+$/ && f+0!=100) || (l ~ /^[0-9.]+$/ && l+0!=100)) { found=1; print } } END { exit !found }'); if [ $? -eq 0 ]; then echo \"Coverage is not 100%. Fix the uncovered lines:\" >&2; echo \"$REPORT\" >&2; exit 1; fi",
-            "statusMessage": "Checking test coverage is 100%..."
           }
         ]
       }


### PR DESCRIPTION
- Remove the 100% coverage gate from the Stop hook in `.claude/settings.json`
- Keep the lint/format and type check hooks as the remaining stop-time gates
- Drop the awk/perl coverage report parsing that blocked stops on any uncovered line