### PR TITLE
[main] feat: render multi-paragraph summary folds

### DIFF
--- a/apps/trends/CLAUDE.md
+++ b/apps/trends/CLAUDE.md
@@ -43,7 +43,8 @@ public/                       # robots.txt, manifest, static favicons (generated
 - When changing the schema, update in the same change: `content.config.ts`, the JSON example in the skill's SKILL.md, and every existing file in `src/content/runs/`.
 - File name must equal the `date` field; `[date].astro`'s getStaticPaths throws on mismatch.
 - All string fields are required with `""` for absent values (no nulls) — keeps `exactOptionalPropertyTypes` out of the data path.
-- `discussion_summary` is non-empty only for the top items of comment-capable sources (HN / Lobsters / はてなブックマーク, `comments_top_n` in the skill's config); it renders as a `<details>` fold. Older runs predate the field and rely on the zod default.
+- `discussion_summary` is non-empty only for the top items of comment-capable sources (HN / Lobsters / はてなブックマーク, `comments_top_n` in the skill's config, default 10 = every displayed item). It is 2-3 short paragraphs separated by blank lines (`\n\n`); `item-row.astro` splits on blank lines and renders one `<p>` per paragraph inside a `<details>` fold, so older single-paragraph runs render unchanged.
+- `article_summary` is the same multi-paragraph format for the sources without a comment fetcher (GitHub Trending / dev.to / Zenn / Qiita, `articles_top_n` in the skill's config), summarizing the article body the fetch script attaches. Mutually exclusive with `discussion_summary`; the fold label switches (コメントの要約 / 記事の要約). Older runs predate the field and rely on the zod default.
 - `title_ja` (on items and digest highlights) is a Japanese translation of an originally non-Japanese title, `""` when the title is already Japanese. When present it becomes the linked title and the original renders beneath it. Older runs predate the field and rely on the zod default.
 
 ## Key Design Decisions

--- a/apps/trends/src/__tests__/utils/paragraphs.test.ts
+++ b/apps/trends/src/__tests__/utils/paragraphs.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { splitParagraphs } from "#/utils/paragraphs";
+
+describe("splitParagraphs", () => {
+  it("splits on blank lines", () => {
+    expect(splitParagraphs("第一段落。\n\n第二段落。\n\n第三段落。")).toEqual([
+      "第一段落。",
+      "第二段落。",
+      "第三段落。",
+    ]);
+  });
+
+  it("keeps a single paragraph intact", () => {
+    expect(splitParagraphs("段落がひとつだけの古い形式。")).toEqual([
+      "段落がひとつだけの古い形式。",
+    ]);
+  });
+
+  it("ignores extra blank lines and surrounding whitespace", () => {
+    expect(splitParagraphs("  一つ目。 \n\n\n\n 二つ目。\n\n")).toEqual(["一つ目。", "二つ目。"]);
+  });
+
+  it("returns an empty array for an empty string", () => {
+    expect(splitParagraphs("")).toEqual([]);
+  });
+});

--- a/apps/trends/src/components/item-row.astro
+++ b/apps/trends/src/components/item-row.astro
@@ -3,6 +3,7 @@ import type { CollectionEntry } from "astro:content";
 
 import Budoux from "#/components/budoux.astro";
 import { formatHost } from "#/utils/host";
+import { splitParagraphs } from "#/utils/paragraphs";
 import { scoreLevel } from "#/utils/score";
 
 type Item =
@@ -19,6 +20,10 @@ const host = formatHost(item.url);
 const hasDiscussionLink = item.comments_url !== "" && item.comments_url !== item.url;
 const displayTitle = item.title_ja || item.title;
 const originalTitle = item.title_ja ? item.title : "";
+const discussionParagraphs = splitParagraphs(item.discussion_summary);
+const foldParagraphs =
+  discussionParagraphs.length > 0 ? discussionParagraphs : splitParagraphs(item.article_summary);
+const foldLabel = discussionParagraphs.length > 0 ? "コメントの要約" : "記事の要約";
 ---
 
 <article class="item">
@@ -38,11 +43,13 @@ const originalTitle = item.title_ja ? item.title : "";
       )
     }
     {
-      item.discussion_summary && (
+      foldParagraphs.length > 0 && (
         <details class="discussion">
-          <summary>議論の要約</summary>
+          <summary>{foldLabel}</summary>
           <Budoux>
-            <p>{item.discussion_summary}</p>
+            {foldParagraphs.map((paragraph) => (
+              <p>{paragraph}</p>
+            ))}
           </Budoux>
         </details>
       )
@@ -57,7 +64,7 @@ const originalTitle = item.title_ja ? item.title : "";
       {
         hasDiscussionLink && (
           <a class="comments" href={item.comments_url} target="_blank" rel="noopener">
-            議論を見る
+            コメントを見る
           </a>
         )
       }
@@ -135,6 +142,10 @@ const originalTitle = item.title_ja ? item.title : "";
     margin: 0.3rem 0 0;
     font-size: 0.8125rem;
     line-height: 1.7;
+  }
+
+  .discussion p + p {
+    margin-top: 0.6rem;
   }
 
   .meta {

--- a/apps/trends/src/content.config.ts
+++ b/apps/trends/src/content.config.ts
@@ -16,6 +16,10 @@ const item = z.object({
   interest: z.number().int().min(1).max(3),
   summary: z.string().default(""),
   discussion_summary: z.string().default(""),
+  // Multi-paragraph summary of the article body itself, for sources without
+  // a comment fetcher (GitHub / dev.to / Zenn / Qiita). Mutually exclusive
+  // with discussion_summary. Older runs predate the field.
+  article_summary: z.string().default(""),
   seen_before: z.boolean().default(false),
   extra: z.string().default(""),
 });

--- a/apps/trends/src/pages/about.astro
+++ b/apps/trends/src/pages/about.astro
@@ -39,9 +39,14 @@ const glossary = [
     description: "興味プロフィールのテーマから付けた短いラベル（AI/開発 など）。",
   },
   {
-    term: "議論の要約",
+    term: "コメントの要約",
     description:
-      "Hacker News / Lobsters / はてなブックマークの上位記事に付く折りたたみ。コメント欄の主な論点を2-3文でまとめています。",
+      "Hacker News / Lobsters / はてなブックマークの記事に付く折りたたみ。記事の概要と、コメント欄の主な論点や意見の分かれ方を2-3段落でまとめています。",
+  },
+  {
+    term: "記事の要約",
+    description:
+      "GitHub Trending / dev.to / Zenn / Qiita の記事に付く折りたたみ。コメント欄の取得に対応していないソースのため、代わりに記事本文の要点を2-3段落でまとめています。",
   },
   {
     term: "ハイライト",

--- a/apps/trends/src/utils/paragraphs.ts
+++ b/apps/trends/src/utils/paragraphs.ts
@@ -1,0 +1,5 @@
+export const splitParagraphs = (text: string): string[] =>
+  text
+    .split(/\n{2,}/u)
+    .map((paragraph) => paragraph.trim())
+    .filter((paragraph) => paragraph !== "");


### PR DESCRIPTION
- Add `article_summary` schema field for sources without a comment fetcher (GitHub Trending / dev.to / Zenn / Qiita), mutually exclusive with `discussion_summary`
- Split summary text on blank lines with a new `splitParagraphs` utility and render one `<p>` per paragraph inside the `<details>` fold
- Switch the fold label between コメントの要約 and 記事の要約 depending on which summary is present
- Update the about page glossary and CLAUDE.md to describe the multi-paragraph format
- Add unit tests for `splitParagraphs`

Skill-side changes: kkhys/claude-code-marketplace#86