### PR TITLE
[main] fix: pin the trends top page description

### DIFF
--- a/apps/trends/src/layouts/base-layout.astro
+++ b/apps/trends/src/layouts/base-layout.astro
@@ -11,8 +11,9 @@ interface Props {
 }
 
 const SITE_NAME = "Trend Digest";
+const SITE_DESCRIPTION = "国内外の技術系サービスで話題になった記事を、1日1回ダイジェストとしてまとめています。";
 
-const { title = SITE_NAME, description = "Daily tech trend digest by kkhys" } = Astro.props;
+const { title = SITE_NAME, description = SITE_DESCRIPTION } = Astro.props;
 ---
 
 <html lang="ja">

--- a/apps/trends/src/pages/index.astro
+++ b/apps/trends/src/pages/index.astro
@@ -14,7 +14,9 @@ if (!latest) {
 }
 ---
 
-<BaseLayout description={latest.data.digest.headline}>
+{/* The description stays the site-level default: `/` always shows the newest
+    run, so a per-day headline here would churn the OG card every day. */}
+<BaseLayout>
   <SiteHeader />
   <DigestView entry={latest} prev={runs[1]?.id} next={undefined} />
 </BaseLayout>


### PR DESCRIPTION
- Stop passing the latest run headline as the `/` page description so the OG card and meta description no longer churn daily
- Fall back to the site-level default description on the trends top page
- Reword the trends default description in Japanese to describe the site rather than a single day digest
- Add a comment explaining why the top page intentionally keeps the site-level default