### PR TITLE
[main] feat: add design system docs site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Apps:
 - `apps/lgtm` — `@kkhys/lgtm`, LGTM images for GitHub PRs at lgtm.kkhys.me. See `apps/lgtm/CLAUDE.md`.
 - `apps/diary` — `@kkhys/diary`, photo diary at diary.kkhys.me. See `apps/diary/CLAUDE.md`.
 - `apps/trends` — `@kkhys/trends`, daily tech trend digest at trends.kkhys.me. See `apps/trends/CLAUDE.md`.
+- `apps/design` — `@kkhys/design`, design system docs at design.kkhys.me. See `apps/design/CLAUDE.md`.
 - `apps/studio` — `@kkhys/studio`, local-only memo composer (never deployed). See `apps/studio/CLAUDE.md`.
 
 Packages:
@@ -30,7 +31,7 @@ Run from the repo root:
 
 - `pnpm build` / `pnpm test` / `pnpm check` — workspace-wide via `pnpm -r`
 - `pnpm lint` / `pnpm lint:fix` — oxlint + oxfmt over the whole repo
-- `pnpm dev:me` / `pnpm build:me` / `pnpm deploy:me` — me shortcuts (`:lgtm` / `:diary` / `:trends` variants too)
+- `pnpm dev:me` / `pnpm build:me` / `pnpm deploy:me` — me shortcuts (`:lgtm` / `:diary` / `:trends` / `:design` variants too)
 - `pnpm --filter @kkhys/memo <script>` — target a single app
 - `pnpm release` — tag a repo-wide release (the apps ship independently; one tag for the repo)
 
@@ -38,7 +39,7 @@ Run from the repo root:
 
 - `.github/workflows/ci.yml` — runs on PRs and the merge queue. Lint → test → type check → build across the workspace against fixtures (all apps read `USE_FIXTURE_DATA`); content submodules are skipped. The `skip-ci` label opts out.
 - `.github/workflows/deploy-memo.yml` — on push to main touching `apps/memo/**` or `packages/**`, re-runs memo's checks then deploys to Cloudflare Pages.
-- me, lgtm, diary, and trends are built and deployed locally (`pnpm deploy:me` / `pnpm deploy:lgtm` / `pnpm deploy:diary` / `pnpm deploy:trends`), not from CI. trends is normally published end-to-end by the `creating-trend-digest` skill (data commit → deploy → push).
+- me, lgtm, diary, trends, and design are built and deployed locally (`pnpm deploy:me` / `pnpm deploy:lgtm` / `pnpm deploy:diary` / `pnpm deploy:trends` / `pnpm deploy:design`), not from CI. trends is normally published end-to-end by the `creating-trend-digest` skill (data commit → deploy → push).
 
 ## Gotchas
 

--- a/apps/design/CLAUDE.md
+++ b/apps/design/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+Design system documentation site (design.kkhys.me), the `@kkhys/design` app
+of the kkhys monorepo. Astro 7 static site on Cloudflare Pages. Documents
+the shared tokens (`@kkhys/styles`) and components (`@kkhys/ui`) by parsing
+the actual CSS sources at build time — token pages can never drift from the
+real values. TypeScript strictest mode. Path alias: `#/*` → `./src/*`.
+
+## Project Map
+
+```
+src/
+  pages/index.astro           # Principles + usage + table of contents
+  pages/colors.astro          # Semantic --c-* tokens (light/dark swatch pairs) + uchu palette
+  pages/typography.astro      # --fs- / --fw- / --lh- / --font-mono with live samples
+  pages/layout.astro          # --space- / --radius- / --content-width / --shadow-sm / selection
+  pages/components.astro      # Live @kkhys/ui demos + base.css behaviors (focus ring, scrollbar)
+  layouts/base-layout.astro   # HTML shell wired to @kkhys/seo BaseSEO
+  components/site-header.astro / site-footer.astro
+  components/token-swatch.astro  # name / light+dark swatch / value row
+  utils/tokens.ts             # parseCustomProperties / splitLightDark / filterByPrefix (unit-tested)
+  styles/global.css           # Imports @kkhys/styles (uchu + tokens + base) + page chrome
+  __tests__/                  # Vitest unit tests
+```
+
+## Key Design Decisions
+
+- Token pages import the shared CSS with Vite `?raw` and parse the custom
+  properties with `utils/tokens.ts` — the stylesheet itself is the single
+  source of truth, there is no duplicated token table to maintain.
+- Light/dark swatch pairs render by pinning `color-scheme` per swatch, so
+  the browser resolves each `light-dark()` token exactly as apps see it.
+- No analytics and no OG image pipeline yet — add `@kkhys/analytics` with a
+  Umami website id when the site is registered there.
+
+## How to Work
+
+- Run scripts from this directory, or from the repo root via
+  `pnpm dev:design` / `build:design` / `deploy:design`.
+- CI: lint → test → type check → build across the workspace; no content
+  submodule, no fixtures needed.
+- Deploy: built and shipped locally via `pnpm deploy:design`
+  (`wrangler pages deploy dist --project-name=design`); not deployed from CI.
+
+## Gotchas
+
+- `exactOptionalPropertyTypes: true` — optional props need `| undefined`, not just `?:`
+- `.astro` files can't be imported from `.ts` (tsc doesn't resolve them)

