### PR TITLE
[main] feat: add press feedback to post nav cards

### DIFF
--- a/apps/me/src/features/blog/components/ui/post-navigation.astro
+++ b/apps/me/src/features/blog/components/ui/post-navigation.astro
@@ -74,11 +74,17 @@ const { olderPost, newerPost, class: className, ...rest } = Astro.props;
     border-radius: var(--radius-md);
     text-decoration: none;
     color: var(--c-prose-text);
-    transition: background-color 0.2s;
+    transition:
+      background-color 0.2s,
+      transform 0.15s ease;
   }
 
   .post-nav-item:hover {
     background-color: oklch(from var(--c-surface) l c h / 50%);
+  }
+
+  .post-nav-item:active {
+    transform: scale(0.99);
   }
 
   .post-nav-item--newer {


### PR DESCRIPTION
- Add an :active state that scales post navigation cards down to 0.99 for press feedback
- Extend the transition to animate transform (0.15s ease) alongside background-color