### PR TITLE
[main] fix: resolve link card and toc display issues

### DIFF
--- a/apps/me/src/__tests__/lib/api/metadata.test.ts
+++ b/apps/me/src/__tests__/lib/api/metadata.test.ts
@@ -373,6 +373,34 @@ describe("getMetadata", () => {
       expect(result.description).toBe("楽天");
     });
 
+    it("repairs a description declared with a capitalized name attribute", async () => {
+      // www.kinn-tailor.com (Shift_JIS) writes `<meta name="Description">`;
+      // a case-sensitive selector match would leave the description garbled.
+      mockFetchByUrl(
+        () =>
+          new Response(
+            concatBytes(
+              ascii('<html><head><meta charset="euc-jp"><title>'),
+              RAKUTEN_EUC_JP,
+              ascii('</title><meta name="Description" content="'),
+              RAKUTEN_EUC_JP,
+              ascii('" /></head></html>'),
+            ) as unknown as BodyInit,
+            { status: 200, headers: { "content-type": "text/html" } },
+          ),
+      );
+      mockFetchSiteMetadata.mockResolvedValueOnce({
+        title: "����",
+        description: "����",
+        image: undefined,
+        icon: undefined,
+      });
+
+      const result = await getMetadata("https://capitalized-meta-example.com");
+      expect(result.title).toBe("楽天");
+      expect(result.description).toBe("楽天");
+    });
+
     it("falls back to the <title> element when the page has no og:title", async () => {
       mockFetchByUrl(
         () =>

--- a/apps/me/src/features/blog/components/ui/blocks/link-card.astro
+++ b/apps/me/src/features/blog/components/ui/blocks/link-card.astro
@@ -42,8 +42,8 @@ const blurryImage = image
       </span>
       </div>
     </div>
-    <div class="link-card-image">
-      {image && (
+    {image && (
+        <div class="link-card-image">
           <div
               class="link-card-blur-load blur-load"
               style={`background-image: url(${blurryImage?.src})`}
@@ -60,8 +60,8 @@ const blurryImage = image
                 {...blurLoadHandlers(".link-card-blur-load")}
             />
           </div>
-      )}
-    </div>
+        </div>
+    )}
   </a>
 </div>
 
@@ -146,11 +146,14 @@ const blurryImage = image
 
   /* Mobile: full-width banner on top, kept at the standard OG ratio.
      overflow: hidden clips the blur halo so it doesn't bleed past the image
-     box into the adjacent text on the desktop horizontal layout. */
+     box into the adjacent text on the desktop horizontal layout.
+     The divider keeps near-white OG images from blending into the card
+     background in light mode; it sits on the edge facing the text. */
   .link-card-image {
     width: 100%;
     aspect-ratio: 40 / 21;
     overflow: hidden;
+    border-bottom: 1px solid var(--c-border);
   }
 
   .link-card-blur-load {
@@ -191,6 +194,8 @@ const blurryImage = image
     .link-card-image {
       width: auto;
       height: 100%;
+      border-bottom: none;
+      border-left: 1px solid var(--c-border);
     }
   }
 </style>

--- a/apps/me/src/features/blog/components/ui/toc.astro
+++ b/apps/me/src/features/blog/components/ui/toc.astro
@@ -94,7 +94,9 @@ const items = headings.filter(({ depth }) => depth === 2 || depth === 3);
       --toc-rail-active-color: light-dark(var(--uchu-yin-8), var(--uchu-gray-3));
 
       background-color: var(--toc-rail-active-color);
-      box-shadow: 0 0 3px var(--toc-rail-active-color);
+      /* The glow reads as emitted light in dark mode but as ink bleeding
+         around the near-black rail in light mode, so light mode drops it. */
+      box-shadow: 0 0 3px light-dark(transparent, var(--toc-rail-active-color));
     }
 
     .toc-panel {

--- a/apps/me/src/lib/api/metadata.ts
+++ b/apps/me/src/lib/api/metadata.ts
@@ -118,38 +118,44 @@ const decodeWithDeclaredCharset = (
   }
 };
 
-// Same precedence as fetch-site-metadata's own rules, minus the case-insensitive
-// attribute matching linkedom's selector engine doesn't support.
-const TITLE_SELECTORS = [
-  'meta[property="og:title"]',
-  'meta[name="twitter:title"]',
-  'meta[property="twitter:title"]',
+// Same precedence as fetch-site-metadata's own rules. Legacy sites capitalize
+// these attributes (www.kinn-tailor.com writes `name="Description"`) and
+// linkedom's selector engine lacks the `[name="description" i]` flag, so match
+// attribute values manually, case-insensitively.
+const TITLE_SOURCES = [
+  ["property", "og:title"],
+  ["name", "twitter:title"],
+  ["property", "twitter:title"],
 ] as const;
 
-const DESCRIPTION_SELECTORS = [
-  'meta[property="og:description"]',
-  'meta[name="description"]',
-  'meta[name="twitter:description"]',
+const DESCRIPTION_SOURCES = [
+  ["property", "og:description"],
+  ["name", "description"],
+  ["name", "twitter:description"],
 ] as const;
 
 const firstContent = (
   document: ReturnType<typeof parseHTML>["document"],
-  selectors: readonly string[],
+  sources: readonly (readonly [attribute: string, value: string])[],
 ): string | undefined => {
-  for (const selector of selectors) {
-    const content = document.querySelector(selector)?.getAttribute("content")?.trim();
-    if (content) return content;
+  const metas = [...document.querySelectorAll("meta")];
+  for (const [attribute, value] of sources) {
+    for (const meta of metas) {
+      if (meta.getAttribute(attribute)?.toLowerCase() !== value) continue;
+      const content = meta.getAttribute("content")?.trim();
+      if (content) return content;
+    }
   }
   return undefined;
 };
 
 const reextractText = (html: string, metadata: Metadata): Metadata => {
   const { document } = parseHTML(html);
-  const title = firstContent(document, TITLE_SELECTORS) ?? document.title.trim();
+  const title = firstContent(document, TITLE_SOURCES) ?? document.title.trim();
   return {
     ...metadata,
     title: title || metadata.title,
-    description: firstContent(document, DESCRIPTION_SELECTORS) ?? metadata.description,
+    description: firstContent(document, DESCRIPTION_SOURCES) ?? metadata.description,
   };
 };
 


### PR DESCRIPTION
- Match og meta attributes case-insensitively when repairing garbled link card metadata, since legacy sites capitalize `name="Description"` and linkedom lacks the `i` selector flag
- Add tests covering the case-insensitive meta extraction
- Drop the link card image wrapper when a page has no og:image so the description no longer truncates short of the card edge
- Draw a hairline divider between the og image and text so near-white images stay visible in light mode
- Make the toc rail glow transparent in light mode via `light-dark()`