--- a/apps/design/astro.config.ts
+++ b/apps/design/astro.config.ts
@@ -1,0 +1,10 @@
+import sitemap from "@astrojs/sitemap";
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  site: "https://design.kkhys.me",
+  integrations: [sitemap()],
+  build: {
+    format: "file",
+  },
+});

--- a/apps/design/package.json
+++ b/apps/design/package.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@kkhys/design",
+  "private": true,
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "check": "astro check && tsc --noEmit",
+    "lint": "oxlint && oxfmt --check",
+    "lint:fix": "oxlint --fix && oxfmt",
+    "deploy": "pnpm build && wrangler pages deploy dist --project-name=design",
+    "test": "vitest run",
+    "coverage": "vitest run --coverage",
+    "all": "pnpm build && pnpm check && pnpm lint:fix && pnpm test && pnpm coverage"
+  },
+  "dependencies": {
+    "@astrojs/compiler-rs": "catalog:",
+    "@kkhys/seo": "workspace:*",
+    "@kkhys/styles": "workspace:*",
+    "@kkhys/ui": "workspace:*",
+    "astro": "catalog:",
+    "kiso.css": "catalog:"
+  },
+  "devDependencies": {
+    "@astrojs/check": "catalog:",
+    "@astrojs/sitemap": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "wrangler": "catalog:"
+  }
+}

--- a/apps/design/public/favicon.svg
+++ b/apps/design/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="46" fill="#fcfcfc" stroke="#0e1117" stroke-width="8"/><path d="M50 4a46 46 0 0 1 0 92z" fill="#0e1117"/></svg>

--- a/apps/design/public/robots.txt
+++ b/apps/design/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://design.kkhys.me/sitemap-index.xml

--- a/apps/design/src/__tests__/tokens.test.ts
+++ b/apps/design/src/__tests__/tokens.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { filterByPrefix, parseCustomProperties, splitLightDark } from "#/utils/tokens";
+
+describe("parseCustomProperties", () => {
+  it("extracts declarations in order", () => {
+    const css = `:root {\n  --fs-sm: 0.875rem;\n  --fw-medium: 500;\n}`;
+    expect(parseCustomProperties(css)).toEqual([
+      { name: "--fs-sm", value: "0.875rem" },
+      { name: "--fw-medium", value: "500" },
+    ]);
+  });
+
+  it("collapses multi-line values to single-space", () => {
+    const css = `--font-mono:\n    ui-monospace, "Cascadia Code",\n    monospace;`;
+    expect(parseCustomProperties(css)).toEqual([
+      { name: "--font-mono", value: 'ui-monospace, "Cascadia Code", monospace' },
+    ]);
+  });
+
+  it("returns an empty list when no custom properties exist", () => {
+    expect(parseCustomProperties("html { color: red; }")).toEqual([]);
+  });
+});
+
+describe("splitLightDark", () => {
+  it("splits a simple pair", () => {
+    expect(splitLightDark("light-dark(var(--uchu-yang), var(--uchu-yin))")).toEqual({
+      light: "var(--uchu-yang)",
+      dark: "var(--uchu-yin)",
+    });
+  });
+
+  it("ignores commas nested inside functions", () => {
+    expect(
+      splitLightDark("light-dark(oklch(95% 0.07 92.39), oklch(var(--uchu-yang-raw) / 10%))"),
+    ).toEqual({
+      light: "oklch(95% 0.07 92.39)",
+      dark: "oklch(var(--uchu-yang-raw) / 10%)",
+    });
+  });
+
+  it("returns null for non-light-dark values", () => {
+    expect(splitLightDark("var(--uchu-orange-5)")).toBeNull();
+    expect(splitLightDark("0.875rem")).toBeNull();
+  });
+});
+
+describe("filterByPrefix", () => {
+  it("keeps only matching names", () => {
+    const declarations = parseCustomProperties("--fs-sm: 1rem; --c-bg: red; --fs-lg: 2rem;");
+    expect(filterByPrefix(declarations, "--fs-")).toEqual([
+      { name: "--fs-sm", value: "1rem" },
+      { name: "--fs-lg", value: "2rem" },
+    ]);
+  });
+});

--- a/apps/design/src/components/site-footer.astro
+++ b/apps/design/src/components/site-footer.astro
@@ -1,0 +1,31 @@
+---
+const year = new Date().getFullYear();
+---
+
+<footer class="site-footer">
+  <p class="copyright">© {year} Keisuke Hayashi</p>
+  <a href="https://github.com/kkhys/me" class="repo-link">GitHub</a>
+</footer>
+
+<style>
+  .site-footer {
+    grid-row: main-end / bottom;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-4);
+    border-top: 1px solid var(--c-border);
+    padding-block: var(--space-8);
+    margin-block-start: var(--space-12);
+  }
+
+  .copyright,
+  .repo-link {
+    font-size: var(--fs-xs);
+    color: var(--c-sub);
+  }
+
+  .copyright {
+    margin: 0;
+  }
+</style>

