### PR TITLE
[main] refactor: share design tokens across apps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Apps:
 
 Packages:
 
-- `packages/styles` — `@kkhys/styles`, uchu.css OKLCH palette.
+- `packages/styles` — `@kkhys/styles`, uchu.css OKLCH palette + shared semantic tokens (`tokens.css`), base styles (`base.css`), and Satori hex mirrors (`colors`).
 - `packages/seo` — `@kkhys/seo`, BaseSEO / OpenGraph / TwitterCard Astro primitives.
 - `packages/og` — `@kkhys/og`, Satori OG image + favicon generators.
 - `packages/analytics` — `@kkhys/analytics`, self-hosted Umami tracker component.

--- a/apps/diary/CLAUDE.md
+++ b/apps/diary/CLAUDE.md
@@ -11,7 +11,7 @@ src/
   layouts/base-layout.astro   # HTML shell wired to the @kkhys/seo primitives
   components/diary-image.astro # <Picture> with AVIF/WebP variants + blur-up placeholder
   utils/entries.ts            # buildEntries: glob paths → dated, numbered entries (newest first)
-  styles/global.css           # Design tokens (--c-*, --ff-mono) + base styles; palette from @kkhys/styles
+  styles/global.css           # Imports @kkhys/styles (uchu + tokens + base) + app-local base styles
   __tests__/                  # Vitest unit tests
 public/robots.txt
 diary-content/                # Git submodule (private) — photos at diary/<YYYY-MM-DD>/<n>.jpg, not checked out in CI
@@ -21,7 +21,7 @@ diary-content/                # Git submodule (private) — photos at diary/<YYY
 
 Consumed as source (no build step).
 
-- `@kkhys/styles` — uchu.css OKLCH palette, imported in `src/styles/global.css`. The `--c-*` semantic tokens stay app-local.
+- `@kkhys/styles` — uchu.css palette + shared `tokens.css` / `base.css`, imported in `src/styles/global.css`. Tokens resolve to their light values (no dark scheme opt-in).
 - `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard in `base-layout.astro`. diary's OG image is the newest photo (variable-height JPEG), passed via the `imageType`/`imageWidth`/`imageHeight` props; `twitter:card` switches to "summary" when no photo exists.
 - `@kkhys/og` — favicon routes (`src/pages/api/favicon/[file].ts`, bound to the grayscale gradient). The OG image stays app-local (a photo, not a Satori card).
 

--- a/apps/diary/src/components/diary-image.astro
+++ b/apps/diary/src/components/diary-image.astro
@@ -59,7 +59,7 @@ const blurryImage = await getImage({ src, width: 20 });
   }
 
   .meta {
-    font-family: var(--ff-mono);
+    font-family: var(--font-mono);
     font-size: var(--fs-2xs);
     font-variant-numeric: tabular-nums;
     color: var(--c-sub);

--- a/apps/diary/src/pages/index.astro
+++ b/apps/diary/src/pages/index.astro
@@ -58,7 +58,7 @@ const ogImage = entries[0]
   }
 
   .title {
-    font-family: var(--ff-mono);
+    font-family: var(--font-mono);
     font-size: var(--fs-2xs);
     font-weight: var(--fw-normal);
     font-variant-numeric: tabular-nums;

--- a/apps/diary/src/styles/global.css
+++ b/apps/diary/src/styles/global.css
@@ -2,47 +2,12 @@
 
 @import "kiso.css" layer(reset);
 @import "@kkhys/styles/uchu.css" layer(tokens);
-
-/* ===== Design Tokens ===== */
-
-@layer tokens {
-  :root {
-    --c-bg: var(--uchu-yang);
-    --c-text: var(--uchu-yin);
-    --c-sub: var(--uchu-yin-6);
-    --c-border: var(--uchu-gray-2);
-
-    --ff-mono:
-      ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono",
-      monospace;
-
-    --fs-2xs: 0.625rem;
-    --fw-normal: 400;
-  }
-}
+@import "@kkhys/styles/tokens.css" layer(tokens);
+@import "@kkhys/styles/base.css" layer(base);
 
 /* ===== Base Styles ===== */
 
 @layer base {
-  * {
-    border-color: var(--c-border);
-  }
-
-  html {
-    font-family: system-ui, sans-serif;
-    scrollbar-gutter: stable both-edges;
-    scrollbar-color: var(--uchu-gray-3) transparent;
-    scrollbar-width: thin;
-    background-color: var(--c-bg);
-    color: var(--c-text);
-  }
-
-  ::selection {
-    box-shadow: none;
-    background-color: var(--uchu-gray-3);
-    color: var(--c-text);
-  }
-
   img {
     display: block;
     max-width: 100%;

--- a/apps/lgtm/CLAUDE.md
+++ b/apps/lgtm/CLAUDE.md
@@ -31,7 +31,7 @@ scripts/convert-videos.ts         # Bun + ffmpeg: convert .mov sources to animat
 
 Consumed as source (no build step); this app supplies its own config via thin wrappers.
 
-- `@kkhys/styles` — uchu.css OKLCH palette, imported in `src/styles/global.css`. The `--c-*` semantic tokens and the `prefers-color-scheme` dark mode stay app-local.
+- `@kkhys/styles` — uchu.css palette + shared `tokens.css` / `base.css`, imported in `src/styles/global.css`. Dark mode via `light-dark()`. Only lgtm-specific tokens (`--c-bg-gray`, `--c-text-emphasis`) stay app-local.
 - `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard primitives, wrapped by thin adapters in `src/components/seo/`. `head-meta.astro` and `json-ld.astro` are app-local.
 - `@kkhys/og` — favicon routes (`src/pages/api/favicon/[file].ts`, bound to the green gradient) + OG route handlers. The default OG card (`opengraph-image.tsx`) and the per-id OG (`pages/api/og/[id].png.ts`) stay app-local (bespoke layouts).
 

--- a/apps/lgtm/src/components/footer.astro
+++ b/apps/lgtm/src/components/footer.astro
@@ -30,7 +30,7 @@ const currentYear = new Date().getFullYear();
 
     footer a {
         font-size: var(--fs-xs);
-        color: var(--c-sub-text);
+        color: var(--c-sub);
         text-decoration: none;
     }
 
@@ -40,11 +40,11 @@ const currentYear = new Date().getFullYear();
 
     footer span {
         font-size: var(--fs-xs);
-        color: var(--c-sub-text);
+        color: var(--c-sub);
     }
 
     footer .separator {
         font-size: var(--fs-xs);
-        color: var(--c-sub-text);
+        color: var(--c-sub);
     }
 </style>

