### PR TITLE
[main] fix: apply alert container query on a wrapper

### DIFF
--- a/apps/me/src/features/blog/components/ui/blocks/alert-block.astro
+++ b/apps/me/src/features/blog/components/ui/blocks/alert-block.astro
@@ -25,17 +25,25 @@ const alertIcons: Record<AlertType, SvgComponent> = {
 const IconComponent = alertIcons[alertType];
 ---
 
-<div class:list={["alert", `alert--${alertType}`]} {...rest}>
-  <IconComponent
-      class="alert-icon"
-      aria-hidden="true"
-  />
-  <slot />
+<div class="alert-container">
+  <div class:list={["alert", `alert--${alertType}`]} {...rest}>
+    <IconComponent
+        class="alert-icon"
+        aria-hidden="true"
+    />
+    <slot />
+  </div>
 </div>
 
 <style>
-  .alert {
+  /* The query container has to be an ancestor of the queried element: an
+     element never matches @container against itself, so keeping
+     container-type on .alert left the width query below permanently unmatched. */
+  .alert-container {
     container-type: inline-size;
+  }
+
+  .alert {
     display: flex;
     flex-direction: column;
     gap: 0.75rem;


### PR DESCRIPTION
- Wrap the alert in a dedicated `.alert-container` element that carries `container-type: inline-size`
- Remove `container-type` from `.alert` so the `@container (width >= 500px)` rule can match it
- Restore the horizontal alert layout on containers 500px and wider
- Add a comment explaining that a query container must be an ancestor of the queried element