--- a/apps/design/src/components/site-header.astro
+++ b/apps/design/src/components/site-header.astro
@@ -1,0 +1,66 @@
+---
+const links = [
+  { href: "/colors", label: "Colors" },
+  { href: "/typography", label: "Typography" },
+  { href: "/layout", label: "Layout" },
+  { href: "/components", label: "Components" },
+];
+
+const currentPath = Astro.url.pathname;
+---
+
+<header class="site-header">
+  <a class="brand palt" href="/">kkhys <span class="brand-sub">design system</span></a>
+  <nav class="site-nav" aria-label="サイト内ナビゲーション">
+    {
+      links.map(({ href, label }) => (
+        <a href={href} aria-current={currentPath.startsWith(href) ? "page" : undefined}>
+          {label}
+        </a>
+      ))
+    }
+  </nav>
+</header>
+
+<style>
+  .site-header {
+    grid-row: top / main-start;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--space-2) var(--space-4);
+    padding-block: var(--space-8) var(--space-12);
+  }
+
+  .brand {
+    font-size: var(--fs-sm);
+    font-weight: var(--fw-semibold);
+  }
+
+  .brand-sub {
+    font-weight: var(--fw-normal);
+    color: var(--c-sub);
+  }
+
+  .site-nav {
+    display: flex;
+    gap: var(--space-4);
+  }
+
+  .site-nav a {
+    font-size: var(--fs-xs);
+    color: var(--c-sub);
+    transition: color 0.2s;
+  }
+
+  .site-nav a:hover {
+    color: var(--c-text);
+    text-decoration: none;
+  }
+
+  .site-nav a[aria-current="page"] {
+    color: var(--c-text);
+    font-weight: var(--fw-medium);
+  }
+</style>

