### PR TITLE
[main] chore: pin pages project names in deploy scripts

### DIFF
--- a/apps/diary/package.json
+++ b/apps/diary/package.json
@@ -9,7 +9,7 @@
     "check": "astro check && tsc --noEmit",
     "lint": "oxlint && oxfmt --check",
     "lint:fix": "oxlint --fix && oxfmt",
-    "deploy": "pnpm build && wrangler pages deploy dist",
+    "deploy": "pnpm build && wrangler pages deploy dist --project-name=diary",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
     "all": "pnpm build && pnpm check && pnpm lint:fix && pnpm test && pnpm coverage"

--- a/apps/lgtm/package.json
+++ b/apps/lgtm/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "coverage": "vitest run --coverage",
     "all": "pnpm build && pnpm check && pnpm lint:fix && pnpm test && pnpm coverage",
-    "deploy": "pnpm build && wrangler pages deploy dist",
+    "deploy": "pnpm build && wrangler pages deploy dist --project-name=lgtm",
     "convert-videos": "bun run scripts/convert-videos.ts"
   },
   "dependencies": {

--- a/apps/me/package.json
+++ b/apps/me/package.json
@@ -16,7 +16,7 @@
     "playwright-install": "pnpm dlx playwright-core install chromium",
     "render:mermaid": "bun run scripts/render-mermaid.ts",
     "create:entry": "bun run scripts/create-entry.ts",
-    "deploy": "pnpm build && wrangler pages deploy dist"
+    "deploy": "pnpm build && wrangler pages deploy dist --project-name=me"
   },
   "dependencies": {
     "@astrojs/check": "catalog:",


### PR DESCRIPTION
- Add `--project-name` to the wrangler pages deploy scripts for me, lgtm, and diary
- Ensure local deploys always target the intended Cloudflare Pages project instead of relying on interactive selection