### PR TITLE
[main] chore: link home page to august dev environment snapshot

### DIFF
--- a/apps/me/src/pages/index.astro
+++ b/apps/me/src/pages/index.astro
@@ -21,7 +21,7 @@ import { websiteSchema } from "#/lib/json-ld";
         <p>コードを書いていないときは、珈琲を淹れたりボクシングジムで汗を流したりしています。日々考えたことは<a href="https://memo.kkhys.me" target="_blank" rel="noreferrer" class="home-link external-link">メモ<MoveUpRightIcon class="external-icon" /></a>に書き留めて、いつかやりたいことは<a href="/bucket-list" class="home-link">バケットリスト</a>にまとめています。</p>
         <p>私の好きな文章には次のようなものがあります。</p>
         <ul class="home-list">
-          <li><a href="/blog/posts/b1qjure" class="home-link">2026年5月時点の開発環境スナップショット</a></li>
+          <li><a href="/blog/posts/b1e2lej" class="home-link">2026年8月時点の開発環境スナップショット</a></li>
           <li><a href="/blog/posts/b1mslu4" class="home-link">デスク構成スナップショット2026</a></li>
           <li><a href="/blog/posts/b1rw6y2" class="home-link">ホームページを枯山水として育てる</a></li>
           <li><a href="/blog/posts/b1x478m" class="home-link">夏の北海道2泊3日の旅行記</a></li>


### PR DESCRIPTION
- Update the home page favorite-posts list to point at the August 2026 dev environment snapshot (b1e2lej) instead of the May 2026 one (b1qjure)