--- a/apps/design/src/components/token-swatch.astro
+++ b/apps/design/src/components/token-swatch.astro
@@ -1,0 +1,90 @@
+---
+interface Props {
+  name: string;
+  value: string;
+  /** Render one swatch instead of a light/dark pair (static palette colors). */
+  single?: boolean | undefined;
+}
+
+const { name, value, single = false } = Astro.props;
+---
+
+<div class="token-row">
+  <code class="token-name">{name}</code>
+  <span class="swatches">
+    {
+      single ? (
+        <span class="swatch"><span class="swatch-fill" style={`background: var(${name})`} /></span>
+      ) : (
+        <>
+          <span class="swatch" style="color-scheme: light" title="light">
+            <span class="swatch-fill" style={`background: var(${name})`} />
+          </span>
+          <span class="swatch swatch--dark" style="color-scheme: dark" title="dark">
+            <span class="swatch-fill" style={`background: var(${name})`} />
+          </span>
+        </>
+      )
+    }
+  </span>
+  <code class="token-value">{value}</code>
+</div>
+
+<style>
+  .token-row {
+    display: grid;
+    grid-template-columns: minmax(9rem, auto) auto 1fr;
+    align-items: center;
+    gap: var(--space-4);
+    padding-block: var(--space-2);
+    border-bottom: 1px solid var(--c-border);
+  }
+
+  .token-name {
+    color: var(--c-text);
+  }
+
+  .swatches {
+    display: flex;
+    gap: var(--space-1);
+  }
+
+  /* Scheme canvas behind the fill so translucent token values render as
+     they do in situ on each scheme's background. */
+  .swatch {
+    display: inline-block;
+    width: var(--space-8);
+    height: var(--space-6);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    background: var(--uchu-yang);
+    /* Hairline so near-background swatches stay visible on both schemes. */
+    box-shadow: inset 0 0 0 1px oklch(50% 0 0 / 0.25);
+  }
+
+  .swatch--dark {
+    background: var(--uchu-yin);
+  }
+
+  .swatch-fill {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .token-value {
+    color: var(--c-sub);
+    font-size: var(--fs-2xs);
+    overflow-wrap: anywhere;
+  }
+
+  @media (width < 640px) {
+    .token-row {
+      grid-template-columns: auto 1fr;
+    }
+
+    .token-value {
+      grid-column: 1 / -1;
+    }
+  }
+</style>

--- a/apps/design/src/layouts/base-layout.astro
+++ b/apps/design/src/layouts/base-layout.astro
@@ -1,0 +1,46 @@
+---
+import "#/styles/global.css";
+import BaseSEO from "@kkhys/seo/base-seo.astro";
+import SiteFooter from "#/components/site-footer.astro";
+import SiteHeader from "#/components/site-header.astro";
+
+interface Props {
+  title?: string | undefined;
+  description?: string | undefined;
+}
+
+const SITE_NAME = "kkhys design system";
+const DEFAULT_DESCRIPTION = "kkhys.me と周辺サイトを支えるデザイントークンと共有コンポーネント";
+
+const { title, description = DEFAULT_DESCRIPTION } = Astro.props;
+const resolvedTitle = title === undefined ? SITE_NAME : `${title} · ${SITE_NAME}`;
+---
+
+<html lang="ja">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  {/* Declared before any CSS loads so dark-preference users don't get a
+      white canvas flash; pairs with `color-scheme: light dark` in CSS. */}
+  <meta name="color-scheme" content="light dark"/>
+
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+
+  <BaseSEO title={resolvedTitle} description={description} />
+  <link rel="sitemap" href="/sitemap-index.xml"/>
+</head>
+<body>
+  <SiteHeader />
+  <main>
+    <slot />
+  </main>
+  <SiteFooter />
+</body>
+</html>
+
+<style>
+  main {
+    grid-row: main-start / main-end;
+    padding-block-end: var(--space-12);
+  }
+</style>

--- a/apps/design/src/pages/colors.astro
+++ b/apps/design/src/pages/colors.astro
@@ -1,0 +1,57 @@
+---
+import tokensCss from "@kkhys/styles/tokens.css?raw";
+import uchuCss from "@kkhys/styles/uchu.css?raw";
+import TokenSwatch from "#/components/token-swatch.astro";
+import BaseLayout from "#/layouts/base-layout.astro";
+import { filterByPrefix, parseCustomProperties } from "#/utils/tokens";
+
+const semanticColors = filterByPrefix(parseCustomProperties(tokensCss), "--c-");
+const palette = parseCustomProperties(uchuCss).filter(({ name }) => !name.endsWith("-raw"));
+---
+
+<BaseLayout title="Colors" description="uchu OKLCH パレットとセマンティックカラートークン">
+  <h1>Colors</h1>
+  <p class="lead">
+    色は <a href="https://github.com/NeverCease/uchu">uchu</a> の OKLCH パレットのサブセットだけを使う。
+    アプリのコードが参照するのは用途名を持つセマンティックトークンで、
+    各トークンは <code>light-dark()</code> で両テーマの値を持つ。
+  </p>
+
+  <h2>セマンティックカラー</h2>
+  <p class="note">スワッチは左がライト、右がダークの解決値。</p>
+  <div class="token-list">
+    {semanticColors.map(({ name, value }) => <TokenSwatch name={name} value={value} />)}
+  </div>
+
+  <h2>uchu パレット</h2>
+  <p class="note">
+    生のパレット値。原則としてアプリからは直接使わず、セマンティックトークンの材料にする。
+    透明度を後付けする場合のために、一部の色は <code>oklch()</code> の引数だけを持つ
+    <code>-raw</code> 変種も持つ。
+  </p>
+  <div class="token-list">
+    {palette.map(({ name, value }) => <TokenSwatch name={name} value={value} single />)}
+  </div>
+</BaseLayout>
+
+<style>
+  .lead {
+    color: var(--c-sub);
+    margin-block: var(--space-4) 0;
+  }
+
+  .lead a {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+
+  .note {
+    font-size: var(--fs-xs);
+    color: var(--c-sub);
+    margin-block: 0 var(--space-4);
+  }
+
+  .token-list {
+    display: grid;
+  }
+</style>

--- a/apps/design/src/pages/components.astro
+++ b/apps/design/src/pages/components.astro
@@ -1,0 +1,170 @@
+---
+import Budoux from "@kkhys/ui/budoux.astro";
+import Spinner from "@kkhys/ui/spinner.astro";
+import BaseLayout from "#/layouts/base-layout.astro";
+
+const BUDOUX_SAMPLE = "あらゆる現実をすべて自分のほうへねじ曲げたのだと思われるかもしれない。";
+
+const spinnerSnippet = `import Spinner from "@kkhys/ui/spinner.astro";`;
+const budouxSnippet = `import Budoux from "@kkhys/ui/budoux.astro";
+
+<h1 class="budoux"><Budoux>タイトル</Budoux></h1>`;
+---
+
+<BaseLayout title="Components" description="@kkhys/ui の共有コンポーネントとベーススタイルの挙動">
+  <h1>Components</h1>
+  <p class="lead">
+    <code>@kkhys/ui</code> の共有 Astro コンポーネントと、<code>base.css</code> が全サイトに与える挙動。
+  </p>
+
+  <h2>Spinner</h2>
+  <p class="note">無限スクロールの読み込み表示(memo / lgtm)。色は <code>--c-sub</code> を参照する。</p>
+  <div class="demo">
+    <Spinner />
+  </div>
+  <pre class="snippet"><code>{spinnerSnippet}</code></pre>
+
+  <h2>BudouX</h2>
+  <p class="note">
+    スロットの日本語を文節境界で <code>&lt;wbr&gt;</code> 区切りにする(me / trends)。
+    <code>.budoux</code> クラス(<code>word-break: keep-all</code>)と組で使う。
+  </p>
+  <div class="demo demo--narrow-pair">
+    <figure>
+      <figcaption><code>Budoux</code> なし</figcaption>
+      <p class="narrow">{BUDOUX_SAMPLE}</p>
+    </figure>
+    <figure>
+      <figcaption><code>Budoux</code> あり</figcaption>
+      <p class="narrow budoux"><Budoux>{BUDOUX_SAMPLE}</Budoux></p>
+    </figure>
+  </div>
+  <pre class="snippet"><code>{budouxSnippet}</code></pre>
+
+  <h2>フォーカスリング</h2>
+  <p class="note">
+    キーボードフォーカス(<kbd>Tab</kbd>)で全サイト共通のリングが出る。
+    <code>outline</code> ベースなので角丸に追従し、レイアウトを揺らさず、Forced Colors でも消えない。
+  </p>
+  <div class="demo demo--row">
+    <button class="demo-button" type="button">ボタン</button>
+    <a class="demo-link" href="#">リンク</a>
+    <input class="demo-input" type="text" placeholder="入力欄" />
+  </div>
+
+  <h2>スクロールバー</h2>
+  <p class="note">
+    ページ・要素とも 8px の細いつまみ(<code>--c-scrollbar</code>)。トラックは透明。
+  </p>
+  <div class="demo">
+    <div class="scroll-demo">
+      <p>
+        {BUDOUX_SAMPLE}
+        {BUDOUX_SAMPLE}
+        {BUDOUX_SAMPLE}
+        {BUDOUX_SAMPLE}
+        {BUDOUX_SAMPLE}
+      </p>
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .lead {
+    color: var(--c-sub);
+    margin-block: var(--space-4) 0;
+  }
+
+  .note {
+    font-size: var(--fs-xs);
+    color: var(--c-sub);
+    margin-block: 0 var(--space-4);
+  }
+
+  .demo {
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-6);
+  }
+
+  .demo--row {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-4);
+  }
+
+  .demo--narrow-pair {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-8);
+  }
+
+  .demo--narrow-pair figure {
+    margin: 0;
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .demo--narrow-pair figcaption {
+    font-size: var(--fs-xs);
+    color: var(--c-sub);
+  }
+
+  .narrow {
+    width: 11rem;
+    margin: 0;
+    font-size: var(--fs-sm);
+    line-height: var(--lh-base);
+    border-inline-start: 2px solid var(--c-border);
+    padding-inline-start: var(--space-3);
+  }
+
+  .snippet {
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    overflow-x: auto;
+    font-size: var(--fs-xs);
+    line-height: var(--lh-sm);
+  }
+
+  .snippet code {
+    font-size: inherit;
+  }
+
+  .demo-button {
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-md);
+    background: var(--c-surface);
+    color: var(--c-text);
+    font-size: var(--fs-sm);
+    padding: var(--space-2) var(--space-4);
+    cursor: pointer;
+  }
+
+  .demo-link {
+    font-size: var(--fs-sm);
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+
+  .demo-input {
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-md);
+    background: var(--c-bg);
+    color: inherit;
+    font-size: var(--fs-sm);
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .scroll-demo {
+    max-height: 6rem;
+    overflow-y: auto;
+  }
+
+  .scroll-demo p {
+    margin: 0;
+    font-size: var(--fs-sm);
+  }
+</style>

--- a/apps/design/src/pages/index.astro
+++ b/apps/design/src/pages/index.astro
@@ -1,0 +1,129 @@
+---
+import BaseLayout from "#/layouts/base-layout.astro";
+
+const usageSnippet = `@layer reset, tokens, base;
+
+@import "kiso.css" layer(reset);
+@import "@kkhys/styles/uchu.css" layer(tokens);
+@import "@kkhys/styles/tokens.css" layer(tokens);
+@import "@kkhys/styles/base.css" layer(base);`;
+---
+
+<BaseLayout>
+  <h1 class="palt">kkhys design system</h1>
+  <p class="lead">
+    kkhys.me / memo / lgtm / diary / trends の5サイトを支えるデザイントークンと共有コンポーネント。
+    実体は monorepo の <code>packages/styles</code> と <code>packages/ui</code> にあり、
+    このサイトは同じソースを読んで描画している。
+  </p>
+
+  <h2>原則</h2>
+  <ul class="principles">
+    <li>
+      <strong>髪の毛ラインで区切る。</strong>
+      カードや影を重ねず、<code>--c-border</code> の1px境界線と余白で構造を示す。
+    </li>
+    <li>
+      <strong>パレットは uchu ひとつ。</strong>
+      OKLCH の <code>--uchu-*</code> を直接使わず、意味を持つ <code>--c-*</code> を介して使う。
+    </li>
+    <li>
+      <strong>テーマは light-dark()。</strong>
+      メディアクエリの分岐ではなく、トークン自身が両テーマの値を持つ。
+    </li>
+    <li>
+      <strong>本文カラムは <code>--content-width</code>(42rem)。</strong>
+      どのサイトも同じ幅に収まる。
+    </li>
+    <li>
+      <strong>素の CSS。</strong>
+      フレームワークを足さず、カスケードレイヤーとモダン CSS で組む。
+    </li>
+  </ul>
+
+  <h2>使い方</h2>
+  <p>各アプリの global.css は次の4行から始まる。</p>
+  <pre class="snippet"><code>{usageSnippet}</code></pre>
+  <p>
+    アプリ固有のトークンは、この後のローカル <code>tokens</code> レイヤーで追加・上書きする。
+    Satori(OG 画像)など CSS 変数を解決できない場所では
+    <code>@kkhys/styles/colors</code> の hex ミラーを使う。
+  </p>
+
+  <h2>目次</h2>
+  <nav class="toc" aria-label="ページ一覧">
+    <a href="/colors"><strong>Colors</strong><span>uchu パレットとセマンティックカラー</span></a>
+    <a href="/typography"><strong>Typography</strong><span>サイズ・ウェイト・行送り・等幅</span></a>
+    <a href="/layout"><strong>Layout</strong><span>スペーシング・角丸・影・選択色</span></a>
+    <a href="/components"><strong>Components</strong><span>@kkhys/ui とベーススタイルの挙動</span></a>
+  </nav>
+</BaseLayout>
+
+<style>
+  .lead {
+    color: var(--c-sub);
+    margin-block: var(--space-4) 0;
+  }
+
+  .principles {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .principles li {
+    padding-block: var(--space-3);
+    border-bottom: 1px solid var(--c-border);
+    line-height: var(--lh-base);
+    font-size: var(--fs-sm);
+  }
+
+  .principles strong {
+    font-weight: var(--fw-medium);
+  }
+
+  .snippet {
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+    overflow-x: auto;
+    font-size: var(--fs-xs);
+    line-height: var(--lh-sm);
+  }
+
+  .snippet code {
+    font-size: inherit;
+  }
+
+  .toc {
+    display: grid;
+    gap: var(--space-2);
+  }
+
+  .toc a {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-4);
+    padding-block: var(--space-3);
+    border-bottom: 1px solid var(--c-border);
+    font-size: var(--fs-sm);
+  }
+
+  .toc a:hover {
+    text-decoration: none;
+  }
+
+  .toc a:hover strong {
+    text-decoration: underline;
+  }
+
+  .toc strong {
+    font-weight: var(--fw-medium);
+    min-width: 8rem;
+  }
+
+  .toc span {
+    color: var(--c-sub);
+    font-size: var(--fs-xs);
+  }
+</style>

--- a/apps/design/src/pages/layout.astro
+++ b/apps/design/src/pages/layout.astro
@@ -1,0 +1,152 @@
+---
+import tokensCss from "@kkhys/styles/tokens.css?raw";
+import BaseLayout from "#/layouts/base-layout.astro";
+import { filterByPrefix, parseCustomProperties } from "#/utils/tokens";
+
+const declarations = parseCustomProperties(tokensCss);
+const spaces = filterByPrefix(declarations, "--space-");
+const radii = filterByPrefix(declarations, "--radius-");
+const contentWidth = declarations.find(({ name }) => name === "--content-width");
+const shadow = declarations.find(({ name }) => name === "--shadow-sm");
+---
+
+<BaseLayout title="Layout" description="スペーシング・角丸・影・選択色のトークン">
+  <h1>Layout</h1>
+  <p class="lead">
+    余白と寸法のスケール。gap や padding の値はこのスケールから選び、スケール外の直値を増やさない。
+  </p>
+
+  <h2>スペーシング</h2>
+  <div class="rows">
+    {
+      spaces.map(({ name, value }) => (
+        <div class="row">
+          <code class="row-name">{name}</code>
+          <code class="row-value">{value}</code>
+          <span class="space-bar" style={`width: var(${name})`} />
+        </div>
+      ))
+    }
+  </div>
+
+  <h2>角丸</h2>
+  <div class="radius-grid">
+    {
+      radii.map(({ name, value }) => (
+        <figure class="radius-box-wrap">
+          <span class="radius-box" style={`border-radius: var(${name})`} />
+          <figcaption>
+            <code class="row-name">{name}</code>
+            <code class="row-value">{value}</code>
+          </figcaption>
+        </figure>
+      ))
+    }
+  </div>
+
+  <h2>コンテンツ幅</h2>
+  {
+    contentWidth && (
+      <p class="note">
+        本文カラムは <code>{contentWidth.name}</code> = <code>{contentWidth.value}</code>。
+        このページの幅がそのまま実物。
+      </p>
+    )
+  }
+
+  <h2>影</h2>
+  {
+    shadow && (
+      <div class="rows">
+        <div class="row">
+          <code class="row-name">{shadow.name}</code>
+          <code class="row-value">{shadow.value}</code>
+          <span class="shadow-box" />
+        </div>
+      </div>
+    )
+  }
+  <p class="note">影はボタンなど操作要素の浮きにだけ使い、区切りには使わない(区切りは1pxの境界線)。</p>
+
+  <h2>選択色</h2>
+  <p class="selection-demo">
+    この段落を選択すると <code>--c-selection</code> が現れる。ライトでは淡い黄、ダークでは深い黄土。
+  </p>
+</BaseLayout>
+
+<style>
+  .lead {
+    color: var(--c-sub);
+    margin-block: var(--space-4) 0;
+  }
+
+  .note {
+    font-size: var(--fs-xs);
+    color: var(--c-sub);
+  }
+
+  .rows {
+    display: grid;
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: minmax(7rem, auto) minmax(4rem, auto) 1fr;
+    align-items: center;
+    gap: var(--space-4);
+    padding-block: var(--space-2);
+    border-bottom: 1px solid var(--c-border);
+  }
+
+  .row-value {
+    color: var(--c-sub);
+    font-size: var(--fs-2xs);
+  }
+
+  .space-bar {
+    height: var(--space-4);
+    background: var(--c-primary);
+    border-radius: var(--radius-xs);
+  }
+
+  .radius-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-6);
+  }
+
+  .radius-box-wrap {
+    margin: 0;
+    display: grid;
+    gap: var(--space-2);
+    justify-items: start;
+  }
+
+  .radius-box {
+    display: block;
+    width: var(--space-12);
+    height: var(--space-12);
+    border: 1px solid var(--c-border);
+    background: var(--c-surface);
+  }
+
+  figcaption {
+    display: grid;
+  }
+
+  .shadow-box {
+    display: block;
+    width: var(--space-12);
+    height: var(--space-8);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--c-border);
+    background: var(--c-bg);
+    box-shadow: var(--shadow-sm);
+  }
+
+  .selection-demo {
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
+  }
+</style>