--- a/apps/lgtm/src/components/legal-layout.astro
+++ b/apps/lgtm/src/components/legal-layout.astro
@@ -50,24 +50,24 @@ const { currentLang, currentPage } = Astro.props;
 	}
 
 	.language-toggle .current {
-		color: var(--c-sub-text);
+		color: var(--c-sub);
 	}
 
 	article :global(h1) {
-		font-size: var(--fs-2xl);
+		font-size: var(--fs-xl);
 		margin-bottom: 2rem;
 		color: var(--c-text-emphasis);
 	}
 
 	article :global(h2) {
-		font-size: var(--fs-xl);
+		font-size: var(--fs-lg);
 		margin-top: 2rem;
 		margin-bottom: 1rem;
 		color: var(--c-text-emphasis);
 	}
 
 	article :global(h3) {
-		font-size: var(--fs-lg);
+		font-size: var(--fs-md);
 		margin-top: 1.5rem;
 		margin-bottom: 0.75rem;
 	}
@@ -99,7 +99,7 @@ const { currentLang, currentPage } = Astro.props;
 	article :global(.last-updated) {
 		margin-top: 3rem;
 		font-size: var(--fs-sm);
-		color: var(--c-sub-text);
+		color: var(--c-sub);
 		text-align: right;
 	}
 </style>

--- a/apps/lgtm/src/components/spinner.astro
+++ b/apps/lgtm/src/components/spinner.astro
@@ -4,7 +4,7 @@
   height={16}
   viewBox="0 0 24 24"
   fill="none"
-  stroke="var(--c-sub-text)"
+  stroke="var(--c-sub)"
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"

--- a/apps/lgtm/src/pages/[...page].astro
+++ b/apps/lgtm/src/pages/[...page].astro
@@ -157,7 +157,7 @@ const ogImageUrl = new URL("/api/og/default.png", Astro.site).href;
     aspect-ratio: 3 / 2;
     overflow: hidden;
     border-radius: 1rem;
-    background-color: var(--c-bg-light-gray);
+    background-color: var(--c-surface);
     transition: transform 0.1s ease;
   }
 

--- a/apps/lgtm/src/pages/[id].astro
+++ b/apps/lgtm/src/pages/[id].astro
@@ -131,7 +131,7 @@ const ogImageUrl = new URL(`/api/og/${id}.png`, Astro.site).href;
     width: 100%;
     border-radius: 1rem;
     overflow: hidden;
-    background-color: var(--c-bg-light-gray);
+    background-color: var(--c-surface);
   }
 
   .blur-load {
@@ -174,13 +174,13 @@ const ogImageUrl = new URL(`/api/og/${id}.png`, Astro.site).href;
     border: 1px solid var(--c-border);
     border-radius: 0.25rem;
     background-color: transparent;
-    color: var(--c-sub-text);
+    color: var(--c-sub);
     cursor: pointer;
     transition: all 0.1s ease;
   }
 
   .copy-format-button:hover {
-    border-color: var(--c-sub-text);
+    border-color: var(--c-sub);
     background-color: var(--c-bg-gray);
     color: var(--c-text);
   }

--- a/apps/lgtm/src/styles/global.css
+++ b/apps/lgtm/src/styles/global.css
@@ -1,53 +1,35 @@
-@import "@kkhys/styles/uchu.css";
-@import "kiso.css";
+@layer reset, tokens, base;
 
