### PR TITLE
[main] feat: show site favicons on link cards

### DIFF
--- a/apps/me/src/__tests__/lib/api/favicon.test.ts
+++ b/apps/me/src/__tests__/lib/api/favicon.test.ts
@@ -1,0 +1,137 @@
+import { Buffer } from "node:buffer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// PNG magic number, padded so signature checks read past the header.
+const PNG_BYTES = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0, 0, 0, 0, 0,
+]);
+
+// ICO header: reserved 0x0000, type 0x0001, one image entry.
+const ICO_BYTES = new Uint8Array([0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+const SVG_TEXT = '<svg xmlns="http://www.w3.org/2000/svg"><rect /></svg>';
+
+const mockFetch = (body: BodyInit | null, init?: ResponseInit) => {
+  const spy = vi.fn<typeof fetch>().mockResolvedValue(new Response(body, init));
+  vi.stubGlobal("fetch", spy);
+  return spy;
+};
+
+describe("getFavicon", () => {
+  let getFavicon: typeof import("#/lib/api/favicon").getFavicon;
+
+  beforeEach(async () => {
+    // Fresh module per test so the module-level cache doesn't leak between tests.
+    vi.resetModules();
+    ({ getFavicon } = await import("#/lib/api/favicon"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a remote favicon for bytes sharp can decode", async () => {
+    mockFetch(PNG_BYTES as unknown as BodyInit);
+
+    const result = await getFavicon("https://example.com/icon.png");
+    expect(result).toEqual({ kind: "remote", src: "https://example.com/icon.png" });
+  });
+
+  it("upgrades an http favicon to https before fetching", async () => {
+    const spy = mockFetch(PNG_BYTES as unknown as BodyInit);
+
+    const result = await getFavicon("http://example.com/icon.png");
+    expect(result).toEqual({ kind: "remote", src: "https://example.com/icon.png" });
+    expect(spy).toHaveBeenCalledWith("https://example.com/icon.png", expect.anything());
+  });
+
+  it("inlines an ICO favicon as a data URI", async () => {
+    mockFetch(ICO_BYTES as unknown as BodyInit);
+
+    const result = await getFavicon("https://example.com/favicon.ico");
+    expect(result).toEqual({
+      kind: "inline",
+      src: `data:image/x-icon;base64,${Buffer.from(ICO_BYTES).toString("base64")}`,
+    });
+  });
+
+  it("inlines an SVG favicon as a data URI", async () => {
+    mockFetch(SVG_TEXT);
+
+    const result = await getFavicon("https://example.com/icon.svg");
+    expect(result).toEqual({
+      kind: "inline",
+      src: `data:image/svg+xml;base64,${Buffer.from(SVG_TEXT).toString("base64")}`,
+    });
+  });
+
+  it("accepts an SVG that opens with an XML prolog", async () => {
+    const svg = `<?xml version="1.0" encoding="UTF-8"?>\n${SVG_TEXT}`;
+    mockFetch(svg);
+
+    const result = await getFavicon("https://example.com/prolog.svg");
+    expect(result.kind).toBe("inline");
+  });
+
+  it("rejects XML that is not an SVG", async () => {
+    mockFetch('<?xml version="1.0"?><rss version="2.0"></rss>');
+
+    const result = await getFavicon("https://example.com/feed.xml");
+    expect(result).toEqual({ kind: "none" });
+  });
+
+  it("rejects an HTML page served as a favicon", async () => {
+    mockFetch("<!DOCTYPE html><html><body><svg></svg></body></html>");
+
+    const result = await getFavicon("https://example.com/favicon.ico");
+    expect(result).toEqual({ kind: "none" });
+  });
+
+  it("rejects a favicon that responds with a non-ok status", async () => {
+    mockFetch(null, { status: 404 });
+
+    const result = await getFavicon("https://example.com/missing.ico");
+    expect(result).toEqual({ kind: "none" });
+  });
+
+  it("rejects an empty response body", async () => {
+    mockFetch(null, { status: 200 });
+
+    const result = await getFavicon("https://example.com/empty.ico");
+    expect(result).toEqual({ kind: "none" });
+  });
+
+  it("rejects an ICO too large to inline", async () => {
+    const huge = new Uint8Array(50 * 1024 + 1);
+    huge.set(ICO_BYTES);
+    mockFetch(huge as unknown as BodyInit);
+
+    const result = await getFavicon("https://example.com/huge.ico");
+    expect(result).toEqual({ kind: "none" });
+  });
+
+  it("keeps a raster favicon regardless of size", async () => {
+    const huge = new Uint8Array(50 * 1024 + 1);
+    huge.set(PNG_BYTES);
+    mockFetch(huge as unknown as BodyInit);
+
+    const result = await getFavicon("https://example.com/huge.png");
+    expect(result.kind).toBe("remote");
+  });
+
+  it("returns none when the fetch itself fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")));
+
+    const result = await getFavicon("https://example.com/unreachable.ico");
+    expect(result).toEqual({ kind: "none" });
+  });
+
+  it("caches results per icon URL", async () => {
+    const spy = mockFetch(PNG_BYTES as unknown as BodyInit);
+
+    const first = await getFavicon("https://example.com/cached.png");
+    const second = await getFavicon("https://example.com/cached.png");
+    expect(first).toBe(second);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/me/src/features/blog/components/ui/blocks/link-card.astro
+++ b/apps/me/src/features/blog/components/ui/blocks/link-card.astro
@@ -2,6 +2,7 @@
 import { getImage, Image } from "astro:assets";
 import type { HTMLAttributes } from "astro/types";
 import GlobeIcon from "#/components/icons/globe.svg";
+import { type Favicon, getFavicon } from "#/lib/api/favicon";
 import { getMetadata } from "#/lib/api/metadata";
 import { BASE_URL } from "#/utils/base-url";
 import { blurLoadHandlers } from "#/utils/blur-load";
@@ -13,7 +14,9 @@ interface Props extends HTMLAttributes<"a"> {
 const props = Astro.props;
 
 const isExternal = !props.href.startsWith(BASE_URL);
-const { title, description, image } = await getMetadata(props.href);
+const { title, description, image, icon } = await getMetadata(props.href);
+
+const favicon: Favicon = icon ? await getFavicon(icon) : { kind: "none" };
 
 // Tiny blurred placeholder shown until the real OG image loads, matching the
 // blur-load effect used by content and memo-card images.
@@ -36,7 +39,28 @@ const blurryImage = image
       {description}
       </span>
       <div class="link-card-domain">
-        <GlobeIcon class="link-card-globe" />
+        {favicon.kind === "remote" ? (
+            <Image
+                src={favicon.src}
+                alt=""
+                width={32}
+                height={32}
+                format="png"
+                class="link-card-favicon"
+            />
+        ) : favicon.kind === "inline" ? (
+            <img
+                src={favicon.src}
+                alt=""
+                width="32"
+                height="32"
+                loading="lazy"
+                decoding="async"
+                class="link-card-favicon"
+            />
+        ) : (
+            <GlobeIcon class="link-card-globe" />
+        )}
         <span class="link-card-hostname">
         {new URL(props.href).hostname}
       </span>
@@ -137,6 +161,21 @@ const blurryImage = image
     height: 0.75rem;
     flex-shrink: 0;
     margin-top: 1.5px;
+  }
+
+  /* Slightly larger than the globe fallback so the glyph stays legible inside
+     the chip padding. Favicons assume a light surface, so the chip stays light
+     in both themes to keep dark logos visible in dark mode; it's dimmed there
+     (gray-3, not white) so the chip doesn't glare against the dark card. */
+  .link-card-favicon {
+    width: 0.875rem;
+    height: 0.875rem;
+    flex-shrink: 0;
+    margin-top: 1.5px;
+    padding: 1.5px;
+    border-radius: 3px;
+    background-color: light-dark(var(--uchu-yang), var(--uchu-gray-3));
+    object-fit: contain;
   }
 
   .link-card-hostname {

--- a/apps/me/src/lib/api/favicon.ts
+++ b/apps/me/src/lib/api/favicon.ts
@@ -1,0 +1,56 @@
+import { Buffer } from "node:buffer";
+import { createResolvedCache } from "#/lib/api/cache";
+import { isIcoImage, isRasterImage, isSvgDocument } from "#/utils/image-signature";
+
+/**
+ * Favicon resolved at build time for a link card.
+ * - "remote": sharp-decodable raster; render through Astro's image pipeline.
+ * - "inline": ICO/SVG, which sharp can't decode; embedded as a data URI.
+ * - "none": missing, unreachable, or not a usable image; caller falls back.
+ */
+export type Favicon =
+  | { kind: "remote"; src: string }
+  | { kind: "inline"; src: string }
+  | { kind: "none" };
+
+const NONE: Favicon = { kind: "none" };
+
+// Inline data URIs are duplicated into every page that renders the card, so
+// oversized multi-resolution .ico files fall back to the globe icon instead.
+const MAX_INLINE_BYTES = 50 * 1024;
+
+const cache = createResolvedCache<Favicon>();
+
+// Astro only optimizes https remote images (`image.remotePatterns`), so an
+// http favicon would be emitted verbatim and blocked as mixed content.
+const toHttps = (src: string): string =>
+  src.startsWith("http://") ? `https://${src.slice("http://".length)}` : src;
+
+const inline = (mime: string, bytes: Uint8Array): Favicon => ({
+  kind: "inline",
+  src: `data:${mime};base64,${Buffer.from(bytes).toString("base64")}`,
+});
+
+// `fetch-site-metadata` guesses `/favicon.ico` without checking it exists
+// (suppressAdditionalRequest), and declared icons can 404 or serve HTML, so
+// verify the bytes here; anything dubious degrades to the globe fallback.
+export const getFavicon = (url: string): Promise<Favicon> =>
+  cache(url, async () => {
+    try {
+      const src = toHttps(url);
+      const response = await fetch(src, { headers: { accept: "image/*" } });
+      if (!response.ok) return NONE;
+
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      if (bytes.length === 0) return NONE;
+
+      if (isRasterImage(bytes)) return { kind: "remote", src };
+
+      if (bytes.length > MAX_INLINE_BYTES) return NONE;
+      if (isIcoImage(bytes)) return inline("image/x-icon", bytes);
+      if (isSvgDocument(bytes)) return inline("image/svg+xml", bytes);
+      return NONE;
+    } catch {
+      return NONE;
+    }
+  });

--- a/apps/me/src/lib/api/metadata.ts
+++ b/apps/me/src/lib/api/metadata.ts
@@ -2,6 +2,7 @@ import { NODE_ENV } from "astro:env/client";
 import fetchSiteMetadata, { type Metadata } from "fetch-site-metadata";
 import { parseHTML } from "linkedom";
 import { createResolvedCache } from "#/lib/api/cache";
+import { isRasterImage } from "#/utils/image-signature";
 
 const cache = createResolvedCache<Metadata>();
 
@@ -21,30 +22,6 @@ const isSvgSrc = (src: string): boolean => {
 // HTML (e.g. a bot-protection challenge page) to non-browser clients. sharp then
 // fails with "Could not process image metadata" and crashes the whole build, so
 // we sniff the leading bytes and only keep images sharp can actually decode.
-const matchesAt = (bytes: Uint8Array, offset: number, signature: readonly number[]): boolean =>
-  signature.every((byte, index) => bytes[offset + index] === byte);
-
-const isRasterImage = (bytes: Uint8Array): boolean => {
-  // PNG
-  if (matchesAt(bytes, 0, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
-    return true;
-  }
-  // JPEG
-  if (matchesAt(bytes, 0, [0xff, 0xd8, 0xff])) return true;
-  // GIF ("GIF8")
-  if (matchesAt(bytes, 0, [0x47, 0x49, 0x46, 0x38])) return true;
-  // WebP ("RIFF"...."WEBP")
-  if (
-    matchesAt(bytes, 0, [0x52, 0x49, 0x46, 0x46]) &&
-    matchesAt(bytes, 8, [0x57, 0x45, 0x42, 0x50])
-  ) {
-    return true;
-  }
-  // AVIF / HEIF (ISOBMFF "ftyp" box)
-  if (matchesAt(bytes, 4, [0x66, 0x74, 0x79, 0x70])) return true;
-  return false;
-};
-
 const isProcessableImage = async (src: string): Promise<boolean> => {
   try {
     const response = await fetch(src, { headers: { accept: "image/*" } });

--- a/apps/me/src/utils/image-signature.ts
+++ b/apps/me/src/utils/image-signature.ts
@@ -1,0 +1,47 @@
+/**
+ * Byte-signature sniffing for image formats, shared by the og:image and
+ * favicon validators. Content-type headers can't be trusted (some endpoints
+ * advertise `image/png` but serve an HTML challenge page), so callers check
+ * the leading bytes instead.
+ */
+
+const matchesAt = (bytes: Uint8Array, offset: number, signature: readonly number[]): boolean =>
+  signature.every((byte, index) => bytes[offset + index] === byte);
+
+/** Formats Astro's sharp service can actually decode. */
+export const isRasterImage = (bytes: Uint8Array): boolean => {
+  // PNG
+  if (matchesAt(bytes, 0, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return true;
+  }
+  // JPEG
+  if (matchesAt(bytes, 0, [0xff, 0xd8, 0xff])) return true;
+  // GIF ("GIF8")
+  if (matchesAt(bytes, 0, [0x47, 0x49, 0x46, 0x38])) return true;
+  // WebP ("RIFF"...."WEBP")
+  if (
+    matchesAt(bytes, 0, [0x52, 0x49, 0x46, 0x46]) &&
+    matchesAt(bytes, 8, [0x57, 0x45, 0x42, 0x50])
+  ) {
+    return true;
+  }
+  // AVIF / HEIF (ISOBMFF "ftyp" box)
+  if (matchesAt(bytes, 4, [0x66, 0x74, 0x79, 0x70])) return true;
+  return false;
+};
+
+/** ICO header (reserved 0x0000 + type 0x0001); sharp can't decode these. */
+export const isIcoImage = (bytes: Uint8Array): boolean =>
+  matchesAt(bytes, 0, [0x00, 0x00, 0x01, 0x00]);
+
+/**
+ * An HTML error page can mention "<svg" somewhere in its body, so only accept
+ * documents that open with an SVG root or an XML prolog leading to one.
+ */
+export const isSvgDocument = (bytes: Uint8Array): boolean => {
+  const head = new TextDecoder()
+    .decode(bytes.slice(0, 1024))
+    .replace(/^\uFEFF/u, "")
+    .trimStart();
+  return head.startsWith("<svg") || (head.startsWith("<?xml") && head.includes("<svg"));
+};


### PR DESCRIPTION
- Show the linked site's favicon on link cards instead of the static globe icon, keeping the globe as fallback
- Resolve favicons at build time: sharp-decodable rasters go through Astro's image pipeline, while ICO/SVG icons are inlined as data URIs (capped at 50 KB)
- Verify favicon bytes by signature since declared icons can 404 or serve HTML challenge pages, and upgrade http favicon URLs to https
- Extract image byte sniffing from metadata.ts into a shared image-signature util
- Add unit tests covering favicon resolution and fallback paths