### PR TITLE
[main] chore: remove skipped sources from backfilled trend runs

### DIFF
--- a/apps/trends/src/content/runs/2026-07-01.json
+++ b/apps/trends/src/content/runs/2026-07-01.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-02.json
+++ b/apps/trends/src/content/runs/2026-07-02.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-03.json
+++ b/apps/trends/src/content/runs/2026-07-03.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-04.json
+++ b/apps/trends/src/content/runs/2026-07-04.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-05.json
+++ b/apps/trends/src/content/runs/2026-07-05.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-06.json
+++ b/apps/trends/src/content/runs/2026-07-06.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-07.json
+++ b/apps/trends/src/content/runs/2026-07-07.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-08.json
+++ b/apps/trends/src/content/runs/2026-07-08.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-09.json
+++ b/apps/trends/src/content/runs/2026-07-09.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-10.json
+++ b/apps/trends/src/content/runs/2026-07-10.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-11.json
+++ b/apps/trends/src/content/runs/2026-07-11.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-12.json
+++ b/apps/trends/src/content/runs/2026-07-12.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-13.json
+++ b/apps/trends/src/content/runs/2026-07-13.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-14.json
+++ b/apps/trends/src/content/runs/2026-07-14.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-15.json
+++ b/apps/trends/src/content/runs/2026-07-15.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-16.json
+++ b/apps/trends/src/content/runs/2026-07-16.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-17.json
+++ b/apps/trends/src/content/runs/2026-07-17.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-18.json
+++ b/apps/trends/src/content/runs/2026-07-18.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-19.json
+++ b/apps/trends/src/content/runs/2026-07-19.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-20.json
+++ b/apps/trends/src/content/runs/2026-07-20.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-21.json
+++ b/apps/trends/src/content/runs/2026-07-21.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-22.json
+++ b/apps/trends/src/content/runs/2026-07-22.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-23.json
+++ b/apps/trends/src/content/runs/2026-07-23.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-24.json
+++ b/apps/trends/src/content/runs/2026-07-24.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-25.json
+++ b/apps/trends/src/content/runs/2026-07-25.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-26.json
+++ b/apps/trends/src/content/runs/2026-07-26.json
@@ -33,33 +33,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -200,27 +173,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-27.json
+++ b/apps/trends/src/content/runs/2026-07-27.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-28.json
+++ b/apps/trends/src/content/runs/2026-07-28.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-29.json
+++ b/apps/trends/src/content/runs/2026-07-29.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-30.json
+++ b/apps/trends/src/content/runs/2026-07-30.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-07-31.json
+++ b/apps/trends/src/content/runs/2026-07-31.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-08-01.json
+++ b/apps/trends/src/content/runs/2026-08-01.json
@@ -33,33 +33,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -200,27 +173,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-08-02.json
+++ b/apps/trends/src/content/runs/2026-08-02.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-08-03.json
+++ b/apps/trends/src/content/runs/2026-08-03.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-08-04.json
+++ b/apps/trends/src/content/runs/2026-08-04.json
@@ -33,33 +33,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -200,27 +173,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-08-05.json
+++ b/apps/trends/src/content/runs/2026-08-05.json
@@ -33,33 +33,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -200,27 +173,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-08-06.json
+++ b/apps/trends/src/content/runs/2026-08-06.json
@@ -39,33 +39,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -206,27 +179,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }

--- a/apps/trends/src/content/runs/2026-08-07.json
+++ b/apps/trends/src/content/runs/2026-08-07.json
@@ -33,33 +33,6 @@
   },
   "markets": [
     {
-      "id": "japan",
-      "label": "日本",
-      "services": [
-        {
-          "id": "hatena",
-          "label": "はてなブックマーク",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "zenn",
-          "label": "Zenn",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "qiita",
-          "label": "Qiita",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        }
-      ]
-    },
-    {
       "id": "global",
       "label": "グローバル",
       "services": [
@@ -200,27 +173,6 @@
               "extra": ""
             }
           ]
-        },
-        {
-          "id": "lobsters",
-          "label": "Lobsters",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "github",
-          "label": "GitHub Trending",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
-        },
-        {
-          "id": "devto",
-          "label": "dev.to",
-          "status": "skipped",
-          "note": "過去日付を照会できるAPIがないため取得不可",
-          "items": []
         }
       ]
     }


### PR DESCRIPTION
- Remove placeholder service entries whose sources cannot be queried for past dates from backfilled runs (2026-07-01 to 2026-08-07)
- Drop the japan market from runs where no services remain after the cleanup
- Stop empty "取得不可" cards from rendering on the affected digest pages