### PR TITLE
[main] feat: add japanese title translations to trends

### DIFF
--- a/apps/trends/CLAUDE.md
+++ b/apps/trends/CLAUDE.md
@@ -44,6 +44,7 @@ public/                       # robots.txt, manifest, static favicons (generated
 - File name must equal the `date` field; `[date].astro`'s getStaticPaths throws on mismatch.
 - All string fields are required with `""` for absent values (no nulls) — keeps `exactOptionalPropertyTypes` out of the data path.
 - `discussion_summary` is non-empty only for the top items of comment-capable sources (HN / Lobsters / はてなブックマーク, `comments_top_n` in the skill's config); it renders as a `<details>` fold. Older runs predate the field and rely on the zod default.
+- `title_ja` (on items and digest highlights) is a Japanese translation of an originally non-Japanese title, `""` when the title is already Japanese. When present it becomes the linked title and the original renders beneath it. Older runs predate the field and rely on the zod default.
 
 ## Key Design Decisions
 

--- a/apps/trends/src/components/digest-hero.astro
+++ b/apps/trends/src/components/digest-hero.astro
@@ -26,11 +26,12 @@ const { digest } = Astro.props;
             <Budoux>
               <span class="hl-title palt">
                 <a href={highlight.url} target="_blank" rel="noopener">
-                  {highlight.title}
+                  {highlight.title_ja || highlight.title}
                 </a>
                 <span class="hl-service">{highlight.service_label}</span>
               </span>
             </Budoux>
+            {highlight.title_ja && <span class="hl-original">{highlight.title}</span>}
             <Budoux>
               <span class="hl-reason">{highlight.reason}</span>
             </Budoux>
@@ -114,6 +115,15 @@ const { digest } = Astro.props;
     padding: 0.0625rem 0.5rem;
     margin-left: 0.5rem;
     white-space: nowrap;
+  }
+
+  .hl-original {
+    display: block;
+    margin-top: 0.15rem;
+    color: var(--c-faint);
+    font-size: var(--fs-xs);
+    line-height: 1.5;
+    overflow-wrap: anywhere;
   }
 
   .hl-reason {

--- a/apps/trends/src/components/item-row.astro
+++ b/apps/trends/src/components/item-row.astro
@@ -17,6 +17,8 @@ const { item, rank } = Astro.props;
 
 const host = formatHost(item.url);
 const hasDiscussionLink = item.comments_url !== "" && item.comments_url !== item.url;
+const displayTitle = item.title_ja || item.title;
+const originalTitle = item.title_ja ? item.title : "";
 ---
 
 <article class="item">
@@ -24,9 +26,10 @@ const hasDiscussionLink = item.comments_url !== "" && item.comments_url !== item
   <div class="body">
     <Budoux>
       <div class="title palt">
-        <a href={item.url} target="_blank" rel="noopener">{item.title}</a>
+        <a href={item.url} target="_blank" rel="noopener">{displayTitle}</a>
       </div>
     </Budoux>
+    {originalTitle && <p class="original-title">{originalTitle}</p>}
     {
       item.summary && (
         <Budoux>
@@ -88,6 +91,14 @@ const hasDiscussionLink = item.comments_url !== "" && item.comments_url !== item
     font-size: 0.9375rem;
     font-weight: var(--fw-medium);
     line-height: 1.6;
+  }
+
+  .original-title {
+    margin: 0.15rem 0 0;
+    color: var(--c-faint);
+    font-size: var(--fs-xs);
+    line-height: 1.5;
+    overflow-wrap: anywhere;
   }
 
   .summary {

--- a/apps/trends/src/content.config.ts
+++ b/apps/trends/src/content.config.ts
@@ -4,6 +4,9 @@ import { defineCollection } from "astro:content";
 
 const item = z.object({
   title: z.string(),
+  // Japanese translation of an originally non-Japanese title; "" when the
+  // title is already Japanese. Older runs predate the field.
+  title_ja: z.string().default(""),
   url: z.url(),
   // Empty when the source has no separate discussion page.
   comments_url: z.string().default(""),
@@ -37,6 +40,7 @@ const runs = defineCollection({
         highlights: z.array(
           z.object({
             title: z.string(),
+            title_ja: z.string().default(""),
             url: z.url(),
             service_label: z.string(),
             reason: z.string(),


### PR DESCRIPTION
- Add `title_ja` field to item and digest highlight schemas, defaulting to `""` so older runs without the field keep validating
- Render the Japanese translation as the linked title in item rows and digest hero highlights when present
- Show the original title in muted small text beneath the translated title
- Document the `title_ja` convention in apps/trends/CLAUDE.md