### PR TITLE
[main] fix: unify dark mode handling across apps

### DIFF
--- a/apps/diary/src/styles/global.css
+++ b/apps/diary/src/styles/global.css
@@ -5,6 +5,15 @@
 @import "@kkhys/styles/tokens.css" layer(tokens);
 @import "@kkhys/styles/base.css" layer(base);
 
+/* ===== Design Tokens ===== */
+
+@layer tokens {
+  :root {
+    /* Light theme only: pins every light-dark() token to its light value. */
+    color-scheme: light;
+  }
+}
+
 /* ===== Base Styles ===== */
 
 @layer base {

--- a/apps/lgtm/src/layouts/layout.astro
+++ b/apps/lgtm/src/layouts/layout.astro
@@ -9,6 +9,9 @@ import "#/styles/global.css";
 <html lang="en">
     <head>
         <HeadMeta />
+        {/* Declared before any CSS loads so dark-preference users don't get a
+            white canvas flash; pairs with `color-scheme: light dark` in CSS. */}
+        <meta name="color-scheme" content="light dark" />
         <Umami websiteId="115514e5-6612-4721-8913-1d0d904fd333" domains="lgtm.kkhys.me" />
         <slot name="head" />
         <slot name="seo" />

--- a/apps/memo/src/components/profile-header.astro
+++ b/apps/memo/src/components/profile-header.astro
@@ -103,16 +103,8 @@ const coverImage = getCoverImage(cover);
     border: 1.5px solid var(--c-border);
     background: var(--c-bg);
     box-shadow:
-      0 1px 3px oklch(0% 0 0 / 0.08),
-      0 4px 12px oklch(0% 0 0 / 0.04);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .profile-avatar-ring {
-      box-shadow:
-        0 1px 3px oklch(0% 0 0 / 0.3),
-        0 4px 12px oklch(0% 0 0 / 0.2);
-    }
+      0 1px 3px light-dark(oklch(0% 0 0 / 0.08), oklch(0% 0 0 / 0.3)),
+      0 4px 12px light-dark(oklch(0% 0 0 / 0.04), oklch(0% 0 0 / 0.2));
   }
 
   .profile-info {

--- a/apps/memo/src/layouts/layout.astro
+++ b/apps/memo/src/layouts/layout.astro
@@ -9,6 +9,9 @@ import "#/styles/global.css";
 <html lang="ja">
     <head>
         <HeadMeta />
+        {/* Declared before any CSS loads so dark-preference users don't get a
+            white canvas flash; pairs with `color-scheme: light dark` in CSS. */}
+        <meta name="color-scheme" content="light dark" />
         <Umami websiteId="05b2c387-63e2-4d83-86f3-6fd54872d125" domains="memo.kkhys.me" />
         <slot name="head" />
         <slot name="seo" />

--- a/apps/studio/src/index.html
+++ b/apps/studio/src/index.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="robots" content="noindex" />
+    <!-- Declared before the stylesheet loads so dark-preference users don't
+         get a white canvas flash; pairs with `color-scheme: light dark` in CSS. -->
+    <meta name="color-scheme" content="light dark" />
     <title>Studio</title>
     <link rel="stylesheet" href="./styles.css" />
     <script type="module" src="./client.ts"></script>

--- a/apps/trends/src/layouts/base-layout.astro
+++ b/apps/trends/src/layouts/base-layout.astro
@@ -19,6 +19,9 @@ const { title = SITE_NAME, description = "Daily tech trend digest by kkhys" } = 
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  {/* Declared before any CSS loads so dark-preference users don't get a
+      white canvas flash; pairs with `color-scheme: light dark` in CSS. */}
+  <meta name="color-scheme" content="light dark"/>
 
   <link rel="manifest" href="/manifest.webmanifest">
   <link rel="icon" href="/favicon.ico" sizes="32x32">


### PR DESCRIPTION
- Standardize dark mode on light-dark(), converting memo's prefers-color-scheme media query holdout
- Add a color-scheme meta tag to every light/dark app to prevent a white flash for dark-preference users before CSS loads
- Pin diary's tokens to light explicitly

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