--- a/apps/design/src/pages/typography.astro
+++ b/apps/design/src/pages/typography.astro
@@ -1,0 +1,124 @@
+---
+import tokensCss from "@kkhys/styles/tokens.css?raw";
+import BaseLayout from "#/layouts/base-layout.astro";
+import { filterByPrefix, parseCustomProperties } from "#/utils/tokens";
+
+const declarations = parseCustomProperties(tokensCss);
+const fontSizes = filterByPrefix(declarations, "--fs-");
+const fontWeights = filterByPrefix(declarations, "--fw-");
+const lineHeights = filterByPrefix(declarations, "--lh-");
+const fontMono = declarations.find(({ name }) => name === "--font-mono");
+
+const SAMPLE = "あらゆる現実をすべて自分のほうへねじ曲げたのだ Sphinx of black quartz 0123";
+---
+
+<BaseLayout title="Typography" description="フォントサイズ・ウェイト・行送りのスケール">
+  <h1>Typography</h1>
+  <p class="lead">
+    本文は <code>system-ui, sans-serif</code>。見出しは <code>font-feature-settings: "palt"</code> で詰め、
+    日本語の折り返しは BudouX(<a href="/components">Components</a>)に任せる。
+  </p>
+
+  <h2>フォントサイズ</h2>
+  <div class="rows">
+    {
+      fontSizes.map(({ name, value }) => (
+        <div class="row">
+          <code class="row-name">{name}</code>
+          <code class="row-value">{value}</code>
+          <p class="sample palt" style={`font-size: var(${name})`}>
+            {SAMPLE}
+          </p>
+        </div>
+      ))
+    }
+  </div>
+
+  <h2>フォントウェイト</h2>
+  <div class="rows">
+    {
+      fontWeights.map(({ name, value }) => (
+        <div class="row">
+          <code class="row-name">{name}</code>
+          <code class="row-value">{value}</code>
+          <p class="sample" style={`font-weight: var(${name})`}>
+            {SAMPLE}
+          </p>
+        </div>
+      ))
+    }
+  </div>
+
+  <h2>行送り</h2>
+  <div class="rows">
+    {
+      lineHeights.map(({ name, value }) => (
+        <div class="row">
+          <code class="row-name">{name}</code>
+          <code class="row-value">{value}</code>
+          <p class="sample sample--paragraph" style={`line-height: var(${name})`}>
+            {SAMPLE}
+            {SAMPLE}
+          </p>
+        </div>
+      ))
+    }
+  </div>
+
+  <h2>等幅</h2>
+  {
+    fontMono && (
+      <div class="rows">
+        <div class="row">
+          <code class="row-name">{fontMono.name}</code>
+          <code class="row-value">{fontMono.value}</code>
+          <p class="sample" style="font-family: var(--font-mono)">
+            const parsed = parseCustomProperties(css);
+          </p>
+        </div>
+      </div>
+    )
+  }
+</BaseLayout>
+
+<style>
+  .lead {
+    color: var(--c-sub);
+    margin-block: var(--space-4) 0;
+  }
+
+  .lead a {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+  }
+
+  .rows {
+    display: grid;
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: minmax(7rem, auto) auto;
+    align-items: baseline;
+    gap: var(--space-1) var(--space-4);
+    padding-block: var(--space-3);
+    border-bottom: 1px solid var(--c-border);
+  }
+
+  .row-value {
+    color: var(--c-sub);
+    font-size: var(--fs-2xs);
+  }
+
+  .sample {
+    grid-column: 1 / -1;
+    margin: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .sample--paragraph {
+    white-space: normal;
+  }
+</style>

--- a/apps/design/src/styles/global.css
+++ b/apps/design/src/styles/global.css
@@ -1,0 +1,65 @@
+@layer reset, tokens, base;
+
+@import "kiso.css" layer(reset);
+@import "@kkhys/styles/uchu.css" layer(tokens);
+@import "@kkhys/styles/tokens.css" layer(tokens);
+@import "@kkhys/styles/base.css" layer(base);
+
+/* ===== Design Tokens ===== */
+
+@layer tokens {
+  :root {
+    color-scheme: light dark;
+  }
+}
+
+/* ===== Base Styles ===== */
+
+@layer base {
+  body {
+    margin-inline: auto;
+    padding-inline: 1rem;
+    min-height: 100vh;
+    max-width: var(--content-width);
+    display: grid;
+    grid-template-rows: [top] auto [main-start] 1fr [main-end] auto [bottom];
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  a:hover {
+    text-decoration: underline;
+  }
+
+  h1 {
+    margin-block: 0;
+    font-size: var(--fs-lg);
+    font-weight: var(--fw-medium);
+  }
+
+  h2 {
+    margin-block: var(--space-12) var(--space-4);
+    font-size: var(--fs-base);
+    font-weight: var(--fw-medium);
+  }
+
+  h3 {
+    margin-block: var(--space-8) var(--space-3);
+    font-size: var(--fs-sm);
+    font-weight: var(--fw-medium);
+    color: var(--c-sub);
+  }
+
+  p {
+    line-height: var(--lh-base);
+  }
+
+  code {
+    font-family: var(--font-mono);
+    font-size: var(--fs-xs);
+  }
+}

--- a/apps/design/src/utils/tokens.ts
+++ b/apps/design/src/utils/tokens.ts
@@ -1,0 +1,40 @@
+export interface TokenDeclaration {
+  name: string;
+  value: string;
+}
+
+/** Parses `--name: value;` declarations out of a stylesheet, in order. */
+export const parseCustomProperties = (css: string): TokenDeclaration[] => {
+  const declarations: TokenDeclaration[] = [];
+  for (const match of css.matchAll(/(--[\w-]+):\s*([^;]+);/gu)) {
+    const [, name, value] = match;
+    if (name === undefined || value === undefined) continue;
+    declarations.push({ name, value: value.replaceAll(/\s+/gu, " ").trim() });
+  }
+  return declarations;
+};
+
+/**
+ * Splits a `light-dark(a, b)` value at its top-level comma. Returns null for
+ * anything else, including nested light-dark() inside a larger expression.
+ */
+export const splitLightDark = (value: string): { light: string; dark: string } | null => {
+  const match = value.match(/^light-dark\((?<inner>.*)\)$/u);
+  const inner = match?.groups?.["inner"];
+  if (inner === undefined) return null;
+  let depth = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const character = inner[i];
+    if (character === "(") depth++;
+    else if (character === ")") depth--;
+    else if (character === "," && depth === 0) {
+      return { light: inner.slice(0, i).trim(), dark: inner.slice(i + 1).trim() };
+    }
+  }
+  return null;
+};
+
+export const filterByPrefix = (
+  declarations: TokenDeclaration[],
+  prefix: string,
+): TokenDeclaration[] => declarations.filter(({ name }) => name.startsWith(prefix));

--- a/apps/design/tsconfig.json
+++ b/apps/design/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "astro/tsconfigs/strictest",
+  "compilerOptions": {
+    "paths": {
+      "#/*": ["./src/*"]
+    }
+  },
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}

