### PR TITLE
[main] feat: enable incremental build with cache keys

### DIFF
--- a/apps/me/astro.config.ts
+++ b/apps/me/astro.config.ts
@@ -53,6 +53,9 @@ export default defineConfig({
   vite: {
     plugins: [],
   },
+  experimental: {
+    incrementalBuild: true,
+  },
   env: {
     schema: {
       GITHUB_ACCESS_TOKEN: envField.string({

--- a/apps/me/src/__tests__/features/blog/utils/cache-key.test.ts
+++ b/apps/me/src/__tests__/features/blog/utils/cache-key.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type Entry = {
+  id: string;
+  collection: "blog";
+  digest?: string;
+  data: {
+    title: string;
+    emoji: string;
+    category: string;
+    tags?: string[];
+    status: "published" | "draft";
+    publishedAt: Date;
+  };
+};
+
+const createEntry = (
+  id: string,
+  overrides: Partial<Entry["data"]> & { digest?: string | undefined } = {},
+): Entry => {
+  const { digest, ...data } = overrides;
+  return {
+    id,
+    collection: "blog",
+    ...(digest !== undefined && { digest }),
+    data: {
+      title: `title-${id}`,
+      emoji: "📝",
+      category: "Tech",
+      status: "published",
+      publishedAt: new Date("2025-01-01"),
+      ...data,
+    },
+  };
+};
+
+const loadModule = () => {
+  vi.doMock("astro:env/client", () => ({ NODE_ENV: "production" }));
+  vi.doMock("astro:content", () => ({ getCollection: vi.fn<() => Promise<never[]>>() }));
+  return import("#/features/blog/utils/cache-key");
+};
+
+// The helpers take `CollectionEntry<"blog">`; the mock entries cover every
+// field they read, so the cast only bridges the generated content types.
+const asEntries = (entries: Entry[]) =>
+  entries as unknown as Parameters<Awaited<ReturnType<typeof loadModule>>["getPostCacheKey"]>[0];
+
+describe("toCacheKey", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("is stable for equal input and distinct for different input", async () => {
+    const { toCacheKey } = await loadModule();
+
+    expect(toCacheKey({ a: 1, b: [new Date("2025-01-01")] })).toBe(
+      toCacheKey({ a: 1, b: [new Date("2025-01-01")] }),
+    );
+    expect(toCacheKey({ a: 1 })).not.toBe(toCacheKey({ a: 2 }));
+    expect(toCacheKey({ a: 1 })).toMatch(/^[0-9a-f]{16}$/u);
+  });
+});
+
+describe("withCacheKey", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("keys each path on its props and keeps params and props intact", async () => {
+    const { toCacheKey, withCacheKey } = await loadModule();
+    const paths = [
+      { params: { page: undefined }, props: { page: { data: ["a"], currentPage: 1 } } },
+      { params: { page: "2" }, props: { page: { data: ["b"], currentPage: 2 } } },
+    ];
+
+    const keyed = withCacheKey(paths);
+
+    expect(keyed).toHaveLength(2);
+    expect(keyed[0]).toEqual({ ...paths[0], cacheKey: toCacheKey(paths[0]?.props) });
+    expect(keyed[1]).toEqual({ ...paths[1], cacheKey: toCacheKey(paths[1]?.props) });
+    expect(keyed[0]?.cacheKey).not.toBe(keyed[1]?.cacheKey);
+  });
+});
+
+describe("getPostCacheKey", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  const target = createEntry("target", { digest: "d-target", tags: ["React"] });
+  const sibling = createEntry("sibling", { digest: "d-sibling", tags: ["React"] });
+  const unrelated = createEntry("unrelated", { digest: "d-unrelated", category: "Life" });
+  const nav = { id: "sibling", title: "title-sibling", emoji: "📝" };
+
+  it("returns undefined when the entry has no digest", async () => {
+    const { getPostCacheKey } = await loadModule();
+    const noDigest = createEntry("no-digest");
+
+    expect(
+      getPostCacheKey(asEntries([noDigest]), asEntries([noDigest])[0]!, undefined, undefined),
+    ).toBeUndefined();
+  });
+
+  it("is deterministic across calls", async () => {
+    const { getPostCacheKey } = await loadModule();
+    const entries = asEntries([target, sibling, unrelated]);
+
+    expect(getPostCacheKey(entries, entries[0]!, nav, undefined)).toBe(
+      getPostCacheKey(entries, entries[0]!, nav, undefined),
+    );
+  });
+
+  it("changes when the entry body, a nav item, or a related post's displayed data changes", async () => {
+    const { getPostCacheKey } = await loadModule();
+    const entries = asEntries([target, sibling, unrelated]);
+    const base = getPostCacheKey(entries, entries[0]!, nav, undefined);
+
+    const edited = asEntries([
+      createEntry("target", { digest: "d-target-2", tags: ["React"] }),
+      sibling,
+      unrelated,
+    ]);
+    expect(getPostCacheKey(edited, edited[0]!, nav, undefined)).not.toBe(base);
+
+    expect(getPostCacheKey(entries, entries[0]!, { ...nav, title: "renamed" }, undefined)).not.toBe(
+      base,
+    );
+
+    const renamedSibling = asEntries([
+      target,
+      createEntry("sibling", { digest: "d-sibling", tags: ["React"], title: "renamed" }),
+      unrelated,
+    ]);
+    expect(getPostCacheKey(renamedSibling, renamedSibling[0]!, nav, undefined)).not.toBe(base);
+  });
+
+  it("changes when a new related post appears but not when an unrelated post changes", async () => {
+    const { getPostCacheKey } = await loadModule();
+    const entries = asEntries([target, sibling, unrelated]);
+    const base = getPostCacheKey(entries, entries[0]!, nav, undefined);
+
+    const withNewRelated = asEntries([
+      target,
+      sibling,
+      unrelated,
+      createEntry("newcomer", { digest: "d-new", tags: ["React"] }),
+    ]);
+    expect(getPostCacheKey(withNewRelated, withNewRelated[0]!, nav, undefined)).not.toBe(base);
+
+    const unrelatedEdited = asEntries([
+      target,
+      sibling,
+      createEntry("unrelated", { digest: "d-unrelated-2", category: "Life", title: "renamed" }),
+    ]);
+    expect(getPostCacheKey(unrelatedEdited, unrelatedEdited[0]!, nav, undefined)).toBe(base);
+  });
+
+  it("ignores body-only edits of a related post", async () => {
+    const { getPostCacheKey } = await loadModule();
+    const entries = asEntries([target, sibling]);
+    const base = getPostCacheKey(entries, entries[0]!, nav, undefined);
+
+    const siblingBodyEdited = asEntries([
+      target,
+      createEntry("sibling", { digest: "d-sibling-2", tags: ["React"] }),
+    ]);
+    expect(getPostCacheKey(siblingBodyEdited, siblingBodyEdited[0]!, nav, undefined)).toBe(base);
+  });
+});

--- a/apps/me/src/components/ui/image/image.astro
+++ b/apps/me/src/components/ui/image/image.astro
@@ -1,6 +1,6 @@
 ---
 import { Picture as AstroPicture, getImage, type Picture } from "astro:assets";
-import type { UnresolvedImageTransform } from "astro";
+import type { ImageMetadata, UnresolvedImageTransform } from "astro";
 
 import { blurLoadHandlers } from "@kkhys/ui/blur-load";
 import type { CustomImageProps } from "./types";
@@ -19,8 +19,12 @@ const blurryImage = await getImage({
 const WIDE_DISPLAY_PX = 896;
 const WIDE_THRESHOLD_PX = WIDE_DISPLAY_PX * 2;
 const { src } = rest;
-const metadata =
-  typeof src === "object" && src !== null && "width" in src ? src : null;
+// In dev, markdown images arrive as a function-shaped Proxy around
+// ImageMetadata, so a plain `typeof === "object"` check misses them.
+const metadata: ImageMetadata | null =
+  src === undefined || src === null || typeof src === "string"
+    ? null
+    : (src as ImageMetadata);
 const intrinsicWidth = metadata?.width ?? 0;
 const intrinsicHeight = metadata?.height ?? 0;
 const isLandscape = intrinsicWidth > intrinsicHeight;
@@ -33,9 +37,12 @@ const sizes = isWide
   ? `(min-width: 960px) ${WIDE_DISPLAY_PX}px, (min-width: 672px) calc(100vw - 4rem), 100vw`
   : `(min-width: 672px) 672px, 100vw`;
 
+// SVG can't be transcoded to raster formats; an avif <source> would 500.
+const isSvg = metadata?.format === "svg";
+
 const pictureProps = {
   class: `image-rounded ${className ?? ""}`.trim(),
-  formats: ["avif"],
+  formats: isSvg ? ["svg"] : ["avif"],
   quality: 80,
   widths,
   sizes,

--- a/apps/me/src/features/blog/utils/cache-key.ts
+++ b/apps/me/src/features/blog/utils/cache-key.ts
@@ -1,0 +1,58 @@
+import { createHash } from "node:crypto";
+import type { GetStaticPathsItem } from "astro";
+import type { CollectionEntry } from "astro:content";
+import {
+  type PostNavItem,
+  type RelatedPostsInput,
+  scoreRelatedPosts,
+  toListEntries,
+} from "#/features/blog/utils/entry";
+
+// Render inputs that every cached page reads outside of its props. The footer
+// prints the current year, so a page restored from the cache would keep last
+// year's footer if the year were not part of its key.
+const siteWideInputs = { footerYear: new Date().getFullYear() };
+
+// Digest the serialized value instead of storing it verbatim: `cacheKey` is
+// written to the incremental-build manifest for every path, and a page of list
+// entries serializes to several kilobytes.
+export const toCacheKey = (value: unknown): string =>
+  createHash("sha256")
+    .update(JSON.stringify([siteWideInputs, value]))
+    .digest("hex")
+    .slice(0, 16);
+
+// The post page renders the entry, the prev/next nav items, and a related-post
+// list picked from the whole collection, so all three feed the key. Related
+// candidates are keyed on the fields the list displays (via `toListEntries`)
+// plus their score; a body-only edit elsewhere must not invalidate this page.
+// `digest` is set by the glob loader from the file contents; without one we
+// cannot prove the page is unchanged, so it is left uncached.
+export const getPostCacheKey = (
+  entries: CollectionEntry<"blog">[],
+  entry: CollectionEntry<"blog">,
+  newerPost: PostNavItem | undefined,
+  olderPost: PostNavItem | undefined,
+): string | undefined => {
+  if (entry.digest === undefined) {
+    return undefined;
+  }
+
+  const relatedInput: RelatedPostsInput = {
+    id: entry.id,
+    category: entry.data.category,
+    tags: entry.data.tags,
+  };
+  const related = scoreRelatedPosts(entries, relatedInput);
+  const relatedEntries = toListEntries(related.map(({ post }) => post));
+  const relatedScores = related.map(({ score }) => score);
+
+  return toCacheKey([entry.digest, newerPost, olderPost, relatedEntries, relatedScores]);
+};
+
+// `paginate()` has no cacheKey hook, so key each page on its full props. The
+// props only carry `ListEntry` scalars and pagination URLs, never entry bodies.
+export const withCacheKey = <T extends GetStaticPathsItem>(
+  paths: T[],
+): (T & { cacheKey: string })[] =>
+  paths.map((path) => Object.assign(path, { cacheKey: toCacheKey(path.props) }));

--- a/apps/me/src/features/blog/utils/entry.ts
+++ b/apps/me/src/features/blog/utils/entry.ts
@@ -88,25 +88,35 @@ export const getPublicListEntries = async (sort: "asc" | "desc" = "desc"): Promi
   });
 };
 
-export const getRelatedPosts = async ({
-  id,
-  category,
-  tags,
-}: { id: string } & Pick<InferEntrySchema<"blog">, "category" | "tags">) => {
-  const candidates = (await getPublicBlogEntries()).filter((post) => post.id !== id);
+export type RelatedPostsInput = { id: string } & Pick<
+  InferEntrySchema<"blog">,
+  "category" | "tags"
+>;
 
-  // Shared tags weigh double so a cross-category post on the same topic can
-  // outrank a same-category post that merely shares the category.
-  const scored = candidates
+// Deterministic part of related-post selection, shared with the post page's
+// incremental-build cache key so the key tracks exactly the inputs that can
+// change which posts are shown.
+export const scoreRelatedPosts = (
+  entries: CollectionEntry<"blog">[],
+  { id, category, tags }: RelatedPostsInput,
+) =>
+  entries
+    .filter((post) => post.id !== id)
+    // Shared tags weigh double so a cross-category post on the same topic can
+    // outrank a same-category post that merely shares the category.
     .map((post) => ({
       post,
       score:
         (tags?.filter((tag) => post.data.tags?.includes(tag)).length ?? 0) * 2 +
         (post.data.category === category ? 1 : 0),
     }))
-    .filter(({ score }) => score > 0);
+    .filter(({ score }) => score > 0)
+    .toSorted((a, b) => b.score - a.score);
 
-  // Sort by score (desc), shuffle within same score
+export const getRelatedPosts = async (input: RelatedPostsInput) => {
+  const scored = scoreRelatedPosts(await getPublicBlogEntries(), input);
+
+  // Shuffle within same score
   scored.sort((a, b) => b.score - a.score || Math.random() - 0.5);
 
   return scored.map(({ post }) => post).slice(0, relatedEntriesCount);

--- a/apps/me/src/pages/api/og/[id].png.ts
+++ b/apps/me/src/pages/api/og/[id].png.ts
@@ -4,7 +4,7 @@ import { getPublicBlogEntries } from "#/features/blog/utils/entry";
 
 export const getStaticPaths = (async () =>
   (await getPublicBlogEntries()).map((entry) => {
-    return {
+    const path = {
       params: {
         id: entry.id,
       },
@@ -12,6 +12,8 @@ export const getStaticPaths = (async () =>
         entry,
       },
     };
+
+    return entry.digest === undefined ? path : Object.assign(path, { cacheKey: entry.digest });
   })) satisfies GetStaticPaths;
 
 export const GET: APIRoute = async ({ props }) => {

--- a/apps/me/src/pages/blog/[...page].astro
+++ b/apps/me/src/pages/blog/[...page].astro
@@ -2,6 +2,7 @@
 import type { PaginateFunction } from "astro";
 import { countPerPage } from "#/config/constant";
 import BlogIndex from "#/features/blog/components/ui/blog-index.astro";
+import { withCacheKey } from "#/features/blog/utils/cache-key";
 import { getPublicListEntries } from "#/features/blog/utils/entry";
 
 export const getStaticPaths = async ({
@@ -10,7 +11,7 @@ export const getStaticPaths = async ({
   paginate: PaginateFunction;
 }) => {
   const entries = await getPublicListEntries();
-  return paginate(entries, { pageSize: countPerPage });
+  return withCacheKey(paginate(entries, { pageSize: countPerPage }));
 };
 
 const { page } = Astro.props;

--- a/apps/me/src/pages/blog/categories/[category]/[...page].astro
+++ b/apps/me/src/pages/blog/categories/[category]/[...page].astro
@@ -3,6 +3,7 @@ import type { PaginateFunction } from "astro";
 import { countPerPage } from "#/config/constant";
 import BlogIndex from "#/features/blog/components/ui/blog-index.astro";
 import { getCategoryBySlug } from "#/features/blog/config/category";
+import { withCacheKey } from "#/features/blog/utils/cache-key";
 import { getPublicListEntries } from "#/features/blog/utils/entry";
 
 export const getStaticPaths = async ({
@@ -16,10 +17,12 @@ export const getStaticPaths = async ({
     const filteredEntries = entries
       .filter((entry) => entry.category === category)
       .toSorted((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
-    return paginate(filteredEntries, {
-      pageSize: countPerPage,
-      params: { category: category.toLowerCase() },
-    });
+    return withCacheKey(
+      paginate(filteredEntries, {
+        pageSize: countPerPage,
+        params: { category: category.toLowerCase() },
+      }),
+    );
   });
 };
 

--- a/apps/me/src/pages/blog/posts/[id].astro
+++ b/apps/me/src/pages/blog/posts/[id].astro
@@ -5,6 +5,7 @@ import type { BreadcrumbList, WithContext } from "schema-dts";
 import JsonLd from "#/components/seo/json-ld.astro";
 import ContentWrapper from "#/features/blog/components/content-wrapper.astro";
 import { getCategoryByTitle } from "#/features/blog/config/category";
+import { getPostCacheKey } from "#/features/blog/utils/cache-key";
 import { getPublicBlogEntries, toPostNavItem } from "#/features/blog/utils/entry";
 import BlogLayout from "#/layouts/blog-layout.astro";
 import { getBlogPostingSchema } from "#/lib/json-ld";
@@ -17,17 +18,22 @@ export const getStaticPaths = (async () => {
   const entries = await getPublicBlogEntries();
 
   return entries.map((entry, index) => {
-    return {
+    const newerPost = toPostNavItem(entries[index - 1]);
+    const olderPost = toPostNavItem(entries[index + 1]);
+    const cacheKey = getPostCacheKey(entries, entry, newerPost, olderPost);
+    const path = {
       params: {
         id: entry.id,
       },
       props: {
         entry,
         description: extractDescription(entry.body ?? ""),
-        newerPost: toPostNavItem(entries[index - 1]),
-        olderPost: toPostNavItem(entries[index + 1]),
+        newerPost,
+        olderPost,
       },
     };
+
+    return cacheKey === undefined ? path : Object.assign(path, { cacheKey });
   });
 }) satisfies GetStaticPaths;
 

--- a/apps/me/src/pages/blog/tags/[tag]/[...page].astro
+++ b/apps/me/src/pages/blog/tags/[tag]/[...page].astro
@@ -5,6 +5,7 @@ import JsonLd from "#/components/seo/json-ld.astro";
 import { countPerPage } from "#/config/constant";
 import BlogIndex from "#/features/blog/components/ui/blog-index.astro";
 import { getTagBySlug } from "#/features/blog/config/tag";
+import { withCacheKey } from "#/features/blog/utils/cache-key";
 import { getPublicListEntries } from "#/features/blog/utils/entry";
 import { BASE_URL } from "#/utils/base-url";
 
@@ -19,10 +20,12 @@ export const getStaticPaths = async ({
     const filteredEntries = entries
       .filter((entry) => entry.tags?.includes(tag))
       .toSorted((a, b) => b.publishedAt.getTime() - a.publishedAt.getTime());
-    return paginate(filteredEntries, {
-      pageSize: countPerPage,
-      params: { tag: tag.toLowerCase().replaceAll(/[\s.]+/gu, "-") },
-    });
+    return withCacheKey(
+      paginate(filteredEntries, {
+        pageSize: countPerPage,
+        params: { tag: tag.toLowerCase().replaceAll(/[\s.]+/gu, "-") },
+      }),
+    );
   });
 };
 


### PR DESCRIPTION
- Enable Astro's experimental incrementalBuild in apps/me so unchanged pages are restored from the cache
- Add cache-key utilities that key post pages on the entry digest, prev/next nav items, and related posts' displayed fields and scores
- Extract scoreRelatedPosts from getRelatedPosts so the page and its cache key share the same deterministic selection
- Key OG images on the entry digest and paginated list pages on a digest of their props
- Serve SVG images as-is instead of transcoding to avif, and detect image metadata without relying on typeof object