-:root {
-  --c-bg: var(--uchu-yang);
-  --c-bg-light-gray: var(--uchu-gray-1);
-  --c-bg-gray: var(--uchu-gray-2);
-  --c-border: var(--uchu-gray-4);
-  --c-text: var(--uchu-yin-9);
-  --c-sub-text: var(--uchu-yin-5);
-  --c-text-emphasis: var(--uchu-yin-7);
+@import "kiso.css" layer(reset);
+@import "@kkhys/styles/uchu.css" layer(tokens);
+@import "@kkhys/styles/tokens.css" layer(tokens);
+@import "@kkhys/styles/base.css" layer(base);
 
-  --fs-xs: 0.75rem;
-  --fs-sm: 0.875rem;
-  --fs-base: 1rem;
-  --fs-lg: 1.125rem;
-  --fs-xl: 1.25rem;
-  --fs-2xl: 1.5rem;
+/* ===== Design Tokens ===== */
 
-  --fw-semibold: 600;
-
-  --lh-sm: 1.5;
-  --lh-base: 1.75;
-}
-
-@media (prefers-color-scheme: dark) {
+@layer tokens {
   :root {
-    --c-bg: var(--uchu-yin);
-    --c-bg-light-gray: var(--uchu-yin-9);
-    --c-bg-gray: var(--uchu-yin-8);
-    --c-border: var(--uchu-yin-7);
-    --c-text: var(--uchu-yin-1);
-    --c-sub-text: var(--uchu-yin-5);
-    --c-text-emphasis: var(--uchu-yin-4);
+    color-scheme: light dark;
+
+    --c-bg-gray: light-dark(var(--uchu-gray-2), var(--uchu-yin-8));
+    --c-text-emphasis: light-dark(var(--uchu-yin-7), var(--uchu-yin-4));
   }
 }
 
-html {
-  font-size: 16px;
-  line-height: var(--lh-base);
-  background: var(--c-bg);
-  color: var(--c-text);
-  scrollbar-gutter: stable both-edges;
-}
+/* ===== Base Styles ===== */
 
-body {
-  margin-inline: auto;
-  min-height: 100vh;
-  max-width: 42rem;
-  display: grid;
-  grid-template-rows: [top] auto [main-start] 1fr [main-end] auto [bottom];
-  grid-template-columns: minmax(0, 1fr);
+@layer base {
+  html {
+    font-size: 16px;
+    line-height: var(--lh-base);
+  }
+
+  body {
+    margin-inline: auto;
+    min-height: 100vh;
+    max-width: var(--content-width);
+    display: grid;
+    grid-template-rows: [top] auto [main-start] 1fr [main-end] auto [bottom];
+    grid-template-columns: minmax(0, 1fr);
+  }
 }

--- a/apps/me/CLAUDE.md
+++ b/apps/me/CLAUDE.md
@@ -15,7 +15,7 @@ Personal blog (kkhys.me), the `@kkhys/me` app of the kkhys monorepo. Astro 7 sta
 
 Consumed as source (no build step); this app supplies its own config via thin wrappers.
 
-- `@kkhys/styles` — uchu.css OKLCH palette
+- `@kkhys/styles` — uchu.css OKLCH palette + shared semantic tokens / base styles; me keeps only prose- and code-specific tokens local
 - `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard primitives, wrapped in `src/components/seo/`
 - `@kkhys/og` — Satori OG image + favicon generators, wired in `src/pages/api/`
 

--- a/apps/me/src/components/opengraph-image.tsx
+++ b/apps/me/src/components/opengraph-image.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 /** @jsxRuntime automatic */
 
+import { uchuHex } from "@kkhys/styles/colors";
 import satori from "satori";
 import sharp from "sharp";
 import { getBudouxParser } from "#/lib/budoux";
@@ -14,8 +15,7 @@ export const opengraphImage = async ({ title }: { title: string }) => {
   const svg = await satori(
     <div
       style={{
-        // uchu-yang (oklch(99.4% 0 0))
-        background: "#fcfcfc",
+        background: uchuHex.yang,
         width: "100%",
         height: "100%",
         display: "flex",
@@ -30,11 +30,9 @@ export const opengraphImage = async ({ title }: { title: string }) => {
           flexWrap: "wrap",
           flexGrow: 1,
           fontSize: "50px",
-          // uchu-yang (oklch(99.4% 0 0))
-          background: "#fcfcfc",
+          background: uchuHex.yang,
           fontFamily: "Inter",
-          // uchu-yin (oklch(14.38% 0.007 256.88))
-          color: "#0e1117",
+          color: uchuHex.yin,
           lineHeight: "1.4",
         }}
       >

--- a/apps/me/src/components/site-opengraph-image.tsx
+++ b/apps/me/src/components/site-opengraph-image.tsx
@@ -1,4 +1,5 @@
 import { createSiteOgImage } from "@kkhys/og/og";
+import { uchuHex } from "@kkhys/styles/colors";
 import { loadFont } from "#/utils/font-loader";
 
 export const siteOpengraphImage = async () => {
@@ -6,12 +7,9 @@ export const siteOpengraphImage = async () => {
 
   return createSiteOgImage({
     text: "Keisuke Hayashi",
-    // uchu-yang (oklch(99.4% 0 0))
-    background: "#fcfcfc",
-    // uchu-yang (oklch(99.4% 0 0))
-    innerBackground: "#fcfcfc",
-    // uchu-yin (oklch(14.38% 0.007 256.88))
-    color: "#0e1117",
+    background: uchuHex.yang,
+    innerBackground: uchuHex.yang,
+    color: uchuHex.yin,
     fontData: interSemiBold,
   });
 };

--- a/apps/me/src/components/ui/site-footer.astro
+++ b/apps/me/src/components/ui/site-footer.astro
@@ -49,7 +49,7 @@ const currentYear = new Date().getFullYear();
 <style>
   .site-footer {
     width: 100%;
-    max-width: 42rem;
+    max-width: var(--content-width);
     margin-inline: auto;
     padding-inline: 1rem;
   }

--- a/apps/me/src/layouts/base-layout.astro
+++ b/apps/me/src/layouts/base-layout.astro
@@ -68,7 +68,7 @@ const { class: className, showFooter = true } = Astro.props;
   main {
     flex: 1;
     width: 100%;
-    max-width: 42rem;
+    max-width: var(--content-width);
     margin-inline: auto;
   }
 

--- a/apps/me/src/styles/global.css
+++ b/apps/me/src/styles/global.css
@@ -2,6 +2,8 @@
 
 @import "kiso.css" layer(reset);
 @import "@kkhys/styles/uchu.css" layer(tokens);
+@import "@kkhys/styles/tokens.css" layer(tokens);
+@import "@kkhys/styles/base.css" layer(base);
 @import "./prose.css" layer(components);
 
 /* ===== Design Tokens ===== */
@@ -10,30 +12,7 @@
   :root {
     color-scheme: light dark;
 
-    --radius-xs: 0.125rem;
-    --radius-sm: 0.25rem;
-    --radius-md: 0.5rem;
-    --radius-lg: 1rem;
-    --radius-full: 9999px;
-
-    --font-mono: ui-monospace, monospace;
-
-    --c-bg: light-dark(var(--uchu-yang), var(--uchu-yin));
-    --c-text: light-dark(var(--uchu-yin), var(--uchu-gray-1));
     --c-prose-text: light-dark(var(--uchu-yin-8), var(--uchu-gray-2));
-    --c-sub: light-dark(var(--uchu-yin-6), var(--uchu-yin-4));
-
-    --c-primary: light-dark(var(--uchu-yin-8), var(--uchu-gray-3));
-    --c-primary-text: light-dark(var(--uchu-yang), var(--uchu-yin-9));
-
-    --c-surface: light-dark(var(--uchu-gray-1), var(--uchu-yin-9));
-    --c-surface-text: light-dark(var(--uchu-yin-9), var(--uchu-yang));
-
-    --c-border: light-dark(var(--uchu-gray-2), oklch(var(--uchu-yang-raw) / 10%));
-    --c-ring: light-dark(var(--uchu-yin-4), var(--uchu-yin-6));
-
-    --c-link: light-dark(var(--uchu-blue-5), var(--uchu-blue-3));
-    --c-link-visited: light-dark(var(--uchu-purple-5), var(--uchu-purple-3));
 
     --c-strong: light-dark(var(--uchu-yellow-1), var(--uchu-orange-9));
     --c-hr: light-dark(var(--uchu-gray-1), var(--uchu-yin-9));
@@ -56,74 +35,12 @@
       oklch(var(--uchu-yang-raw) / 0.1)
     );
     --c-codeblock-gutter: light-dark(var(--uchu-gray-6), var(--uchu-gray-9));
-
-    --fs-2xs: 0.65rem;
-    --fs-xs: 0.75rem;
-    --fs-sm: 0.875rem;
-    --fs-lg: 1.25rem;
-
-    --fw-normal: 400;
-    --fw-medium: 500;
-
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-
-    /* Unified focus ring. Outline (not box-shadow) so it follows
-       border-radius, never shifts layout, and survives Forced Colors Mode
-       where box-shadow rings are stripped. */
-    --ring: oklch(from var(--c-ring) l c h / 55%);
-    --ring-width: 2px;
-    --ring-offset: 2px;
   }
 }
 
 /* ===== Base Styles ===== */
 
 @layer base {
-  * {
-    border-color: var(--c-border);
-  }
-
-  /* Site-wide keyboard focus ring. Every focusable element gets the same
-     calm, theme-aware outline by default. Elements inside clipping
-     containers (full-bleed rows, bordered cards, masked scrollers) draw the
-     identical ring inset via a negative outline-offset. */
-  :focus-visible {
-    outline: var(--ring-width) solid var(--ring);
-    outline-offset: var(--ring-offset);
-  }
-
-  html {
-    font-family: system-ui, sans-serif;
-    scrollbar-gutter: stable both-edges;
-    background-color: var(--c-bg);
-    color: var(--c-text);
-    /*-webkit-font-smoothing: antialiased;*/
-    /*-moz-osx-font-smoothing: grayscale;*/
-  }
-
-  /* Avoid standard scrollbar-* on :root in Chromium: it disables
-     ::-webkit-scrollbar for every scroller on the page. */
-  ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background: light-dark(var(--uchu-gray-3), var(--uchu-yin-8));
-    border-radius: 4px;
-  }
-
-  ::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  @supports (-moz-appearance: none) {
-    html {
-      scrollbar-color: light-dark(var(--uchu-gray-3), var(--uchu-yin-8)) transparent;
-      scrollbar-width: thin;
-    }
-  }
-
   h1 {
     margin-block: 0;
     font-size: inherit;
@@ -131,31 +48,6 @@
 
   hr {
     margin: 0;
-  }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-feature-settings: "palt";
-    text-wrap: balance;
-  }
-
-  .budoux {
-    word-break: keep-all;
-    overflow-wrap: anywhere;
-  }
-
-  .palt {
-    font-feature-settings: "palt";
-  }
-
-  ::selection {
-    box-shadow: none;
-    background-color: light-dark(var(--uchu-yellow-2), var(--uchu-yellow-9));
-    color: var(--c-text);
   }
 
   li {

--- a/apps/memo/src/components/avatar.astro
+++ b/apps/memo/src/components/avatar.astro
@@ -48,7 +48,7 @@ const { src, alt, size, link } = Astro.props;
   .avatar {
     border-radius: 50%;
     object-fit: cover;
-    outline: 1px solid var(--c-gray);
+    outline: 1px solid var(--c-border);
     outline-offset: -0.5px;
   }
 </style>

--- a/apps/memo/src/components/blur-image.astro
+++ b/apps/memo/src/components/blur-image.astro
@@ -29,7 +29,7 @@ const blurryImage = await getImage({ src, width: 20 });
   .blur-load-wrapper {
     overflow: hidden;
     border-radius: 8px;
-    box-shadow: 0 0 0 1px var(--c-gray);
+    box-shadow: 0 0 0 1px var(--c-border);
     aspect-ratio: var(--aspect-ratio);
   }
 

--- a/apps/memo/src/components/bot-badge.astro
+++ b/apps/memo/src/components/bot-badge.astro
@@ -33,8 +33,8 @@ const { size = 8 } = Astro.props;
     justify-content: center;
     padding: 0.15rem;
     border-radius: 0.2rem;
-    border: 1px solid var(--c-gray);
-    color: var(--c-sub-text);
+    border: 1px solid var(--c-border);
+    color: var(--c-sub);
     flex-shrink: 0;
     line-height: 0;
   }

--- a/apps/memo/src/components/footer.astro
+++ b/apps/memo/src/components/footer.astro
@@ -18,6 +18,6 @@ const currentYear = new Date().getFullYear();
     
     footer span {
         font-size: var(--fs-xs);
-        color: var(--c-sub-text);
+        color: var(--c-sub);
     }
 </style>

--- a/apps/memo/src/components/header.astro
+++ b/apps/memo/src/components/header.astro
@@ -68,7 +68,7 @@ const showBackButton = !isHomePage;
     }
 
     .back-button:hover {
-        background-color: var(--c-gray);
+        background-color: var(--c-surface);
     }
 
     .header-title {

--- a/apps/memo/src/components/link-card.astro
+++ b/apps/memo/src/components/link-card.astro
@@ -61,7 +61,7 @@ if (image) {
     user-select: none;
     overflow: hidden;
     border-radius: 0.75rem;
-    border: 1px solid var(--c-gray);
+    border: 1px solid var(--c-border);
     max-width: 400px;
     transition: transform 0.1s;
   }
@@ -71,7 +71,7 @@ if (image) {
   }
 
   .link-card-image-wrapper {
-    background: var(--blur-bg) center / cover no-repeat var(--c-gray);
+    background: var(--blur-bg) center / cover no-repeat var(--c-surface);
     filter: blur(36px);
     transition: filter 250ms ease-in-out;
   }
@@ -95,13 +95,13 @@ if (image) {
   }
 
   .link-card-image-wrapper + .link-card-content {
-    border-top: 1px solid var(--c-gray);
+    border-top: 1px solid var(--c-border);
   }
 
   .link-card-hostname {
     font-size: var(--fs-xs);
     line-height: var(--lh-xs);
-    color: var(--c-sub-text);
+    color: var(--c-sub);
   }
 
   .link-card-title {

--- a/apps/memo/src/components/post-header.astro
+++ b/apps/memo/src/components/post-header.astro
@@ -47,7 +47,7 @@ const fullDateTimeString = formatDateTime(createdAt);
 
     .post-time {
         font-size: var(--fs-xs);
-        color: var(--c-sub-text);
+        color: var(--c-sub);
         font-variant-numeric: tabular-nums;
     }
 </style>

--- a/apps/memo/src/components/profile-header.astro
+++ b/apps/memo/src/components/profile-header.astro
@@ -100,7 +100,7 @@ const coverImage = getCoverImage(cover);
     justify-content: center;
     padding: 3px;
     border-radius: 50%;
-    border: 1.5px solid var(--c-gray);
+    border: 1.5px solid var(--c-border);
     background: var(--c-bg);
     box-shadow:
       0 1px 3px oklch(0% 0 0 / 0.08),
@@ -132,7 +132,7 @@ const coverImage = getCoverImage(cover);
 
   .profile-username {
     font-size: var(--fs-xs);
-    color: var(--c-sub-text);
+    color: var(--c-sub);
     margin: 0.15rem 0 0;
   }
 
@@ -151,7 +151,7 @@ const coverImage = getCoverImage(cover);
 
   .profile-post-count {
     font-size: var(--fs-xs);
-    color: var(--c-sub-text);
+    color: var(--c-sub);
     margin: 0.75rem 0 0;
   }
 </style>

--- a/apps/memo/src/components/quote-embed.astro
+++ b/apps/memo/src/components/quote-embed.astro
@@ -54,7 +54,7 @@ const fullDateTimeString = formatDateTime(createdAt);
     .quote-card {
         display: block;
         cursor: pointer;
-        border: 1px solid var(--c-gray);
+        border: 1px solid var(--c-border);
         border-radius: 0.75rem;
         padding: 0.75rem;
         transition: background-color 0.15s ease;
@@ -91,7 +91,7 @@ const fullDateTimeString = formatDateTime(createdAt);
 
     .quote-time {
         font-size: var(--fs-xs);
-        color: var(--c-sub-text);
+        color: var(--c-sub);
         font-variant-numeric: tabular-nums;
     }
 

--- a/apps/memo/src/components/seo/opengraph-image.tsx
+++ b/apps/memo/src/components/seo/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { createSiteOgImage } from "@kkhys/og/og";
+import { uchuHex } from "@kkhys/styles/colors";
 import { TITLE } from "#/config/constants";
 
 export const OpengraphImage = async () => {
@@ -7,9 +8,9 @@ export const OpengraphImage = async () => {
 
   return createSiteOgImage({
     text: TITLE,
-    background: "#fff",
-    innerBackground: "#fdfdfc",
-    color: "#21201c",
+    background: uchuHex.yang,
+    innerBackground: uchuHex.yang,
+    color: uchuHex.yin,
     fontData: interSemiBold,
   });
 };

--- a/apps/memo/src/components/social-icon.astro
+++ b/apps/memo/src/components/social-icon.astro
@@ -32,7 +32,7 @@ const labels: Record<string, string> = {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    color: var(--c-sub-text);
+    color: var(--c-sub);
     transition: color 0.15s ease;
   }
 

--- a/apps/memo/src/components/spinner.astro
+++ b/apps/memo/src/components/spinner.astro
@@ -4,7 +4,7 @@
   height={16}
   viewBox="0 0 24 24"
   fill="none"
-  stroke="var(--c-sub-text)"
+  stroke="var(--c-sub)"
   stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"

--- a/apps/memo/src/components/thread-post.astro
+++ b/apps/memo/src/components/thread-post.astro
@@ -120,7 +120,7 @@ const {
         gap: 0.35rem;
         margin-left: calc(27px + 0.65rem);
         padding-top: 0.75rem;
-        color: var(--c-sub-text);
+        color: var(--c-sub);
         font-size: var(--fs-xs);
     }
 
@@ -133,7 +133,7 @@ const {
     }
 
     .post-container {
-        border-bottom: 1px solid var(--c-gray);
+        border-bottom: 1px solid var(--c-border);
     }
 
     .post-container[data-clickable="true"] {
@@ -162,7 +162,7 @@ const {
         left: 13.5px;
         margin-left: -1px;
         width: 2px;
-        background-color: var(--c-gray);
+        background-color: var(--c-border);
         border-radius: 1px;
     }
 
@@ -218,7 +218,7 @@ const {
         align-items: center;
         gap: 0.35rem;
         margin-top: 0.75rem;
-        color: var(--c-sub-text);
+        color: var(--c-sub);
         font-size: var(--fs-xs);
         text-decoration: none;
         transition: color 0.15s;

--- a/apps/memo/src/pages/tag/[tag]/[...page].astro
+++ b/apps/memo/src/pages/tag/[tag]/[...page].astro
@@ -100,7 +100,7 @@ const ogImage = new URL("/api/og/default.png", Astro.site).href;
 
     .tag-header p {
         margin: 0;
-        color: var(--c-sub-text);
+        color: var(--c-sub);
         font-size: var(--fs-xs);
     }
 </style>

--- a/apps/memo/src/styles/global.css
+++ b/apps/memo/src/styles/global.css
@@ -1,41 +1,33 @@
-@import "@kkhys/styles/uchu.css";
-@import "kiso.css";
+@layer reset, tokens, base;
 
-:root {
-  color-scheme: light dark;
+@import "kiso.css" layer(reset);
+@import "@kkhys/styles/uchu.css" layer(tokens);
+@import "@kkhys/styles/tokens.css" layer(tokens);
+@import "@kkhys/styles/base.css" layer(base);
 
-  --c-bg: light-dark(var(--uchu-yang), var(--uchu-yin));
-  --c-gray: light-dark(var(--uchu-yin-1), var(--uchu-yin-9));
-  --c-text: light-dark(var(--uchu-yin-9), var(--uchu-yin-1));
-  --c-sub-text: var(--uchu-yin-5);
-  --c-link: light-dark(var(--uchu-blue-5), var(--uchu-blue-4));
-  --c-scrollbar: light-dark(var(--uchu-gray-3), var(--uchu-yin-8));
+/* ===== Design Tokens ===== */
 
-  --fs-xs: 0.75rem;
-  --fs-sm: 0.875rem;
-  --fs-base: 1rem;
-
-  --fw-semibold: 600;
-
-  --lh-xs: 1.25;
-  --lh-sm: 1.5;
-  --lh-base: 1.75;
+@layer tokens {
+  :root {
+    color-scheme: light dark;
+  }
 }
 
-html {
-  font-size: 16px;
-  line-height: var(--lh-base);
-  background: var(--c-bg);
-  color: var(--c-text);
-  scrollbar-gutter: stable both-edges;
-}
+/* ===== Base Styles ===== */
 
-body {
-  margin-inline: auto;
-  padding-inline: 1rem;
-  min-height: 100vh;
-  max-width: 42rem;
-  display: grid;
-  grid-template-rows: [top] auto [main-start] 1fr [main-end] auto [bottom];
-  grid-template-columns: minmax(0, 1fr);
+@layer base {
+  html {
+    font-size: 16px;
+    line-height: var(--lh-base);
+  }
+
+  body {
+    margin-inline: auto;
+    padding-inline: 1rem;
+    min-height: 100vh;
+    max-width: var(--content-width);
+    display: grid;
+    grid-template-rows: [top] auto [main-start] 1fr [main-end] auto [bottom];
+    grid-template-columns: minmax(0, 1fr);
+  }
 }

--- a/apps/studio/src/styles.css
+++ b/apps/studio/src/styles.css
@@ -1,16 +1,8 @@
 @import "@kkhys/styles/uchu.css";
+@import "@kkhys/styles/tokens.css";
 
 :root {
   color-scheme: light dark;
-
-  /* Same palette mapping as apps/memo global.css (uchu values are static) */
-  --color-bg: light-dark(var(--uchu-yang), var(--uchu-yin));
-  --color-surface: light-dark(var(--uchu-gray-1), var(--uchu-yin-9));
-  --color-border: light-dark(var(--uchu-gray-3), var(--uchu-yin-8));
-  --color-text: light-dark(var(--uchu-yin-9), var(--uchu-yin-1));
-  --color-text-muted: var(--uchu-yin-5);
-  --color-accent: light-dark(var(--uchu-blue-5), var(--uchu-blue-4));
-  --color-danger: light-dark(var(--uchu-red-6), var(--uchu-red-4));
 }
 
 * {
@@ -24,8 +16,8 @@
 }
 
 body {
-  background: var(--color-bg);
-  color: var(--color-text);
+  background: var(--c-bg);
+  color: var(--c-text);
   font-family: system-ui, sans-serif;
   line-height: 1.6;
 }
@@ -56,26 +48,26 @@ body {
 
 .header__status {
   font-size: 0.8rem;
-  color: var(--color-text-muted);
+  color: var(--c-sub);
 }
 
 .header__status--dirty {
-  color: var(--color-danger);
+  color: var(--c-danger);
 }
 
 .btn {
   appearance: none;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--c-border);
   border-radius: 0.5rem;
-  background: var(--color-surface);
-  color: var(--color-text);
+  background: var(--c-surface);
+  color: var(--c-text);
   font-size: 0.875rem;
   padding: 0.375rem 0.875rem;
   cursor: pointer;
 }
 
 .btn:hover {
-  border-color: var(--color-accent);
+  border-color: var(--c-link);
 }
 
 .btn:disabled {
@@ -84,8 +76,8 @@ body {
 }
 
 .btn--primary {
-  background: var(--color-accent);
-  border-color: var(--color-accent);
+  background: var(--c-link);
+  border-color: var(--c-link);
   color: var(--uchu-yang);
 }
 
@@ -101,9 +93,9 @@ body {
 .compose {
   display: grid;
   gap: 0.75rem;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--c-border);
   border-radius: 0.75rem;
-  background: var(--color-surface);
+  background: var(--c-surface);
   padding: 1rem;
 }
 
@@ -112,17 +104,17 @@ body {
   align-items: baseline;
   gap: 0.5rem;
   font-size: 0.8rem;
-  border-inline-start: 3px solid var(--color-accent);
+  border-inline-start: 3px solid var(--c-link);
   padding-inline-start: 0.5rem;
 }
 
 .compose__reply-label {
-  color: var(--color-accent);
+  color: var(--c-link);
   flex-shrink: 0;
 }
 
 .compose__reply-excerpt {
-  color: var(--color-text-muted);
+  color: var(--c-sub);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -131,7 +123,7 @@ body {
 .compose__reply-clear {
   border: none;
   background: none;
-  color: var(--color-text-muted);
+  color: var(--c-sub);
   cursor: pointer;
   font-size: 1rem;
   margin-inline-start: auto;
@@ -169,7 +161,7 @@ body {
   height: 6rem;
   object-fit: cover;
   border-radius: 0.5rem;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--c-border);
 }
 
 .compose__preview-remove {
@@ -179,9 +171,9 @@ body {
   width: 1.25rem;
   height: 1.25rem;
   border-radius: 50%;
-  border: 1px solid var(--color-border);
-  background: var(--color-bg);
-  color: var(--color-text);
+  border: 1px solid var(--c-border);
+  background: var(--c-bg);
+  color: var(--c-text);
   cursor: pointer;
   line-height: 1;
 }
@@ -195,16 +187,16 @@ body {
 }
 
 .compose__input {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--c-border);
   border-radius: 0.375rem;
-  background: var(--color-bg);
+  background: var(--c-bg);
   color: inherit;
   font-size: 0.8rem;
   padding: 0.25rem 0.5rem;
 }
 
 .compose__input:invalid {
-  border-color: var(--color-danger);
+  border-color: var(--c-danger);
 }
 
 .toggle {
@@ -212,7 +204,7 @@ body {
   align-items: center;
   gap: 0.25rem;
   font-size: 0.8rem;
-  color: var(--color-text-muted);
+  color: var(--c-sub);
   cursor: pointer;
 }
 
@@ -229,22 +221,22 @@ body {
 .compose__counter {
   margin-inline-start: auto;
   font-size: 0.8rem;
-  color: var(--color-text-muted);
+  color: var(--c-sub);
   font-variant-numeric: tabular-nums;
 }
 
 .compose__counter--over {
-  color: var(--color-danger);
+  color: var(--c-danger);
   font-weight: 600;
 }
 
 .message {
   font-size: 0.875rem;
-  color: var(--color-accent);
+  color: var(--c-link);
 }
 
 .message--error {
-  color: var(--color-danger);
+  color: var(--c-danger);
 }
 
 .feed {
@@ -253,9 +245,9 @@ body {
 }
 
 .feed__search {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--c-border);
   border-radius: 0.5rem;
-  background: var(--color-surface);
+  background: var(--c-surface);
   color: inherit;
   font-size: 0.875rem;
   padding: 0.375rem 0.75rem;
@@ -263,7 +255,7 @@ body {
 
 .feed__search:focus {
   outline: none;
-  border-color: var(--color-accent);
+  border-color: var(--c-link);
 }
 
 .feed__list {
@@ -278,14 +270,14 @@ body {
 }
 
 .feed__permalink:hover {
-  color: var(--color-accent);
+  color: var(--c-link);
   text-decoration: underline;
 }
 
 .feed__item {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--c-border);
   border-radius: 0.75rem;
-  background: var(--color-surface);
+  background: var(--c-surface);
   padding: 0.875rem 1rem;
   display: grid;
   gap: 0.5rem;
@@ -296,19 +288,19 @@ body {
   align-items: center;
   gap: 0.5rem;
   font-size: 0.75rem;
-  color: var(--color-text-muted);
+  color: var(--c-sub);
 }
 
 .chip {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--c-border);
   border-radius: 999px;
   padding: 0 0.5rem;
   font-size: 0.7rem;
 }
 
 .chip--draft {
-  color: var(--color-danger);
-  border-color: var(--color-danger);
+  color: var(--c-danger);
+  border-color: var(--c-danger);
 }
 
 .feed__body {
@@ -327,7 +319,7 @@ body {
   height: 5rem;
   object-fit: cover;
   border-radius: 0.5rem;
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--c-border);
 }
 
 .feed__actions {

--- a/apps/trends/CLAUDE.md
+++ b/apps/trends/CLAUDE.md
@@ -32,7 +32,7 @@ src/
   utils/seen.ts               # countSeen — 既出 item count for the seen filter (pure, unit-tested)
   utils/toc-active.ts         # pickActiveId — scrollspy state for source-toc (pure, unit-tested)
   utils/service-colors.ts     # Upstream brand colors, shared by service-card and source-toc
-  styles/global.css           # --c-* tokens (light-dark over uchu palette)
+  styles/global.css           # Imports @kkhys/styles (uchu + tokens + base); app-local --c-star / --c-faint
   __tests__/                  # Vitest unit tests
 public/                       # robots.txt, manifest, static favicons (generated from dev routes)
 ```
@@ -51,7 +51,7 @@ public/                       # robots.txt, manifest, static favicons (generated
 
 ## Key Design Decisions
 
-- The UI follows the kkhys.me design language (see apps/me): plain `--uchu-yang`/`--uchu-yin` background, hairline separators instead of cards, 42rem content column, `2026.08.10` date format, and me's `--c-*` / `--fs-*` / `--radius-*` token names.
+- The UI follows the kkhys.me design language (see apps/me): plain `--uchu-yang`/`--uchu-yin` background, hairline separators instead of cards, a `--content-width` content column, `2026.08.10` date format, and the shared `--c-*` / `--fs-*` / `--radius-*` tokens from `@kkhys/styles`.
 - `/` renders the latest run in full (duplicate of its `/[date]` page, accepted); `/[date]` is the permanent URL.
 - Client JS is minimal and colocated: the scrollspy in `source-toc.astro` and the 既出 filter toggle in `seen-filter.astro`. Navigation between sources is the TOC's job — the header stays a plain brand link.
 - The 既出 filter is CSS-driven: rows carry an `is-seen` class, per-service counts are prerendered for both modes, and `html[data-seen-filter="hide"]` switches everything. JS only flips that attribute and persists the choice (`trends:seen-filter`); without JS the toggle stays hidden and the site behaves as before.

--- a/apps/trends/src/components/digest-view.astro
+++ b/apps/trends/src/components/digest-view.astro
@@ -51,7 +51,7 @@ const seenTotal = markets.reduce(
   }
 
   .wrap {
-    max-width: 42rem;
+    max-width: var(--content-width);
     margin: 0 auto;
     padding: 0 1rem 3.5rem;
   }

--- a/apps/trends/src/components/site-header.astro
+++ b/apps/trends/src/components/site-header.astro
@@ -12,7 +12,7 @@
 
 <style>
   .site-inner {
-    max-width: 42rem;
+    max-width: var(--content-width);
     margin: 0 auto;
     padding: 0.625rem 1rem;
     display: flex;

--- a/apps/trends/src/pages/about.astro
+++ b/apps/trends/src/pages/about.astro
@@ -114,7 +114,7 @@ const glossary = [
 
 <style>
   .wrap {
-    max-width: 42rem;
+    max-width: var(--content-width);
     margin: 0 auto;
     padding: 0 1rem 3.5rem;
   }

--- a/apps/trends/src/pages/archive.astro
+++ b/apps/trends/src/pages/archive.astro
@@ -32,7 +32,7 @@ const runs = sortRunsByDateDesc(await getCollection("runs"));
 
 <style>
   .wrap {
-    max-width: 42rem;
+    max-width: var(--content-width);
     margin: 0 auto;
     padding: 0 1rem 3.5rem;
   }

--- a/apps/trends/src/styles/global.css
+++ b/apps/trends/src/styles/global.css
@@ -2,6 +2,8 @@
 
 @import "kiso.css" layer(reset);
 @import "@kkhys/styles/uchu.css" layer(tokens);
+@import "@kkhys/styles/tokens.css" layer(tokens);
+@import "@kkhys/styles/base.css" layer(base);
 
 /* ===== Design Tokens ===== */
 
@@ -9,93 +11,16 @@
   :root {
     color-scheme: light dark;
 
-    --radius-sm: 0.25rem;
-    --radius-md: 0.5rem;
-    --radius-full: 9999px;
-
-    --fs-2xs: 0.65rem;
-    --fs-xs: 0.75rem;
-    --fs-sm: 0.875rem;
-    --fs-lg: 1.25rem;
-
-    --fw-normal: 400;
-    --fw-medium: 500;
-
-    --c-bg: light-dark(var(--uchu-yang), var(--uchu-yin));
-    --c-text: light-dark(var(--uchu-yin), var(--uchu-gray-1));
-    --c-sub: light-dark(var(--uchu-yin-6), var(--uchu-yin-4));
-    --c-border: light-dark(var(--uchu-gray-2), oklch(var(--uchu-yang-raw) / 10%));
-    --c-primary: light-dark(var(--uchu-yin-8), var(--uchu-gray-3));
-    --c-primary-text: light-dark(var(--uchu-yang), var(--uchu-yin-9));
-    --c-surface: light-dark(var(--uchu-gray-1), var(--uchu-yin-9));
     --c-star: var(--uchu-orange-5);
     --c-faint: light-dark(var(--uchu-gray-4), var(--uchu-yin-7));
-    --c-ring: light-dark(var(--uchu-yin-4), var(--uchu-yin-6));
-
-    --ring: oklch(from var(--c-ring) l c h / 55%);
-    --ring-width: 2px;
-    --ring-offset: 2px;
   }
 }
 
 /* ===== Base Styles ===== */
 
 @layer base {
-  * {
-    border-color: var(--c-border);
-  }
-
-  :focus-visible {
-    outline: var(--ring-width) solid var(--ring);
-    outline-offset: var(--ring-offset);
-  }
-
-  html {
-    font-family: system-ui, sans-serif;
-    scrollbar-gutter: stable both-edges;
-    background-color: var(--c-bg);
-    color: var(--c-text);
-  }
-
-  ::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background: light-dark(var(--uchu-gray-3), var(--uchu-yin-8));
-    border-radius: 4px;
-  }
-
-  ::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  @supports (-moz-appearance: none) {
-    html {
-      scrollbar-color: light-dark(var(--uchu-gray-3), var(--uchu-yin-8)) transparent;
-      scrollbar-width: thin;
-    }
-  }
-
   body {
     margin: 0;
-  }
-
-  h1,
-  h2,
-  h3 {
-    font-feature-settings: "palt";
-    text-wrap: balance;
-  }
-
-  .budoux {
-    word-break: keep-all;
-    overflow-wrap: anywhere;
-  }
-
-  .palt {
-    font-feature-settings: "palt";
   }
 
   a {
@@ -105,11 +30,5 @@
 
   a:hover {
     text-decoration: underline;
-  }
-
-  ::selection {
-    box-shadow: none;
-    background-color: light-dark(var(--uchu-yellow-2), var(--uchu-yellow-9));
-    color: var(--c-text);
   }
 }

--- a/packages/styles/CLAUDE.md
+++ b/packages/styles/CLAUDE.md
@@ -1,8 +1,23 @@
 # CLAUDE.md
 
-`@kkhys/styles` — the uchu.css OKLCH color palette, consumed as source by
-every app (`@import "@kkhys/styles/uchu.css"` in each `global.css`).
+`@kkhys/styles` — shared design tokens and base styles, consumed as source
+by every app.
 
-- Exposes raw palette tokens (`--uchu-*`) only; semantic tokens (`--c-*`)
-  stay app-local so each site can map light/dark differently.
-- No build step, no scripts. Changing this file affects all five apps.
+- `uchu.css` — raw uchu OKLCH palette (`--uchu-*`). Primitive layer only.
+- `tokens.css` — shared semantic tokens: `--c-*` colors (via `light-dark()`),
+  `--fs-*` / `--fw-*` / `--lh-*` / `--radius-*` / `--space-*` scales,
+  `--font-mono`, `--shadow-sm`, `--content-width`, focus-ring tokens.
+- `base.css` — shared base rules built on the tokens (focus ring, html
+  defaults, scrollbars, `::selection`, `.budoux` / `.palt`).
+- `src/colors.ts` (`@kkhys/styles/colors`) — hex mirrors of uchu values for
+  Satori, which cannot resolve CSS custom properties.
+
+Apps import css files into their cascade layers
+(`@import "@kkhys/styles/tokens.css" layer(tokens);` etc.). Each app declares
+its own `color-scheme` (diary pins light) and may override any token in its
+local tokens layer; app-specific tokens (me's prose/code colors, trends'
+`--c-star`) stay app-local.
+
+`vitest run` checks token reference integrity (every `var()` in
+tokens.css / base.css resolves; `uchuHex` keys exist in the palette).
+Changing these files affects all apps.

--- a/packages/styles/base.css
+++ b/packages/styles/base.css
@@ -1,0 +1,70 @@
+/* Shared base styles. Requires uchu.css + tokens.css; import into the app's
+   base cascade layer (after tokens when the app doesn't use layers). */
+
+* {
+  border-color: var(--c-border);
+}
+
+/* Site-wide keyboard focus ring. Every focusable element gets the same
+   calm, theme-aware outline by default. Elements inside clipping
+   containers (full-bleed rows, bordered cards, masked scrollers) draw the
+   identical ring inset via a negative outline-offset. */
+:focus-visible {
+  outline: var(--ring-width) solid var(--ring);
+  outline-offset: var(--ring-offset);
+}
+
+html {
+  font-family: system-ui, sans-serif;
+  scrollbar-gutter: stable both-edges;
+  background-color: var(--c-bg);
+  color: var(--c-text);
+}
+
+/* Avoid standard scrollbar-* on :root in Chromium: it disables
+   ::-webkit-scrollbar for every scroller on the page. */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--c-scrollbar);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+@supports (-moz-appearance: none) {
+  html {
+    scrollbar-color: var(--c-scrollbar) transparent;
+    scrollbar-width: thin;
+  }
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-feature-settings: "palt";
+  text-wrap: balance;
+}
+
+.budoux {
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+.palt {
+  font-feature-settings: "palt";
+}
+
+::selection {
+  box-shadow: none;
+  background-color: var(--c-selection);
+  color: var(--c-text);
+}

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -5,6 +5,18 @@
   "private": true,
   "type": "module",
   "exports": {
-    "./uchu.css": "./uchu.css"
+    "./uchu.css": "./uchu.css",
+    "./tokens.css": "./tokens.css",
+    "./base.css": "./base.css",
+    "./colors": "./src/colors.ts"
+  },
+  "scripts": {
+    "check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/bun": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/styles/src/__tests__/tokens.test.ts
+++ b/packages/styles/src/__tests__/tokens.test.ts
@@ -1,0 +1,49 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { uchuHex } from "../colors";
+
+const read = (file: string) => readFile(new URL(`../../${file}`, import.meta.url), "utf8");
+
+const definedVars = (css: string) =>
+  new Set([...css.matchAll(/^\s*(--[\w-]+):/gmu)].map((m) => m[1]));
+
+const referencedVars = (css: string) =>
+  new Set([...css.matchAll(/var\((--[\w-]+)/gu)].map((m) => m[1]));
+
+describe("token reference integrity", () => {
+  it("resolves every var() in tokens.css from uchu.css or tokens.css", async () => {
+    const [uchu, tokens] = await Promise.all([read("uchu.css"), read("tokens.css")]);
+    const defined = new Set([...definedVars(uchu), ...definedVars(tokens)]);
+    for (const name of referencedVars(tokens)) {
+      expect(defined, `undefined token: ${name}`).toContain(name);
+    }
+  });
+
+  it("resolves every var() in base.css from uchu.css or tokens.css", async () => {
+    const [uchu, tokens, base] = await Promise.all([
+      read("uchu.css"),
+      read("tokens.css"),
+      read("base.css"),
+    ]);
+    const defined = new Set([...definedVars(uchu), ...definedVars(tokens)]);
+    for (const name of referencedVars(base)) {
+      expect(defined, `undefined token: ${name}`).toContain(name);
+    }
+  });
+});
+
+describe("uchuHex", () => {
+  it("mirrors only colors that exist in uchu.css", async () => {
+    const uchu = await read("uchu.css");
+    const defined = definedVars(uchu);
+    for (const key of Object.keys(uchuHex)) {
+      expect(defined, `no --uchu-${key} in uchu.css`).toContain(`--uchu-${key}`);
+    }
+  });
+
+  it("holds valid hex colors", () => {
+    for (const value of Object.values(uchuHex)) {
+      expect(value).toMatch(/^#[0-9a-f]{6}$/u);
+    }
+  });
+});

--- a/packages/styles/src/colors.ts
+++ b/packages/styles/src/colors.ts
@@ -1,0 +1,8 @@
+/* Hex mirrors of uchu.css for renderers that cannot resolve CSS custom
+   properties (Satori OG images). Keep in sync with uchu.css. */
+export const uchuHex = {
+  // oklch(99.4% 0 0)
+  yang: "#fcfcfc",
+  // oklch(14.38% 0.007 256.88)
+  yin: "#0e1117",
+} as const;

--- a/packages/styles/tokens.css
+++ b/packages/styles/tokens.css
@@ -1,0 +1,69 @@
+/* Shared semantic tokens on top of uchu.css. Color tokens resolve through
+   light-dark(): each app declares its own color-scheme (diary pins light) and
+   may override any token in its local tokens layer. */
+
+:root {
+  --fs-2xs: 0.65rem;
+  --fs-xs: 0.75rem;
+  --fs-sm: 0.875rem;
+  --fs-base: 1rem;
+  --fs-md: 1.125rem;
+  --fs-lg: 1.25rem;
+  --fs-xl: 1.5rem;
+
+  --fw-normal: 400;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+
+  --lh-xs: 1.25;
+  --lh-sm: 1.5;
+  --lh-base: 1.75;
+
+  --radius-xs: 0.125rem;
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 1rem;
+  --radius-full: 9999px;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+
+  --font-mono:
+    ui-monospace, "Cascadia Code", "Source Code Pro", Menlo, Consolas, "DejaVu Sans Mono", monospace;
+
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+
+  --content-width: 42rem;
+
+  --c-bg: light-dark(var(--uchu-yang), var(--uchu-yin));
+  --c-text: light-dark(var(--uchu-yin), var(--uchu-gray-1));
+  --c-sub: light-dark(var(--uchu-yin-6), var(--uchu-yin-4));
+  --c-border: light-dark(var(--uchu-gray-2), oklch(var(--uchu-yang-raw) / 10%));
+
+  --c-surface: light-dark(var(--uchu-gray-1), var(--uchu-yin-9));
+  --c-surface-text: light-dark(var(--uchu-yin-9), var(--uchu-yang));
+
+  --c-primary: light-dark(var(--uchu-yin-8), var(--uchu-gray-3));
+  --c-primary-text: light-dark(var(--uchu-yang), var(--uchu-yin-9));
+
+  --c-link: light-dark(var(--uchu-blue-5), var(--uchu-blue-3));
+  --c-link-visited: light-dark(var(--uchu-purple-5), var(--uchu-purple-3));
+
+  --c-danger: light-dark(var(--uchu-red-6), var(--uchu-red-4));
+
+  --c-selection: light-dark(var(--uchu-yellow-2), var(--uchu-yellow-9));
+  --c-scrollbar: light-dark(var(--uchu-gray-3), var(--uchu-yin-8));
+
+  --c-ring: light-dark(var(--uchu-yin-4), var(--uchu-yin-6));
+  /* Unified focus ring. Outline (not box-shadow) so it follows
+     border-radius, never shifts layout, and survives Forced Colors Mode
+     where box-shadow rings are stripped. */
+  --ring: oklch(from var(--c-ring) l c h / 55%);
+  --ring-width: 2px;
+  --ring-offset: 2px;
+}

--- a/packages/styles/tsconfig.json
+++ b/packages/styles/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext"],
+    "types": ["bun"],
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,7 +617,17 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@25.0.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
 
-  packages/styles: {}
+  packages/styles:
+    devDependencies:
+      '@types/bun':
+        specifier: 'catalog:'
+        version: 1.3.14
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
 
 packages:
 


### PR DESCRIPTION
- Move semantic color tokens, type/spacing/radius scales, and base styles into @kkhys/styles as tokens.css and base.css
- Re-point every app to the shared source, keeping only genuinely app-specific tokens local
- Export uchu hex mirrors (colors.ts) for Satori OG images, which cannot resolve CSS custom properties
- Add a vitest guard for token reference integrity

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