--- a/apps/design/vitest.config.ts
+++ b/apps/design/vitest.config.ts
@@ -1,0 +1,16 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "#": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    exclude: ["node_modules", ".direnv", "dist"],
+    coverage: {
+      include: ["src/utils/*.ts"],
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "build:trends": "pnpm --filter @kkhys/trends build",
     "dev:trends": "pnpm --filter @kkhys/trends dev",
     "deploy:trends": "pnpm --filter @kkhys/trends run deploy",
+    "build:design": "pnpm --filter @kkhys/design build",
+    "dev:design": "pnpm --filter @kkhys/design dev",
+    "deploy:design": "pnpm --filter @kkhys/design run deploy",
     "dev:studio": "pnpm --filter @kkhys/studio dev",
     "release": "bun run scripts/release.ts"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,52 @@ importers:
         specifier: 'catalog:'
         version: 1.78.0
 
+  apps/design:
+    dependencies:
+      '@astrojs/compiler-rs':
+        specifier: 'catalog:'
+        version: 0.4.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
+      '@kkhys/seo':
+        specifier: workspace:*
+        version: link:../../packages/seo
+      '@kkhys/styles':
+        specifier: workspace:*
+        version: link:../../packages/styles
+      '@kkhys/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      astro:
+        specifier: 'catalog:'
+        version: 7.2.1(@astrojs/markdown-remark@7.2.2)(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+      kiso.css:
+        specifier: 'catalog:'
+        version: 1.2.4
+    devDependencies:
+      '@astrojs/check':
+        specifier: 'catalog:'
+        version: 0.9.10(prettier@3.6.2)(typescript@6.0.3)
+      '@astrojs/sitemap':
+        specifier: 'catalog:'
+        version: 3.7.3
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      oxfmt:
+        specifier: 'catalog:'
+        version: 0.63.0
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.78.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.122.0
+
   apps/diary:
     dependencies:
       '@astrojs/compiler-rs':
@@ -1652,13 +1698,6 @@ packages:
 
   '@mermaid-js/parser@0.4.0':
     resolution: {integrity: sha512-wla8XOWvQAwuqy+gxiZqY+c7FokraOTHRWMsbB4AgRx9Sy7zKslNyejy7E+a77qHfey5GXw/ik3IXv/NHMJgaA==}
-
-  '@napi-rs/wasm-runtime@1.2.0':
-    resolution: {integrity: sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
-    peerDependencies:
-      '@emnapi/core': ^2.0.0-alpha.3
-      '@emnapi/runtime': ^2.0.0-alpha.3
 
   '@napi-rs/wasm-runtime@1.2.3':
     resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
@@ -4877,7 +4916,7 @@ snapshots:
 
   '@astrojs/compiler-binding-wasm32-wasi@0.3.2(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.2.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -5817,13 +5856,6 @@ snapshots:
     dependencies:
       langium: 3.3.1
 
-  '@napi-rs/wasm-runtime@1.2.0(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)':
-    dependencies:
-      '@emnapi/core': 2.0.0-alpha.4
-      '@emnapi/runtime': 2.0.0-alpha.4
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -6398,7 +6430,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@25.0.3)(@vitest/coverage-v8@4.1.10)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
+      vitest: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(vite@8.1.0(@types/node@26.1.2)(esbuild@0.28.1)(terser@5.49.2)(yaml@2.8.2))
 
   '@vitest/expect@4.1.10':
     dependencies:


### PR DESCRIPTION
- Add @kkhys/design, a docs site for the shared design system at design.kkhys.me with principles, colors, typography, layout, and components pages
- Parse the actual @kkhys/styles CSS at build time (?raw imports plus a small tested parser) so token docs cannot drift from real values
- Render light/dark swatch pairs with color-scheme pinned per swatch to show exactly what apps resolve
- Add pnpm deploy:design for local deployment like the other sites

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
