### PR TITLE
[main] feat: add site search with Pagefind

### DIFF
--- a/apps/me/CLAUDE.md
+++ b/apps/me/CLAUDE.md
@@ -33,7 +33,7 @@ Consumed as source (no build step); this app supplies its own config via thin wr
 - CI: lint → test → type check → build, against fixtures. Add the `skip-ci` label to PRs to skip.
 - Deploy: built and shipped locally via `pnpm deploy`; me is not deployed from CI.
 - Lint/format: runs automatically via Stop hook (oxlint + oxfmt auto-fix). Fix remaining errors before completing.
-- Search: `astro-pagefind` indexes `dist` after `astro build`; only elements marked `data-pagefind-body` (blog post title + body in `src/layouts/blog-layout.astro`) are indexed. The dev server serves `/pagefind/` from `dist`, so run `pnpm build` once before `pnpm dev` to try search locally. The dialog lives in `src/features/search/`.
+- Search: `astro-pagefind` indexes `dist` after `astro build`; only elements marked `data-pagefind-body` (blog post title + body in `src/layouts/blog-layout.astro`) are indexed. The dev server serves `/pagefind/` from `dist`, so run `pnpm build` once before `pnpm dev` to try search locally. The dialog lives in `src/features/search/`; pure logic sits in `src/features/search/utils/` so it stays unit-testable. No CSP is configured today; adding one needs `script-src` for the dynamic `import()` of `/pagefind/pagefind.js`, `wasm-unsafe-eval` for the Pagefind WASM, and `connect-src 'self'` for fragment fetches.
 
 ## Key Context Files
 

--- a/apps/me/CLAUDE.md
+++ b/apps/me/CLAUDE.md
@@ -4,7 +4,7 @@ Personal blog (kkhys.me), the `@kkhys/me` app of the kkhys monorepo. Astro 7 sta
 
 ## Project Map
 
-- `src/features/` — Self-contained feature modules (blog, pages)
+- `src/features/` — Self-contained feature modules (blog, pages, search)
 - `src/lib/` — remark/rehype plugins, API wrappers (`api/`), utilities
 - `src/utils/` — Pure helpers (date, hash, font-loader, base-url, extract-description)
 - `src/styles/` — Global CSS with light-dark() theme switching
@@ -33,12 +33,13 @@ Consumed as source (no build step); this app supplies its own config via thin wr
 - CI: lint → test → type check → build, against fixtures. Add the `skip-ci` label to PRs to skip.
 - Deploy: built and shipped locally via `pnpm deploy`; me is not deployed from CI.
 - Lint/format: runs automatically via Stop hook (oxlint + oxfmt auto-fix). Fix remaining errors before completing.
+- Search: `astro-pagefind` indexes `dist` after `astro build`; only elements marked `data-pagefind-body` (blog post title + body in `src/layouts/blog-layout.astro`) are indexed. The dev server serves `/pagefind/` from `dist`, so run `pnpm build` once before `pnpm dev` to try search locally. The dialog lives in `src/features/search/`.
 
 ## Key Context Files
 
 Read these when your task involves their domain:
 
-- `astro.config.ts` — Markdown plugins, env schema, CSP, experimental features
+- `astro.config.ts` — Markdown plugins, integrations (incl. Pagefind), env schema, experimental features
 - `src/content.config.ts` — Collection schemas and validation rules
 - `src/features/blog/config/` — Category and tag definitions
 - `../../.oxlintrc.json` / `../../.oxfmtrc.json` — Linter / formatter configuration (shared across the monorepo)

--- a/apps/me/astro.config.ts
+++ b/apps/me/astro.config.ts
@@ -4,6 +4,7 @@ import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import { defineConfig, envField } from "astro/config";
 import expressiveCode from "astro-expressive-code";
+import pagefind from "astro-pagefind";
 import { expressiveCodeOptions } from "./src/lib/expressive-code";
 import rehypeBudoux from "./src/lib/rehype-budoux";
 import rehypeMermaidCached from "./src/lib/rehype-mermaid-cached";
@@ -16,7 +17,7 @@ import remarkYoutubeBlock from "./src/lib/remark-youtube-block";
 
 export default defineConfig({
   site: "https://kkhys.me",
-  integrations: [expressiveCode(expressiveCodeOptions), react(), mdx(), sitemap()],
+  integrations: [expressiveCode(expressiveCodeOptions), react(), mdx(), sitemap(), pagefind()],
   build: {
     format: "file",
   },

--- a/apps/me/package.json
+++ b/apps/me/package.json
@@ -33,6 +33,7 @@
     "@kkhys/ui": "workspace:*",
     "astro": "catalog:",
     "astro-expressive-code": "0.44.1",
+    "astro-pagefind": "2.0.1",
     "kiso.css": "catalog:",
     "sharp": "catalog:"
   },

--- a/apps/me/src/__tests__/features/search/utils/excerpt.test.ts
+++ b/apps/me/src/__tests__/features/search/utils/excerpt.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseExcerpt } from "#/features/search/utils/excerpt";
+
+describe("parseExcerpt", () => {
+  it("splits Pagefind's <mark> wrappers from the surrounding text", () => {
+    expect(parseExcerpt("分散型 <mark>SNS</mark> を構築する")).toEqual([
+      { text: "分散型 ", marked: false },
+      { text: "SNS", marked: true },
+      { text: " を構築する", marked: false },
+    ]);
+  });
+
+  it("decodes the angle-bracket entities Pagefind emits for HTML in the page text", () => {
+    expect(parseExcerpt(`lastLoginIp === '&lt;iframe src="javascript:alert(1)"&gt;'`)).toEqual([
+      { text: `lastLoginIp === '<iframe src="javascript:alert(1)">'`, marked: false },
+    ]);
+  });
+
+  it("keeps unescaped HTML as literal text", () => {
+    expect(parseExcerpt(`<img src=x onerror="alert(1)">`)).toEqual([
+      { text: `<img src=x onerror="alert(1)">`, marked: false },
+    ]);
+  });
+
+  it("decodes entities inside marks too", () => {
+    expect(parseExcerpt("<mark>&lt;div&gt;</mark>")).toEqual([{ text: "<div>", marked: true }]);
+  });
+
+  it("leaves other entities alone", () => {
+    expect(parseExcerpt("a &amp; b")).toEqual([{ text: "a &amp; b", marked: false }]);
+  });
+
+  it("handles marks at both ends and back to back", () => {
+    expect(parseExcerpt("<mark>a</mark><mark>b</mark>")).toEqual([
+      { text: "a", marked: true },
+      { text: "b", marked: true },
+    ]);
+  });
+
+  it("drops empty marks", () => {
+    expect(parseExcerpt("x<mark></mark>y")).toEqual([
+      { text: "x", marked: false },
+      { text: "y", marked: false },
+    ]);
+  });
+
+  it("returns nothing for an empty excerpt", () => {
+    expect(parseExcerpt("")).toEqual([]);
+  });
+});

--- a/apps/me/src/__tests__/features/search/utils/keyboard.test.ts
+++ b/apps/me/src/__tests__/features/search/utils/keyboard.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { cycleIndex, isEditableTarget, isToggleShortcut } from "#/features/search/utils/keyboard";
+
+const key = (overrides: Partial<Parameters<typeof isToggleShortcut>[0]>) => ({
+  key: "k",
+  metaKey: false,
+  ctrlKey: false,
+  altKey: false,
+  ...overrides,
+});
+
+describe("isToggleShortcut", () => {
+  it("accepts Cmd+K and Ctrl+K regardless of letter case", () => {
+    expect(isToggleShortcut(key({ metaKey: true }))).toBe(true);
+    expect(isToggleShortcut(key({ ctrlKey: true }))).toBe(true);
+    expect(isToggleShortcut(key({ ctrlKey: true, key: "K" }))).toBe(true);
+  });
+
+  it("rejects a bare K and any Alt combination", () => {
+    expect(isToggleShortcut(key({}))).toBe(false);
+    expect(isToggleShortcut(key({ ctrlKey: true, altKey: true }))).toBe(false);
+  });
+
+  it("rejects other keys with the modifier", () => {
+    expect(isToggleShortcut(key({ metaKey: true, key: "j" }))).toBe(false);
+  });
+});
+
+describe("isEditableTarget", () => {
+  it("treats form fields and contenteditable as editable", () => {
+    expect(isEditableTarget({ tagName: "INPUT", isContentEditable: false })).toBe(true);
+    expect(isEditableTarget({ tagName: "textarea", isContentEditable: false })).toBe(true);
+    expect(isEditableTarget({ tagName: "SELECT", isContentEditable: false })).toBe(true);
+    expect(isEditableTarget({ tagName: "DIV", isContentEditable: true })).toBe(true);
+  });
+
+  it("treats everything else as not editable", () => {
+    expect(isEditableTarget({ tagName: "DIV", isContentEditable: false })).toBe(false);
+    expect(isEditableTarget({ tagName: "A", isContentEditable: false })).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});
+
+describe("cycleIndex", () => {
+  it("wraps from the last item back to the first", () => {
+    expect(cycleIndex(3, 1, 4)).toBe(0);
+  });
+
+  it("wraps from the first item back to the last", () => {
+    expect(cycleIndex(0, -1, 4)).toBe(3);
+  });
+
+  it("steps within the list", () => {
+    expect(cycleIndex(1, 1, 4)).toBe(2);
+    expect(cycleIndex(2, -1, 4)).toBe(1);
+  });
+
+  it("stays put with a single item", () => {
+    expect(cycleIndex(0, 1, 1)).toBe(0);
+    expect(cycleIndex(0, -1, 1)).toBe(0);
+  });
+
+  it("returns undefined when nothing in the list is focused", () => {
+    expect(cycleIndex(-1, 1, 4)).toBeUndefined();
+    expect(cycleIndex(0, 1, 0)).toBeUndefined();
+  });
+});

--- a/apps/me/src/__tests__/features/search/utils/meta.test.ts
+++ b/apps/me/src/__tests__/features/search/utils/meta.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { searchConfig } from "#/features/search/config";
+import {
+  buildBodyMeta,
+  buildCategoryFilter,
+  buildDateMeta,
+  buildTitleMeta,
+} from "#/features/search/utils/meta";
+import { buildSearchOptions } from "#/features/search/utils/query";
+
+describe("buildTitleMeta", () => {
+  it("puts the inline emoji capture last so it can hold any character", () => {
+    expect(buildTitleMeta("🧑‍💻")).toBe("title, emoji:🧑‍💻");
+    expect(buildTitleMeta("a,b")).toMatch(/emoji:a,b$/u);
+  });
+});
+
+describe("buildDateMeta", () => {
+  it("captures the visible date and the machine-readable datetime attribute", () => {
+    expect(buildDateMeta()).toBe("date, datetime[datetime]");
+  });
+});
+
+describe("buildBodyMeta", () => {
+  it("blanks the automatic image capture", () => {
+    expect(buildBodyMeta()).toBe("image:");
+  });
+});
+
+describe("buildCategoryFilter", () => {
+  it("uses the same filter key the search options send", () => {
+    expect(buildCategoryFilter("Tech")).toBe(`${searchConfig.filterKey}:Tech`);
+    expect(buildSearchOptions("Tech")).toEqual({
+      filters: { [searchConfig.filterKey]: "Tech" },
+    });
+  });
+});

--- a/apps/me/src/__tests__/features/search/utils/query.test.ts
+++ b/apps/me/src/__tests__/features/search/utils/query.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildSearchOptions, normalizeQuery, toResultHref } from "#/features/search/utils/query";
+
+describe("normalizeQuery", () => {
+  it("trims surrounding whitespace", () => {
+    expect(normalizeQuery("  mastodon  ")).toBe("mastodon");
+  });
+
+  it("collapses runs of whitespace, including ideographic spaces", () => {
+    expect(normalizeQuery("分散型　　SNS   構築")).toBe("分散型 SNS 構築");
+  });
+
+  it("returns an empty string for whitespace-only input", () => {
+    expect(normalizeQuery(" \t\n　")).toBe("");
+  });
+});
+
+describe("buildSearchOptions", () => {
+  it("returns no filters when no category is selected", () => {
+    expect(buildSearchOptions(undefined)).toEqual({});
+    expect(buildSearchOptions("")).toEqual({});
+  });
+
+  it("filters by the selected category", () => {
+    expect(buildSearchOptions("Tech")).toEqual({ filters: { category: "Tech" } });
+  });
+});
+
+describe("toResultHref", () => {
+  it("strips the .html extension Pagefind reports for file-format builds", () => {
+    expect(toResultHref("/blog/posts/b1e2lej.html")).toBe("/blog/posts/b1e2lej");
+  });
+
+  it("leaves extensionless URLs untouched", () => {
+    expect(toResultHref("/blog/posts/b1e2lej")).toBe("/blog/posts/b1e2lej");
+  });
+});

--- a/apps/me/src/__tests__/features/search/utils/search-runner.test.ts
+++ b/apps/me/src/__tests__/features/search/utils/search-runner.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from "vitest";
+import { searchConfig } from "#/features/search/config";
+import type {
+  PagefindFragment,
+  PagefindModule,
+  PagefindSearchResponse,
+  PagefindSearchResult,
+} from "#/features/search/types";
+import {
+  createSearchRunner,
+  formatErrorStatus,
+  formatResultStatus,
+} from "#/features/search/utils/search-runner";
+
+const fragment = (url: string): PagefindFragment => ({
+  url,
+  raw_url: url,
+  content: "",
+  excerpt: "",
+  word_count: 0,
+  meta: {},
+  filters: {},
+});
+
+const result = (
+  url: string,
+  data: () => Promise<PagefindFragment> = () => Promise.resolve(fragment(url)),
+): PagefindSearchResult => ({
+  id: url,
+  score: 1,
+  words: [],
+  data,
+});
+
+const response = (results: PagefindSearchResult[]): PagefindSearchResponse => ({
+  results,
+  unfilteredResultCount: results.length,
+  filters: {},
+  totalFilters: {},
+  timings: { preload: 0, search: 0, total: 0 },
+});
+
+const respond = (results: PagefindSearchResult[]) =>
+  vi.fn<PagefindModule["debouncedSearch"]>().mockResolvedValue(response(results));
+
+const rejectWith = (error: unknown) =>
+  vi.fn<PagefindModule["debouncedSearch"]>().mockRejectedValue(error);
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const createHarness = (pagefind: Partial<PagefindModule>) => {
+  const module: PagefindModule = {
+    options: vi.fn<PagefindModule["options"]>(() => Promise.resolve()),
+    init: vi.fn<PagefindModule["init"]>(() => Promise.resolve()),
+    debouncedSearch: respond([]),
+    ...pagefind,
+  };
+  const deps = {
+    loadPagefind: vi.fn<() => Promise<PagefindModule>>(() => Promise.resolve(module)),
+    render: vi.fn<(fragments: PagefindFragment[]) => void>(),
+    setStatus: vi.fn<(text: string) => void>(),
+    onError: vi.fn<(stage: string, error: unknown) => void>(),
+  };
+  return { module, deps, run: createSearchRunner(deps) };
+};
+
+describe("formatResultStatus", () => {
+  it("names the query when nothing matched", () => {
+    expect(formatResultStatus({ query: "abc", total: 0, shown: 0, failed: 0 })).toBe(
+      "「abc」に一致する記事はありません",
+    );
+  });
+
+  it("shows only the total when every hit is rendered", () => {
+    expect(formatResultStatus({ query: "q", total: 3, shown: 3, failed: 0 })).toBe("3 件");
+  });
+
+  it("says how many of the hits are on screen when the list is capped", () => {
+    expect(formatResultStatus({ query: "q", total: 42, shown: 10, failed: 0 })).toBe(
+      "42 件中 10 件を表示",
+    );
+  });
+
+  it("mentions fragments that failed to load", () => {
+    expect(formatResultStatus({ query: "q", total: 5, shown: 4, failed: 1 })).toBe(
+      "5 件中 4 件を表示（1 件を読み込めませんでした）",
+    );
+  });
+});
+
+describe("formatErrorStatus", () => {
+  it("advises a reload only for the stages a retry cannot fix", () => {
+    expect(formatErrorStatus("load")).toMatch(/再読み込み/u);
+    expect(formatErrorStatus("search")).toMatch(/再読み込み/u);
+    expect(formatErrorStatus("fragments")).toMatch(/もう一度/u);
+    expect(formatErrorStatus("render")).toMatch(/もう一度/u);
+  });
+});
+
+describe("createSearchRunner", () => {
+  it("clears the UI without touching Pagefind for a blank query", async () => {
+    const { deps, run } = createHarness({});
+    await run("  　 ", undefined);
+    expect(deps.loadPagefind).not.toHaveBeenCalled();
+    expect(deps.render).toHaveBeenCalledWith([]);
+    expect(deps.setStatus).toHaveBeenCalledWith("");
+  });
+
+  it("normalizes the query and forwards the category filter and debounce", async () => {
+    const debouncedSearch = respond([result("/a.html")]);
+    const { deps, run } = createHarness({ debouncedSearch });
+    await run(" 分散型　SNS ", "Tech");
+    expect(debouncedSearch).toHaveBeenCalledWith(
+      "分散型 SNS",
+      { filters: { [searchConfig.filterKey]: "Tech" } },
+      searchConfig.debounceMs,
+    );
+    expect(deps.render).toHaveBeenCalledWith([fragment("/a.html")]);
+    expect(deps.setStatus).toHaveBeenLastCalledWith("1 件");
+  });
+
+  it("does nothing when Pagefind reports the call as superseded", async () => {
+    const { deps, run } = createHarness({
+      debouncedSearch: vi.fn<PagefindModule["debouncedSearch"]>(() => Promise.resolve(null)),
+    });
+    await run("q", undefined);
+    expect(deps.render).not.toHaveBeenCalled();
+    expect(deps.setStatus).not.toHaveBeenCalled();
+  });
+
+  it("only loads fragments for the first maxResults hits and reports the total", async () => {
+    const loaded: string[] = [];
+    const results = Array.from({ length: searchConfig.maxResults + 5 }, (_, i) =>
+      result(`/${i}.html`, () => {
+        loaded.push(`/${i}.html`);
+        return Promise.resolve(fragment(`/${i}.html`));
+      }),
+    );
+    const { deps, run } = createHarness({ debouncedSearch: respond(results) });
+    await run("q", undefined);
+    expect(loaded).toEqual(results.slice(0, searchConfig.maxResults).map((r) => r.id));
+    expect(deps.setStatus).toHaveBeenLastCalledWith(
+      `${searchConfig.maxResults + 5} 件中 ${searchConfig.maxResults} 件を表示`,
+    );
+  });
+
+  it("drops a slow response once a newer request has rendered", async () => {
+    const first = deferred<PagefindFragment>();
+    const debouncedSearch = vi
+      .fn<PagefindModule["debouncedSearch"]>()
+      .mockResolvedValueOnce(response([result("/old.html", () => first.promise)]))
+      .mockResolvedValueOnce(response([result("/new.html")]));
+    const { deps, run } = createHarness({ debouncedSearch });
+
+    const older = run("old", undefined);
+    await vi.waitFor(() => expect(debouncedSearch).toHaveBeenCalledTimes(1));
+    await run("new", undefined);
+    expect(deps.render).toHaveBeenLastCalledWith([fragment("/new.html")]);
+
+    first.resolve(fragment("/old.html"));
+    await older;
+    expect(deps.render).toHaveBeenCalledTimes(1);
+    expect(deps.setStatus).toHaveBeenLastCalledWith("1 件");
+  });
+
+  it("drops a late failure once a newer request has rendered", async () => {
+    const first = deferred<PagefindFragment>();
+    const debouncedSearch = vi
+      .fn<PagefindModule["debouncedSearch"]>()
+      .mockResolvedValueOnce(response([result("/old.html", () => first.promise)]))
+      .mockResolvedValueOnce(response([result("/new.html")]));
+    const { deps, run } = createHarness({ debouncedSearch });
+
+    const older = run("old", undefined);
+    await vi.waitFor(() => expect(debouncedSearch).toHaveBeenCalledTimes(1));
+    await run("new", undefined);
+
+    first.reject(new Error("network"));
+    await older;
+    expect(deps.onError).not.toHaveBeenCalled();
+    expect(deps.setStatus).toHaveBeenLastCalledWith("1 件");
+  });
+
+  it("reports a bundle load failure with reload advice and clears the list", async () => {
+    const error = new TypeError("Failed to fetch dynamically imported module");
+    const { deps, run } = createHarness({});
+    deps.loadPagefind.mockRejectedValue(error);
+    await run("q", undefined);
+    expect(deps.onError).toHaveBeenCalledWith("load", error);
+    expect(deps.render).toHaveBeenCalledWith([]);
+    expect(deps.setStatus).toHaveBeenCalledWith(formatErrorStatus("load"));
+  });
+
+  it("treats a rejected search (missing index) as a load-class failure", async () => {
+    const error = new Error("Failed to load the index");
+    const { deps, run } = createHarness({ debouncedSearch: rejectWith(error) });
+    await run("q", undefined);
+    expect(deps.onError).toHaveBeenCalledWith("search", error);
+    expect(deps.setStatus).toHaveBeenCalledWith(formatErrorStatus("search"));
+  });
+
+  it("renders the fragments that loaded and reports the ones that did not", async () => {
+    const error = new Error("gunzip");
+    const { deps, run } = createHarness({
+      debouncedSearch: respond([result("/a.html"), result("/b.html", () => Promise.reject(error))]),
+    });
+    await run("q", undefined);
+    expect(deps.render).toHaveBeenCalledWith([fragment("/a.html")]);
+    expect(deps.onError).toHaveBeenCalledWith("fragments", [error]);
+    expect(deps.setStatus).toHaveBeenLastCalledWith(
+      "2 件中 1 件を表示（1 件を読み込めませんでした）",
+    );
+  });
+
+  it("fails the search when every fragment fails to load", async () => {
+    const error = new Error("gunzip");
+    const { deps, run } = createHarness({
+      debouncedSearch: respond([result("/a.html", () => Promise.reject(error))]),
+    });
+    await run("q", undefined);
+    expect(deps.onError).toHaveBeenCalledTimes(1);
+    expect(deps.onError.mock.calls[0]?.[0]).toBe("fragments");
+    expect(deps.render).toHaveBeenLastCalledWith([]);
+    expect(deps.setStatus).toHaveBeenLastCalledWith(formatErrorStatus("fragments"));
+  });
+
+  it("surfaces a render failure as a retryable error", async () => {
+    const error = new Error("template drift");
+    const { deps, run } = createHarness({ debouncedSearch: respond([result("/a.html")]) });
+    deps.render.mockImplementationOnce(() => {
+      throw error;
+    });
+    await run("q", undefined);
+    expect(deps.onError).toHaveBeenCalledWith("render", error);
+    expect(deps.render).toHaveBeenLastCalledWith([]);
+    expect(deps.setStatus).toHaveBeenLastCalledWith(formatErrorStatus("render"));
+  });
+});

--- a/apps/me/src/components/icons/search.svg
+++ b/apps/me/src/components/icons/search.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>

--- a/apps/me/src/features/search/components/search-button.astro
+++ b/apps/me/src/features/search/components/search-button.astro
@@ -1,0 +1,56 @@
+---
+import SearchIcon from "#/components/icons/search.svg";
+import { searchConfig } from "#/features/search/config";
+---
+
+<button
+  type="button"
+  class="search-button"
+  commandfor={searchConfig.dialogId}
+  command="show-modal"
+  aria-label="記事を検索"
+  data-umami-event="search-open"
+>
+  <SearchIcon />
+</button>
+
+<style>
+  /* Sits beside the hamburger (2.5rem wide at right 1rem) below the desktop
+     breakpoint; above it the hamburger disappears and the button takes the
+     corner, aligned with the fixed site brand's 2rem inset. */
+  .search-button {
+    position: fixed;
+    top: 1rem;
+    right: 4rem;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    appearance: none;
+    padding: 0;
+    background: var(--c-bg);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-full);
+    color: var(--c-sub);
+    cursor: pointer;
+    transition: color 0.2s;
+  }
+
+  .search-button:hover {
+    color: var(--c-text);
+  }
+
+  .search-button svg {
+    width: 1.125rem;
+    height: 1.125rem;
+  }
+
+  @media (width >= 1280px) {
+    .search-button {
+      top: 1.25rem;
+      right: 2rem;
+    }
+  }
+</style>

--- a/apps/me/src/features/search/components/search-dialog.astro
+++ b/apps/me/src/features/search/components/search-dialog.astro
@@ -60,9 +60,10 @@ import { searchConfig } from "#/features/search/config";
 
 <style>
   /* Browsers keep the page behind a modal dialog wheel/touch-scrollable; lock
-     it while the search is open. Only overflow changes: the shared base styles
-     already reserve the scrollbar gutter on both edges, and overriding it here
-     would move the page by half the gutter. */
+     it while the search is open. Only overflow changes: the base styles'
+     `scrollbar-gutter: stable both-edges` keeps both gutters even with overflow
+     hidden, so nothing shifts; switching to single-edge `stable` here would
+     move the centred column by half a scrollbar width. */
   :global(html:has(.search-dialog:modal)) {
     overflow: hidden;
   }
@@ -245,12 +246,21 @@ import { searchConfig } from "#/features/search/config";
     color: var(--c-sub);
   }
 
+  /* Hidden visually rather than with display: none so the live region stays
+     in the accessibility tree and the first announcement is not dropped. */
   .search-status:empty {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    border: 0;
   }
 
-  /* With no results below (no hits, load failure) the status line closes the
-     dialog, so give it the same breathing room below as above. */
+  /* With nothing below it (no hits, load failure) the status line is the
+     dialog's last visible row, so match its top padding below. */
   .search-status:has(+ .search-results:empty) {
     padding-bottom: 0.75rem;
   }
@@ -352,9 +362,8 @@ import { searchConfig } from "#/features/search/config";
     overflow-wrap: anywhere;
   }
 
-  /* A tinted pill in body colour: the excerpt itself is muted grey, so the
-     match is lifted by weight and colour rather than by a saturated fill
-     (the dark yellow selection token swallows grey text in dark mode). */
+  /* Not `--c-selection`: its dark-mode yellow-9 fill drowns the grey excerpt
+     text, so the match gets body colour and weight over a 35% tint instead. */
   .search-result-excerpt :global(mark) {
     padding-inline: 0.125em;
     margin-inline: -0.0625em;
@@ -385,36 +394,73 @@ import { searchConfig } from "#/features/search/config";
 <script>
   import { searchConfig } from "#/features/search/config";
   import type { PagefindFragment, PagefindModule } from "#/features/search/types";
-  import { buildSearchOptions, normalizeQuery, toResultHref } from "#/features/search/utils/query";
+  import { parseExcerpt } from "#/features/search/utils/excerpt";
+  import { cycleIndex, isEditableTarget, isToggleShortcut } from "#/features/search/utils/keyboard";
+  import { toResultHref } from "#/features/search/utils/query";
+  import { createSearchRunner } from "#/features/search/utils/search-runner";
 
   const ACTIVE_FILTER_CLASS = "search-filter--active";
+  const { metaKeys } = searchConfig;
   const pagefindUrl = `${searchConfig.bundlePath}pagefind.js`;
 
-  const isEditableTarget = (target: EventTarget | null) =>
-    target instanceof HTMLElement &&
-    (target.isContentEditable || /^(?:input|textarea|select)$/iu.test(target.tagName));
+  const requireElement = <T extends Element>(
+    root: ParentNode,
+    selector: string,
+    guard: (element: Element) => element is T,
+  ): T => {
+    const element = root.querySelector(selector);
+    if (!element || !guard(element)) {
+      throw new Error(`search-dialog: missing element for "${selector}"`);
+    }
+    return element;
+  };
 
-  const fill = (root: ParentNode, selector: string, apply: (element: HTMLElement) => void) => {
-    const element = root.querySelector<HTMLElement>(selector);
-    if (element) apply(element);
+  const isHTMLElement = (element: Element): element is HTMLElement =>
+    element instanceof HTMLElement;
+
+  const renderExcerpt = (element: HTMLElement, excerpt: string) => {
+    element.replaceChildren(
+      ...parseExcerpt(excerpt).map(({ text, marked }) => {
+        if (!marked) return document.createTextNode(text);
+        const mark = document.createElement("mark");
+        mark.textContent = text;
+        return mark;
+      }),
+    );
   };
 
   const setup = (dialog: HTMLDialogElement) => {
-    const input = dialog.querySelector<HTMLInputElement>(".search-input");
-    const form = dialog.querySelector<HTMLFormElement>(".search-form");
-    const status = dialog.querySelector<HTMLElement>(".search-status");
-    const list = dialog.querySelector<HTMLOListElement>(".search-results");
-    const template = dialog.querySelector<HTMLTemplateElement>(".search-result-template");
-    const filters = dialog.querySelector<HTMLElement>(".search-filters");
+    // Every selector below points at markup in this same file, so a miss is a
+    // programming error and should fail loudly instead of leaving a dead UI.
+    const input = requireElement(
+      dialog,
+      ".search-input",
+      (element): element is HTMLInputElement => element instanceof HTMLInputElement,
+    );
+    const form = requireElement(
+      dialog,
+      ".search-form",
+      (element): element is HTMLFormElement => element instanceof HTMLFormElement,
+    );
+    const status = requireElement(dialog, ".search-status", isHTMLElement);
+    const list = requireElement(dialog, ".search-results", isHTMLElement);
+    const template = requireElement(
+      dialog,
+      ".search-result-template",
+      (element): element is HTMLTemplateElement => element instanceof HTMLTemplateElement,
+    );
+    const filters = requireElement(dialog, ".search-filters", isHTMLElement);
     const triggers = [
       ...document.querySelectorAll<HTMLButtonElement>(`button[commandfor="${dialog.id}"]`),
     ];
-    if (!input || !form || !status || !list || !template || !filters) return;
 
     let category: string | undefined;
     let pagefindPromise: Promise<PagefindModule> | undefined;
-    let requestId = 0;
+    let composing = false;
 
+    // The promise is cached even when it rejects: a failed module fetch is
+    // recorded in the module map, so re-importing the same URL fails
+    // identically without a page reload.
     const loadPagefind = () => {
       pagefindPromise ??= (async () => {
         const pagefind = (await import(
@@ -428,79 +474,69 @@ import { searchConfig } from "#/features/search/config";
       return pagefindPromise;
     };
 
-    // Best-effort warm-up on hover/open; a failure here is reported by the
-    // real search instead, so the dev server without a build stays quiet.
+    // Best-effort warm-up on hover/open. The failure is swallowed here so that
+    // hovering in a dev server without a build neither logs "Search failed"
+    // nor writes to the status line; the next real search reports it.
     const warmUp = () => {
-      loadPagefind().catch(() => {
-        pagefindPromise = undefined;
-      });
+      loadPagefind().catch(() => {});
     };
 
     const renderResult = (fragment: PagefindFragment) => {
       const node = template.content.cloneNode(true) as DocumentFragment;
-      fill(node, ".search-result", (element) => {
-        if (element instanceof HTMLAnchorElement) element.href = toResultHref(fragment.url);
-      });
-      fill(node, ".search-result-emoji", (element) => {
-        element.textContent = fragment.meta.emoji ?? "";
-      });
-      fill(node, ".search-result-title", (element) => {
-        element.textContent = fragment.meta.title ?? toResultHref(fragment.url);
-      });
-      fill(node, ".search-result-excerpt", (element) => {
-        // Pagefind wraps matches in <mark>; the excerpt is built from this
-        // site's own indexed text.
-        element.innerHTML = fragment.excerpt;
-      });
-      fill(node, ".search-result-date", (element) => {
-        element.textContent = fragment.meta.date ?? "";
-        if (element instanceof HTMLTimeElement) element.dateTime = fragment.meta.datetime ?? "";
-      });
+      const href = toResultHref(fragment.url);
+      const title = fragment.meta[metaKeys.title];
+      const emoji = fragment.meta[metaKeys.emoji];
+      const date = fragment.meta[metaKeys.date];
+      const datetime = fragment.meta[metaKeys.datetime];
+      if (import.meta.env.DEV && (!title || !emoji || !date || !datetime)) {
+        console.warn(
+          "Pagefind fragment is missing expected meta; check data-pagefind-meta in blog-layout",
+          fragment.url,
+          fragment.meta,
+        );
+      }
+
+      requireElement(
+        node,
+        ".search-result",
+        (element): element is HTMLAnchorElement => element instanceof HTMLAnchorElement,
+      ).href = href;
+      requireElement(node, ".search-result-emoji", isHTMLElement).textContent = emoji ?? "";
+      requireElement(node, ".search-result-title", isHTMLElement).textContent = title ?? href;
+      renderExcerpt(requireElement(node, ".search-result-excerpt", isHTMLElement), fragment.excerpt);
+      const time = requireElement(
+        node,
+        ".search-result-date",
+        (element): element is HTMLTimeElement => element instanceof HTMLTimeElement,
+      );
+      // `datetime=""` is not a valid value, so drop the element when the
+      // fragment carries no date.
+      if (date && datetime) {
+        time.textContent = date;
+        time.dateTime = datetime;
+      } else {
+        time.remove();
+      }
       return node;
     };
 
-    const search = async () => {
-      const query = normalizeQuery(input.value);
-      const id = ++requestId;
-      if (query === "") {
-        list.replaceChildren();
-        status.textContent = "";
-        return;
-      }
-
-      let pagefind: PagefindModule;
-      try {
-        pagefind = await loadPagefind();
-      } catch (error) {
-        console.error("Failed to load the Pagefind bundle", error);
-        pagefindPromise = undefined;
-        status.textContent = "検索インデックスを読み込めませんでした";
-        return;
-      }
-
-      const response = await pagefind.debouncedSearch(
-        query,
-        buildSearchOptions(category),
-        searchConfig.debounceMs,
-      );
-      if (response === null || id !== requestId) return;
-
-      const fragments = await Promise.all(
-        response.results.slice(0, searchConfig.maxResults).map((result) => result.data()),
-      );
-      if (id !== requestId) return;
-
-      list.replaceChildren(...fragments.map((fragment) => renderResult(fragment)));
-      status.textContent =
-        response.results.length === 0
-          ? `「${query}」に一致する記事はありません`
-          : `${response.results.length} 件`;
-    };
+    const search = createSearchRunner({
+      loadPagefind,
+      render: (fragments) => {
+        list.replaceChildren(...fragments.map((fragment) => renderResult(fragment)));
+      },
+      setStatus: (text) => {
+        status.textContent = text;
+      },
+      onError: (stage, error) => {
+        console.error(`Search failed at stage "${stage}"`, { query: input.value, category, error });
+      },
+    });
 
     const runSearch = () => {
-      search().catch((error: unknown) => {
-        console.error("Search failed", error);
-        status.textContent = "検索に失敗しました";
+      // The runner catches everything it expects; anything left is a bug.
+      search(input.value, category).catch((error: unknown) => {
+        console.error("Search runner threw", error);
       });
     };
 
@@ -509,17 +545,30 @@ import { searchConfig } from "#/features/search/config";
       ...list.querySelectorAll<HTMLAnchorElement>(".search-result"),
     ];
 
-    const openDialog = () => {
-      if (dialog.open) return;
-      dialog.showModal();
+    const onOpened = () => {
       input.select();
       warmUp();
     };
 
+    const openDialog = () => {
+      if (dialog.open) return;
+      dialog.showModal();
+      onOpened();
+    };
+
     input.addEventListener("input", runSearch);
+    input.addEventListener("compositionstart", () => {
+      composing = true;
+    });
+    input.addEventListener("compositionend", () => {
+      composing = false;
+    });
 
     form.addEventListener("submit", (event) => {
       event.preventDefault();
+      // Some engines let the Enter that commits an IME candidate submit the
+      // form; that Enter must not follow the first result.
+      if (composing) return;
       list.querySelector<HTMLAnchorElement>(".search-result")?.click();
     });
 
@@ -546,26 +595,31 @@ import { searchConfig } from "#/features/search/config";
       if (event.key === "Escape") {
         // Chrome consumes the first Escape in a non-empty `type="search"` input
         // to clear it, so close explicitly instead of relying on cancel.
+        // preventDefault also keeps the query, so reopening restores it
+        // selected.
         event.preventDefault();
         dialog.close();
         return;
       }
       if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
       const items = focusableItems();
-      const index = items.findIndex((item) => item === document.activeElement);
-      if (index === -1) return;
-      const offset = event.key === "ArrowDown" ? 1 : -1;
-      const next = items[(index + offset + items.length) % items.length];
+      const index = cycleIndex(
+        items.findIndex((item) => item === document.activeElement),
+        event.key === "ArrowDown" ? 1 : -1,
+        items.length,
+      );
+      const next = index === undefined ? undefined : items[index];
       if (!next) return;
       event.preventDefault();
       next.focus();
     });
 
+    // Invoker-driven opens (`commandfor`) bypass `openDialog`, so the toggle
+    // event is the one path that sees every open; `openDialog` still calls
+    // `onOpened` itself for engines that do not fire toggle on dialogs yet.
+    // Running it twice only re-selects the input.
     dialog.addEventListener("toggle", (event) => {
-      if (event instanceof ToggleEvent && event.newState === "open") {
-        input.select();
-        warmUp();
-      }
+      if (event instanceof ToggleEvent && event.newState === "open") onOpened();
     });
 
     for (const trigger of triggers) {
@@ -573,33 +627,33 @@ import { searchConfig } from "#/features/search/config";
     }
 
     document.addEventListener("keydown", (event) => {
-      if ((event.metaKey || event.ctrlKey) && !event.altKey && event.key.toLowerCase() === "k") {
+      if (isToggleShortcut(event)) {
         event.preventDefault();
         if (dialog.open) dialog.close();
         else openDialog();
         return;
       }
-      if (event.key === "/" && !dialog.open && !isEditableTarget(event.target)) {
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      if (event.key === "/" && !dialog.open && !isEditableTarget(target)) {
         event.preventDefault();
         openDialog();
       }
     });
 
-    // Invoker commands (`commandfor`) are Baseline only since late 2025.
+    // Invoker commands (`commandfor`) are Baseline 2025 (Safari 26.2); older
+    // engines get click handlers.
     if (!("commandForElement" in HTMLButtonElement.prototype)) {
-      for (const button of dialog.ownerDocument.querySelectorAll<HTMLButtonElement>(
-        `button[commandfor="${dialog.id}"]`,
-      )) {
-        button.addEventListener("click", () => {
-          if (button.getAttribute("command") === "close") dialog.close();
+      for (const trigger of triggers) {
+        trigger.addEventListener("click", () => {
+          if (trigger.getAttribute("command") === "close") dialog.close();
           else openDialog();
         });
       }
     }
 
-    // `closedby="any"` light-dismiss is newer still; the dialog has no
-    // padding, so a click that lands on the dialog itself came from the
-    // backdrop.
+    // `closedby` is not Baseline (no Safari support as of 2026-08), so emulate
+    // light dismiss. The dialog has no padding, so a click whose target is the
+    // dialog itself came from the backdrop.
     if (!("closedBy" in HTMLDialogElement.prototype)) {
       dialog.addEventListener("click", (event) => {
         if (event.target === dialog) dialog.close();
@@ -609,4 +663,5 @@ import { searchConfig } from "#/features/search/config";
 
   const dialog = document.querySelector(`#${searchConfig.dialogId}`);
   if (dialog instanceof HTMLDialogElement) setup(dialog);
+  else console.error(`search-dialog: no <dialog id="${searchConfig.dialogId}"> in the document`);
 </script>

--- a/apps/me/src/features/search/components/search-dialog.astro
+++ b/apps/me/src/features/search/components/search-dialog.astro
@@ -1,0 +1,612 @@
+---
+import SearchIcon from "#/components/icons/search.svg";
+import { categories } from "#/features/blog/config/category";
+import { searchConfig } from "#/features/search/config";
+---
+
+<dialog id={searchConfig.dialogId} class="search-dialog" closedby="any" aria-label="記事を検索">
+  <search class="search">
+    <form class="search-form">
+      <div class="search-field">
+        <SearchIcon class="search-field-icon" />
+        <input
+          type="search"
+          class="search-input"
+          name="q"
+          placeholder="記事を検索"
+          aria-label="検索キーワード"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+          enterkeyhint="go"
+        />
+        <button
+          type="button"
+          class="search-close"
+          commandfor={searchConfig.dialogId}
+          command="close"
+          aria-label="閉じる"
+        >
+          esc
+        </button>
+      </div>
+      <div class="search-filters palt" role="group" aria-label="カテゴリで絞り込み">
+        <button type="button" class="search-filter search-filter--active" data-category="" aria-pressed="true">
+          すべて
+        </button>
+        {categories.map(({ title, label }) => (
+          <button type="button" class="search-filter" data-category={title} aria-pressed="false">
+            {label}
+          </button>
+        ))}
+      </div>
+    </form>
+    <p class="search-status" role="status"></p>
+    <ol class="search-results" aria-label="検索結果"></ol>
+  </search>
+  <template class="search-result-template">
+    <li class="search-results-item">
+      <a class="search-result" data-astro-prefetch="hover" data-umami-event="search-result">
+        <span class="search-result-emoji" aria-hidden="true"></span>
+        <span class="search-result-body">
+          <span class="search-result-title palt"></span>
+          <span class="search-result-excerpt"></span>
+        </span>
+        <time class="search-result-date palt"></time>
+      </a>
+    </li>
+  </template>
+</dialog>
+
+<style>
+  /* Browsers keep the page behind a modal dialog wheel/touch-scrollable; lock
+     it while the search is open. Only overflow changes: the shared base styles
+     already reserve the scrollbar gutter on both edges, and overriding it here
+     would move the page by half the gutter. */
+  :global(html:has(.search-dialog:modal)) {
+    overflow: hidden;
+  }
+
+  .search-dialog {
+    position: fixed;
+    inset: 0;
+    width: min(100% - 2rem, 36rem);
+    max-height: min(70dvh, 32rem);
+    /* Command-palette placement: pinned near the top rather than centred, so
+       the results list can grow downward without the box jumping around. */
+    margin: 12vh auto auto;
+    padding: 0;
+    overflow: hidden;
+    background: var(--c-bg);
+    color: var(--c-text);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-lg);
+    box-shadow:
+      0 14px 28px -6px oklch(var(--uchu-yin-raw) / 20%),
+      0 2px 4px -1px oklch(var(--uchu-yin-raw) / 12%);
+    opacity: 1;
+    translate: 0 0;
+    transition:
+      opacity 0.2s,
+      translate 0.2s,
+      display 0.2s allow-discrete,
+      overlay 0.2s allow-discrete;
+  }
+
+  .search-dialog[open] {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* Both the entry (@starting-style) and the exit (:not([open])) states are
+     declared: without the exit state the dialog lingers at full opacity for
+     the length of the display transition before vanishing. */
+  @starting-style {
+    .search-dialog[open] {
+      opacity: 0;
+      translate: 0 -8px;
+    }
+  }
+
+  .search-dialog:not([open]) {
+    opacity: 0;
+    translate: 0 -8px;
+  }
+
+  .search-dialog::backdrop {
+    background: oklch(var(--uchu-yin-raw) / 30%);
+    opacity: 1;
+    transition:
+      opacity 0.2s,
+      display 0.2s allow-discrete,
+      overlay 0.2s allow-discrete;
+  }
+
+  @starting-style {
+    .search-dialog[open]::backdrop {
+      opacity: 0;
+    }
+  }
+
+  .search-dialog:not([open])::backdrop {
+    opacity: 0;
+  }
+
+  .search {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .search-form {
+    flex-shrink: 0;
+  }
+
+  .search-field {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.875rem 1rem 0.5rem;
+  }
+
+  .search-field-icon {
+    flex-shrink: 0;
+    width: 1.125rem;
+    height: 1.125rem;
+    color: var(--c-sub);
+  }
+
+  .search-input {
+    flex: 1;
+    min-width: 0;
+    appearance: none;
+    padding: 0;
+    background: transparent;
+    border: none;
+    font: inherit;
+    /* Never below 16px: iOS zooms the page into any smaller focused input. */
+    font-size: max(16px, var(--fs-base));
+    color: var(--c-text);
+    outline: none;
+  }
+
+  .search-input::placeholder {
+    color: var(--c-sub);
+  }
+
+  .search-input::-webkit-search-decoration,
+  .search-input::-webkit-search-cancel-button {
+    appearance: none;
+  }
+
+  .search-close {
+    flex-shrink: 0;
+    appearance: none;
+    padding: 0.125rem 0.375rem;
+    background: transparent;
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: var(--fs-2xs);
+    line-height: 1.25;
+    color: var(--c-sub);
+    cursor: pointer;
+    transition: color 0.2s;
+  }
+
+  .search-close:hover {
+    color: var(--c-text);
+  }
+
+  .search-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    padding: 0.25rem 0.75rem 0.75rem;
+  }
+
+  .search-filter {
+    display: flex;
+    height: 1.5rem;
+    align-items: center;
+    appearance: none;
+    padding-inline: 0.5rem;
+    background: transparent;
+    border: none;
+    border-radius: var(--radius-full);
+    font-family: inherit;
+    font-size: var(--fs-xs);
+    color: var(--c-sub);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: color 0.2s;
+  }
+
+  .search-filter:hover {
+    color: var(--c-primary);
+  }
+
+  .search-filter--active,
+  .search-filter--active:hover {
+    background-color: var(--c-primary);
+    color: var(--c-primary-text);
+    font-weight: var(--fw-medium);
+  }
+
+  /* The divider lives here rather than under the form so it only appears once
+     there is something below it; the status is never empty while results
+     show. */
+  .search-status {
+    flex-shrink: 0;
+    margin: 0;
+    padding: 0.75rem 1rem 0.25rem;
+    border-top: 1px solid var(--c-border);
+    font-size: var(--fs-xs);
+    color: var(--c-sub);
+  }
+
+  .search-status:empty {
+    display: none;
+  }
+
+  /* With no results below (no hits, load failure) the status line closes the
+     dialog, so give it the same breathing room below as above. */
+  .search-status:has(+ .search-results:empty) {
+    padding-bottom: 0.75rem;
+  }
+
+  .search-results {
+    margin: 0;
+    padding: 0.5rem;
+    list-style: none;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .search-results:empty {
+    display: none;
+  }
+
+  .search-results::-webkit-scrollbar {
+    width: 3px;
+  }
+
+  .search-results::-webkit-scrollbar-thumb {
+    background: var(--c-sub);
+    border-radius: 2px;
+  }
+
+  @supports (-moz-appearance: none) {
+    .search-results {
+      scrollbar-width: thin;
+    }
+  }
+
+  .search-results-item {
+    margin: 0;
+    padding: 0;
+  }
+
+  .search-result {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: var(--radius-md);
+    font-size: var(--fs-sm);
+    color: var(--c-prose-text);
+    text-decoration: none;
+    transition: background-color 0.2s;
+  }
+
+  .search-result:hover {
+    background-color: oklch(from var(--c-surface) l c h / 50%);
+  }
+
+  /* The list clips overflow, so keep the ring inside the row. */
+  .search-result:focus-visible {
+    outline: var(--ring-width) solid var(--ring);
+    outline-offset: calc(-1 * var(--ring-width));
+  }
+
+  .search-result-emoji {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: var(--radius-md);
+    background-color: var(--c-surface);
+    box-shadow: var(--shadow-sm);
+    font-size: 1rem;
+    line-height: 1;
+    user-select: none;
+  }
+
+  .search-result-body {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+  }
+
+  .search-result-title {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    font-weight: var(--fw-medium);
+    line-height: var(--lh-sm);
+  }
+
+  .search-result-excerpt {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    font-size: var(--fs-xs);
+    line-height: var(--lh-sm);
+    color: var(--c-sub);
+    overflow-wrap: anywhere;
+  }
+
+  /* A tinted pill in body colour: the excerpt itself is muted grey, so the
+     match is lifted by weight and colour rather than by a saturated fill
+     (the dark yellow selection token swallows grey text in dark mode). */
+  .search-result-excerpt :global(mark) {
+    padding-inline: 0.125em;
+    margin-inline: -0.0625em;
+    border-radius: var(--radius-xs);
+    background-color: light-dark(
+      var(--uchu-yellow-2),
+      oklch(from var(--uchu-yellow-9) l c h / 35%)
+    );
+    color: var(--c-text);
+    font-weight: var(--fw-medium);
+  }
+
+  .search-result-date {
+    flex-shrink: 0;
+    margin-top: 0.125rem;
+    font-size: var(--fs-xs);
+    font-variant-numeric: tabular-nums;
+    color: var(--c-sub);
+  }
+
+  @media (width < 640px) {
+    .search-result-date {
+      display: none;
+    }
+  }
+</style>
+
+<script>
+  import { searchConfig } from "#/features/search/config";
+  import type { PagefindFragment, PagefindModule } from "#/features/search/types";
+  import { buildSearchOptions, normalizeQuery, toResultHref } from "#/features/search/utils/query";
+
+  const ACTIVE_FILTER_CLASS = "search-filter--active";
+  const pagefindUrl = `${searchConfig.bundlePath}pagefind.js`;
+
+  const isEditableTarget = (target: EventTarget | null) =>
+    target instanceof HTMLElement &&
+    (target.isContentEditable || /^(?:input|textarea|select)$/iu.test(target.tagName));
+
+  const fill = (root: ParentNode, selector: string, apply: (element: HTMLElement) => void) => {
+    const element = root.querySelector<HTMLElement>(selector);
+    if (element) apply(element);
+  };
+
+  const setup = (dialog: HTMLDialogElement) => {
+    const input = dialog.querySelector<HTMLInputElement>(".search-input");
+    const form = dialog.querySelector<HTMLFormElement>(".search-form");
+    const status = dialog.querySelector<HTMLElement>(".search-status");
+    const list = dialog.querySelector<HTMLOListElement>(".search-results");
+    const template = dialog.querySelector<HTMLTemplateElement>(".search-result-template");
+    const filters = dialog.querySelector<HTMLElement>(".search-filters");
+    const triggers = [
+      ...document.querySelectorAll<HTMLButtonElement>(`button[commandfor="${dialog.id}"]`),
+    ];
+    if (!input || !form || !status || !list || !template || !filters) return;
+
+    let category: string | undefined;
+    let pagefindPromise: Promise<PagefindModule> | undefined;
+    let requestId = 0;
+
+    const loadPagefind = () => {
+      pagefindPromise ??= (async () => {
+        const pagefind = (await import(
+          /* @vite-ignore */
+          pagefindUrl
+        )) as PagefindModule;
+        await pagefind.options({ excerptLength: searchConfig.excerptLength });
+        await pagefind.init();
+        return pagefind;
+      })();
+      return pagefindPromise;
+    };
+
+    // Best-effort warm-up on hover/open; a failure here is reported by the
+    // real search instead, so the dev server without a build stays quiet.
+    const warmUp = () => {
+      loadPagefind().catch(() => {
+        pagefindPromise = undefined;
+      });
+    };
+
+    const renderResult = (fragment: PagefindFragment) => {
+      const node = template.content.cloneNode(true) as DocumentFragment;
+      fill(node, ".search-result", (element) => {
+        if (element instanceof HTMLAnchorElement) element.href = toResultHref(fragment.url);
+      });
+      fill(node, ".search-result-emoji", (element) => {
+        element.textContent = fragment.meta.emoji ?? "";
+      });
+      fill(node, ".search-result-title", (element) => {
+        element.textContent = fragment.meta.title ?? toResultHref(fragment.url);
+      });
+      fill(node, ".search-result-excerpt", (element) => {
+        // Pagefind wraps matches in <mark>; the excerpt is built from this
+        // site's own indexed text.
+        element.innerHTML = fragment.excerpt;
+      });
+      fill(node, ".search-result-date", (element) => {
+        element.textContent = fragment.meta.date ?? "";
+        if (element instanceof HTMLTimeElement) element.dateTime = fragment.meta.datetime ?? "";
+      });
+      return node;
+    };
+
+    const search = async () => {
+      const query = normalizeQuery(input.value);
+      const id = ++requestId;
+      if (query === "") {
+        list.replaceChildren();
+        status.textContent = "";
+        return;
+      }
+
+      let pagefind: PagefindModule;
+      try {
+        pagefind = await loadPagefind();
+      } catch (error) {
+        console.error("Failed to load the Pagefind bundle", error);
+        pagefindPromise = undefined;
+        status.textContent = "検索インデックスを読み込めませんでした";
+        return;
+      }
+
+      const response = await pagefind.debouncedSearch(
+        query,
+        buildSearchOptions(category),
+        searchConfig.debounceMs,
+      );
+      if (response === null || id !== requestId) return;
+
+      const fragments = await Promise.all(
+        response.results.slice(0, searchConfig.maxResults).map((result) => result.data()),
+      );
+      if (id !== requestId) return;
+
+      list.replaceChildren(...fragments.map((fragment) => renderResult(fragment)));
+      status.textContent =
+        response.results.length === 0
+          ? `「${query}」に一致する記事はありません`
+          : `${response.results.length} 件`;
+    };
+
+    const runSearch = () => {
+      search().catch((error: unknown) => {
+        console.error("Search failed", error);
+        status.textContent = "検索に失敗しました";
+      });
+    };
+
+    const focusableItems = () => [
+      input,
+      ...list.querySelectorAll<HTMLAnchorElement>(".search-result"),
+    ];
+
+    const openDialog = () => {
+      if (dialog.open) return;
+      dialog.showModal();
+      input.select();
+      warmUp();
+    };
+
+    input.addEventListener("input", runSearch);
+
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      list.querySelector<HTMLAnchorElement>(".search-result")?.click();
+    });
+
+    filters.addEventListener("click", (event) => {
+      const button =
+        event.target instanceof Element
+          ? event.target.closest<HTMLButtonElement>(".search-filter")
+          : null;
+      if (!button) return;
+      category = button.dataset.category || undefined;
+      for (const other of filters.querySelectorAll<HTMLButtonElement>(".search-filter")) {
+        const isActive = other === button;
+        other.classList.toggle(ACTIVE_FILTER_CLASS, isActive);
+        other.setAttribute("aria-pressed", String(isActive));
+      }
+      input.focus();
+      runSearch();
+    });
+
+    dialog.addEventListener("keydown", (event) => {
+      // While an IME is composing, Escape and the arrow keys drive candidate
+      // selection and must reach neither the dialog nor the result list.
+      if (event.isComposing) return;
+      if (event.key === "Escape") {
+        // Chrome consumes the first Escape in a non-empty `type="search"` input
+        // to clear it, so close explicitly instead of relying on cancel.
+        event.preventDefault();
+        dialog.close();
+        return;
+      }
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+      const items = focusableItems();
+      const index = items.findIndex((item) => item === document.activeElement);
+      if (index === -1) return;
+      const offset = event.key === "ArrowDown" ? 1 : -1;
+      const next = items[(index + offset + items.length) % items.length];
+      if (!next) return;
+      event.preventDefault();
+      next.focus();
+    });
+
+    dialog.addEventListener("toggle", (event) => {
+      if (event instanceof ToggleEvent && event.newState === "open") {
+        input.select();
+        warmUp();
+      }
+    });
+
+    for (const trigger of triggers) {
+      trigger.addEventListener("pointerenter", warmUp, { once: true });
+    }
+
+    document.addEventListener("keydown", (event) => {
+      if ((event.metaKey || event.ctrlKey) && !event.altKey && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        if (dialog.open) dialog.close();
+        else openDialog();
+        return;
+      }
+      if (event.key === "/" && !dialog.open && !isEditableTarget(event.target)) {
+        event.preventDefault();
+        openDialog();
+      }
+    });
+
+    // Invoker commands (`commandfor`) are Baseline only since late 2025.
+    if (!("commandForElement" in HTMLButtonElement.prototype)) {
+      for (const button of dialog.ownerDocument.querySelectorAll<HTMLButtonElement>(
+        `button[commandfor="${dialog.id}"]`,
+      )) {
+        button.addEventListener("click", () => {
+          if (button.getAttribute("command") === "close") dialog.close();
+          else openDialog();
+        });
+      }
+    }
+
+    // `closedby="any"` light-dismiss is newer still; the dialog has no
+    // padding, so a click that lands on the dialog itself came from the
+    // backdrop.
+    if (!("closedBy" in HTMLDialogElement.prototype)) {
+      dialog.addEventListener("click", (event) => {
+        if (event.target === dialog) dialog.close();
+      });
+    }
+  };
+
+  const dialog = document.querySelector(`#${searchConfig.dialogId}`);
+  if (dialog instanceof HTMLDialogElement) setup(dialog);
+</script>

--- a/apps/me/src/features/search/config.ts
+++ b/apps/me/src/features/search/config.ts
@@ -1,0 +1,11 @@
+export const searchConfig = {
+  dialogId: "search-dialog",
+  // astro-pagefind writes the bundle to `dist/pagefind` and serves it from
+  // there in dev, so the path is fixed regardless of the page.
+  bundlePath: "/pagefind/",
+  maxResults: 10,
+  debounceMs: 120,
+  // Pagefind measures excerpts in segmented words; Japanese segments are short,
+  // so the default 30 runs to three lines at the dialog's width.
+  excerptLength: 24,
+} as const;

--- a/apps/me/src/features/search/config.ts
+++ b/apps/me/src/features/search/config.ts
@@ -1,11 +1,32 @@
+interface SearchConfig {
+  dialogId: string;
+  /** Leading and trailing slash required: `pagefind.js` is appended verbatim. */
+  bundlePath: `/${string}/`;
+  /** Pagefind filter key that carries the post category. */
+  filterKey: string;
+  /** Pagefind metadata keys the dialog reads off each result fragment. */
+  metaKeys: Record<"title" | "emoji" | "date" | "datetime", string>;
+  maxResults: number;
+  debounceMs: number;
+  excerptLength: number;
+}
+
 export const searchConfig = {
   dialogId: "search-dialog",
-  // astro-pagefind writes the bundle to `dist/pagefind` and serves it from
-  // there in dev, so the path is fixed regardless of the page.
+  // astro-pagefind writes the bundle to `<outDir>/pagefind` and serves
+  // `/pagefind/` from there in dev, so build and dev share this absolute path.
   bundlePath: "/pagefind/",
+  filterKey: "category",
+  metaKeys: {
+    title: "title",
+    emoji: "emoji",
+    date: "date",
+    datetime: "datetime",
+  },
   maxResults: 10,
   debounceMs: 120,
-  // Pagefind measures excerpts in segmented words; Japanese segments are short,
-  // so the default 30 runs to three lines at the dialog's width.
+  // Pagefind counts excerpt length in segmented words and centres the excerpt
+  // on the match; with short Japanese segments the default 30 spills past the
+  // two-line clamp and hides the <mark>.
   excerptLength: 24,
-} as const;
+} as const satisfies SearchConfig;

--- a/apps/me/src/features/search/types.ts
+++ b/apps/me/src/features/search/types.ts
@@ -1,0 +1,54 @@
+// Browser-side surface of `/pagefind/pagefind.js`. The `pagefind` npm package
+// only types the Node indexing API, so the runtime module is typed here.
+
+export interface PagefindSearchOptions {
+  filters?: Record<string, string | string[]> | undefined;
+  sort?: Record<string, "asc" | "desc"> | undefined;
+}
+
+export interface PagefindSubResult {
+  title: string;
+  url: string;
+  excerpt: string;
+}
+
+export interface PagefindFragment {
+  url: string;
+  raw_url: string;
+  content: string;
+  excerpt: string;
+  word_count: number;
+  meta: Record<string, string>;
+  filters: Record<string, string[]>;
+  sub_results: PagefindSubResult[];
+}
+
+export interface PagefindSearchResult {
+  id: string;
+  score: number;
+  words: number[];
+  data: () => Promise<PagefindFragment>;
+}
+
+export interface PagefindSearchResponse {
+  results: PagefindSearchResult[];
+  unfilteredResultCount: number;
+  filters: Record<string, Record<string, number>>;
+  totalFilters: Record<string, Record<string, number>>;
+  timings: { preload: number; search: number; total: number };
+}
+
+export interface PagefindModule {
+  options: (options: Record<string, unknown>) => Promise<void>;
+  init: () => Promise<void>;
+  search: (query: string, options?: PagefindSearchOptions) => Promise<PagefindSearchResponse>;
+  /** Resolves to `null` when a newer call superseded this one. */
+  debouncedSearch: (
+    query: string,
+    options?: PagefindSearchOptions,
+    debounceMs?: number,
+  ) => Promise<PagefindSearchResponse | null>;
+  preload: (query: string, options?: PagefindSearchOptions) => Promise<void>;
+  filters: () => Promise<Record<string, Record<string, number>>>;
+  destroy: () => Promise<void>;
+}

--- a/apps/me/src/features/search/types.ts
+++ b/apps/me/src/features/search/types.ts
@@ -1,26 +1,32 @@
-// Browser-side surface of `/pagefind/pagefind.js`. The `pagefind` npm package
-// only types the Node indexing API, so the runtime module is typed here.
+// Browser-side surface of `/pagefind/pagefind.js`, hand-written after
+// `pagefind_web_js/types/index.d.ts` at Pagefind 1.5.2: the `pagefind` npm
+// package only types the Node indexing API. Only the members this app uses are
+// declared, and `filters` / `sort` are narrowed to the shapes the dialog sends
+// (the compound `{ any: [...] }` / `{ not: ... }` syntax is left out).
+
+export interface PagefindIndexOptions {
+  basePath?: string | undefined;
+  baseUrl?: string | undefined;
+  excerptLength?: number | undefined;
+  highlightParam?: string | undefined;
+  exactDiacritics?: boolean | undefined;
+}
 
 export interface PagefindSearchOptions {
   filters?: Record<string, string | string[]> | undefined;
+  /** Pagefind honours a single key and warns on the rest. */
   sort?: Record<string, "asc" | "desc"> | undefined;
-}
-
-export interface PagefindSubResult {
-  title: string;
-  url: string;
-  excerpt: string;
 }
 
 export interface PagefindFragment {
   url: string;
   raw_url: string;
   content: string;
+  /** Matched words wrapped in `<mark>`; the page text around them has only `<` and `>` escaped. */
   excerpt: string;
   word_count: number;
   meta: Record<string, string>;
   filters: Record<string, string[]>;
-  sub_results: PagefindSubResult[];
 }
 
 export interface PagefindSearchResult {
@@ -39,16 +45,18 @@ export interface PagefindSearchResponse {
 }
 
 export interface PagefindModule {
-  options: (options: Record<string, unknown>) => Promise<void>;
+  /** Must run before `init`. */
+  options: (options: PagefindIndexOptions) => Promise<void>;
+  /**
+   * Resolves as soon as the runtime wrapper exists; the index itself loads in
+   * the background and a missing index surfaces as a rejection of the first
+   * search instead.
+   */
   init: () => Promise<void>;
-  search: (query: string, options?: PagefindSearchOptions) => Promise<PagefindSearchResponse>;
   /** Resolves to `null` when a newer call superseded this one. */
   debouncedSearch: (
     query: string,
     options?: PagefindSearchOptions,
     debounceMs?: number,
   ) => Promise<PagefindSearchResponse | null>;
-  preload: (query: string, options?: PagefindSearchOptions) => Promise<void>;
-  filters: () => Promise<Record<string, Record<string, number>>>;
-  destroy: () => Promise<void>;
 }

--- a/apps/me/src/features/search/utils/excerpt.ts
+++ b/apps/me/src/features/search/utils/excerpt.ts
@@ -1,0 +1,30 @@
+export interface ExcerptPart {
+  text: string;
+  marked: boolean;
+}
+
+const MARK_PATTERN = /<mark>([\s\S]*?)<\/mark>/gu;
+
+// Pagefind escapes only `<` and `>` in the page text before wrapping matches
+// in `<mark>`, so those are the only entities to undo; everything else in the
+// excerpt is literal text.
+const decodeText = (text: string): string => text.replaceAll("&lt;", "<").replaceAll("&gt;", ">");
+
+// The excerpt is rendered as text nodes plus real <mark> elements rather than
+// through innerHTML: the indexed text contains HTML in code samples and titles
+// fetched from external sites for link cards, and relying on Pagefind's
+// runtime escaping to keep that inert ties safety to an implementation detail.
+export const parseExcerpt = (excerpt: string): ExcerptPart[] => {
+  const parts: ExcerptPart[] = [];
+  const push = (text: string, marked: boolean) => {
+    if (text !== "") parts.push({ text: decodeText(text), marked });
+  };
+  let cursor = 0;
+  for (const match of excerpt.matchAll(MARK_PATTERN)) {
+    push(excerpt.slice(cursor, match.index), false);
+    push(match[1] ?? "", true);
+    cursor = match.index + match[0].length;
+  }
+  push(excerpt.slice(cursor), false);
+  return parts;
+};

--- a/apps/me/src/features/search/utils/keyboard.ts
+++ b/apps/me/src/features/search/utils/keyboard.ts
@@ -1,0 +1,21 @@
+type ShortcutKeyEvent = Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey">;
+
+interface EditableCandidate {
+  tagName: string;
+  isContentEditable: boolean;
+}
+
+// Alt is excluded so AltGr combinations on layouts that report ctrlKey for
+// AltGr keep producing characters.
+export const isToggleShortcut = (event: ShortcutKeyEvent): boolean =>
+  (event.metaKey || event.ctrlKey) && !event.altKey && event.key.toLowerCase() === "k";
+
+export const isEditableTarget = (target: EditableCandidate | null): boolean =>
+  target !== null &&
+  (target.isContentEditable || /^(?:input|textarea|select)$/iu.test(target.tagName));
+
+/** Next index when stepping through `length` items with wrap-around; `undefined` when nothing is focused. */
+export const cycleIndex = (current: number, offset: 1 | -1, length: number): number | undefined => {
+  if (current < 0 || length <= 0) return undefined;
+  return (current + offset + length) % length;
+};

--- a/apps/me/src/features/search/utils/meta.ts
+++ b/apps/me/src/features/search/utils/meta.ts
@@ -1,0 +1,21 @@
+import { searchConfig } from "#/features/search/config";
+
+const { metaKeys, filterKey } = searchConfig;
+
+// `data-pagefind-meta` / `data-pagefind-filter` attribute values for the blog
+// layout. Pagefind parses an inline `key:value` capture up to the end of the
+// attribute, so it must come last and each element can carry only one; the
+// date is captured off the `<time>` element instead. Meta captures may sit
+// outside `data-pagefind-body`.
+
+export const buildTitleMeta = (emoji: string): string =>
+  `${metaKeys.title}, ${metaKeys.emoji}:${emoji}`;
+
+export const buildDateMeta = (): string => `${metaKeys.date}, ${metaKeys.datetime}[datetime]`;
+
+// Blocks Pagefind's automatic `image` capture (src of the first <img> after the
+// h1): the dialog never shows it, and for posts that open with a mermaid
+// diagram it would inline the whole SVG data URI into the fragment.
+export const buildBodyMeta = (): string => "image:";
+
+export const buildCategoryFilter = (category: string): string => `${filterKey}:${category}`;

--- a/apps/me/src/features/search/utils/query.ts
+++ b/apps/me/src/features/search/utils/query.ts
@@ -1,10 +1,11 @@
 import { normalizePathname } from "@kkhys/seo/pathname";
+import { searchConfig } from "#/features/search/config";
 import type { PagefindSearchOptions } from "#/features/search/types";
 
 export const normalizeQuery = (raw: string): string => raw.replaceAll(/\s+/gu, " ").trim();
 
 export const buildSearchOptions = (category: string | undefined): PagefindSearchOptions =>
-  category ? { filters: { category } } : {};
+  category ? { filters: { [searchConfig.filterKey]: category } } : {};
 
 // Pagefind derives result URLs from output file paths, and the site builds with
 // `build.format: "file"`, so results arrive as `/blog/posts/<id>.html`.

--- a/apps/me/src/features/search/utils/query.ts
+++ b/apps/me/src/features/search/utils/query.ts
@@ -1,0 +1,11 @@
+import { normalizePathname } from "@kkhys/seo/pathname";
+import type { PagefindSearchOptions } from "#/features/search/types";
+
+export const normalizeQuery = (raw: string): string => raw.replaceAll(/\s+/gu, " ").trim();
+
+export const buildSearchOptions = (category: string | undefined): PagefindSearchOptions =>
+  category ? { filters: { category } } : {};
+
+// Pagefind derives result URLs from output file paths, and the site builds with
+// `build.format: "file"`, so results arrive as `/blog/posts/<id>.html`.
+export const toResultHref = (url: string): string => normalizePathname(url);

--- a/apps/me/src/features/search/utils/search-runner.ts
+++ b/apps/me/src/features/search/utils/search-runner.ts
@@ -1,0 +1,94 @@
+import { searchConfig } from "#/features/search/config";
+import type { PagefindFragment, PagefindModule } from "#/features/search/types";
+import { buildSearchOptions, normalizeQuery } from "#/features/search/utils/query";
+
+export type SearchStage = "load" | "search" | "fragments" | "render";
+
+export interface SearchRunnerDeps {
+  loadPagefind: () => Promise<PagefindModule>;
+  /** Replaces the rendered list; an empty array clears it. May throw on template drift. */
+  render: (fragments: PagefindFragment[]) => void;
+  setStatus: (text: string) => void;
+  /** Called for every failure, including partial fragment loads that still render. */
+  onError: (stage: SearchStage, error: unknown) => void;
+}
+
+export interface ResultStatusInput {
+  query: string;
+  total: number;
+  shown: number;
+  failed: number;
+}
+
+export const formatResultStatus = ({ query, total, shown, failed }: ResultStatusInput): string => {
+  if (total === 0) return `「${query}」に一致する記事はありません`;
+  const count = shown < total ? `${total} 件中 ${shown} 件を表示` : `${total} 件`;
+  return failed > 0 ? `${count}（${failed} 件を読み込めませんでした）` : count;
+};
+
+// A failed module fetch is cached in the module map for the page lifetime and
+// a missing index is only reported by the first search, so both stages share
+// the reload advice; later stages are per-result and worth retrying in place.
+export const formatErrorStatus = (stage: SearchStage): string =>
+  stage === "load" || stage === "search"
+    ? "検索を読み込めませんでした。ページを再読み込みしてください"
+    : "検索結果を取得できませんでした。もう一度お試しください";
+
+export const createSearchRunner = (deps: SearchRunnerDeps) => {
+  let requestId = 0;
+
+  return async (rawQuery: string, category: string | undefined): Promise<void> => {
+    const query = normalizeQuery(rawQuery);
+    const id = ++requestId;
+    if (query === "") {
+      deps.render([]);
+      deps.setStatus("");
+      return;
+    }
+
+    let stage: SearchStage = "load";
+    try {
+      const pagefind = await deps.loadPagefind();
+      stage = "search";
+      const response = await pagefind.debouncedSearch(
+        query,
+        buildSearchOptions(category),
+        searchConfig.debounceMs,
+      );
+      if (response === null || id !== requestId) return;
+
+      stage = "fragments";
+      const settled = await Promise.allSettled(
+        response.results.slice(0, searchConfig.maxResults).map((result) => result.data()),
+      );
+      if (id !== requestId) return;
+      const fragments = settled.flatMap((entry) =>
+        entry.status === "fulfilled" ? [entry.value] : [],
+      );
+      const failures = settled.flatMap((entry) =>
+        entry.status === "rejected" ? [entry.reason as unknown] : [],
+      );
+      if (failures.length > 0 && fragments.length === 0) {
+        throw new Error("Every result fragment failed to load", { cause: failures });
+      }
+      if (failures.length > 0) deps.onError("fragments", failures);
+
+      stage = "render";
+      deps.render(fragments);
+      deps.setStatus(
+        formatResultStatus({
+          query,
+          total: response.results.length,
+          shown: fragments.length,
+          failed: failures.length,
+        }),
+      );
+    } catch (error) {
+      // A newer request owns the UI now; reporting here would overwrite its result.
+      if (id !== requestId) return;
+      deps.onError(stage, error);
+      deps.render([]);
+      deps.setStatus(formatErrorStatus(stage));
+    }
+  };
+};

--- a/apps/me/src/layouts/base-layout.astro
+++ b/apps/me/src/layouts/base-layout.astro
@@ -5,6 +5,8 @@ import BlurLoadNoscript from "@kkhys/ui/blur-load-noscript.astro";
 import BaseSEO from "#/components/seo/base-seo.astro";
 import SiteFooter from "#/components/ui/site-footer.astro";
 import SiteNav from "#/components/ui/site-nav.astro";
+import SearchButton from "#/features/search/components/search-button.astro";
+import SearchDialog from "#/features/search/components/search-dialog.astro";
 
 interface Props {
   class?: string;
@@ -46,12 +48,14 @@ const { class: className, showFooter = true } = Astro.props;
 </head>
 <body>
 <SiteNav />
+<SearchButton />
 <main>
   <div class:list={["content", className]}>
     <slot/>
   </div>
 </main>
 {showFooter && <SiteFooter />}
+<SearchDialog />
 </body>
 </html>
 

--- a/apps/me/src/layouts/blog-layout.astro
+++ b/apps/me/src/layouts/blog-layout.astro
@@ -70,6 +70,15 @@ const tagCloudItems = allTagCloudItems.filter(({ title: tagTitle }) =>
 const relatedPosts = await getRelatedPosts({ id, category, tags });
 
 const seoImage = `${BASE_URL}/api/og/${id}.png`;
+
+// Pagefind metadata for the search dialog. An inline `key:value` capture runs
+// to the end of the attribute, so it must come last and each element carries
+// at most one; the date is read off the `<time>` element instead.
+const pagefindTitleMeta = `title, emoji:${emoji}`;
+const pagefindDateMeta = "date, datetime[datetime]";
+// Overrides Pagefind's automatic `image` capture, which would otherwise embed
+// the first inline mermaid data URI into the result fragment.
+const pagefindBodyMeta = "image:";
 ---
 
 <BaseLayout>
@@ -99,7 +108,7 @@ const seoImage = `${BASE_URL}/api/og/${id}.png`;
           <span class="draft-badge">Draft</span>
       )}
     </div>
-    <h1 class="post-title">{title}</h1>
+    <h1 class="post-title" data-pagefind-body data-pagefind-meta={pagefindTitleMeta}>{title}</h1>
     <div class="post-meta">
       {updatedInfo ? (
         <button
@@ -107,7 +116,9 @@ const seoImage = `${BASE_URL}/api/og/${id}.png`;
           popovertarget="post-updated-at"
           class="post-date post-date--trigger palt"
         >
-          <time datetime={publishedAt.toISOString()}>{publishedAtString}</time>
+          <time datetime={publishedAt.toISOString()} data-pagefind-meta={pagefindDateMeta}>
+            {publishedAtString}
+          </time>
         </button>
         <div id="post-updated-at" popover class="post-updated-at">
           <dl class="post-updated-at__list">
@@ -122,14 +133,23 @@ const seoImage = `${BASE_URL}/api/og/${id}.png`;
           </dl>
         </div>
       ) : (
-        <time datetime={publishedAt.toISOString()} class="post-date palt">
+        <time
+          datetime={publishedAt.toISOString()}
+          class="post-date palt"
+          data-pagefind-meta={pagefindDateMeta}
+        >
           {publishedAtString}
         </time>
       )}
     </div>
   </section>
   <section class="post-body">
-    <article class="prose">
+    <article
+      class="prose"
+      data-pagefind-body
+      data-pagefind-meta={pagefindBodyMeta}
+      data-pagefind-filter={`category:${category}`}
+    >
       <slot />
     </article>
     {tagCloudItems.length > 0 && (

--- a/apps/me/src/layouts/blog-layout.astro
+++ b/apps/me/src/layouts/blog-layout.astro
@@ -14,6 +14,12 @@ import Toc from "#/features/blog/components/ui/toc.astro";
 import { getCategoryByTitle } from "#/features/blog/config/category";
 import { tags as allTags } from "#/features/blog/config/tag";
 import { getRelatedPosts, type PostNavItem, toListEntries } from "#/features/blog/utils/entry";
+import {
+  buildBodyMeta,
+  buildCategoryFilter,
+  buildDateMeta,
+  buildTitleMeta,
+} from "#/features/search/utils/meta";
 import BaseLayout from "#/layouts/base-layout.astro";
 import { BASE_URL } from "#/utils/base-url";
 
@@ -71,14 +77,10 @@ const relatedPosts = await getRelatedPosts({ id, category, tags });
 
 const seoImage = `${BASE_URL}/api/og/${id}.png`;
 
-// Pagefind metadata for the search dialog. An inline `key:value` capture runs
-// to the end of the attribute, so it must come last and each element carries
-// at most one; the date is read off the `<time>` element instead.
-const pagefindTitleMeta = `title, emoji:${emoji}`;
-const pagefindDateMeta = "date, datetime[datetime]";
-// Overrides Pagefind's automatic `image` capture, which would otherwise embed
-// the first inline mermaid data URI into the result fragment.
-const pagefindBodyMeta = "image:";
+const pagefindTitleMeta = buildTitleMeta(emoji);
+const pagefindDateMeta = buildDateMeta();
+const pagefindBodyMeta = buildBodyMeta();
+const pagefindCategoryFilter = buildCategoryFilter(category);
 ---
 
 <BaseLayout>
@@ -148,7 +150,7 @@ const pagefindBodyMeta = "image:";
       class="prose"
       data-pagefind-body
       data-pagefind-meta={pagefindBodyMeta}
-      data-pagefind-filter={`category:${category}`}
+      data-pagefind-filter={pagefindCategoryFilter}
     >
       <slot />
     </article>

--- a/packages/seo/src/pathname.test.ts
+++ b/packages/seo/src/pathname.test.ts
@@ -15,6 +15,10 @@ describe("normalizePathname", () => {
     expect(normalizePathname("/privacy/ja.html")).toBe("/privacy/ja");
   });
 
+  it("only treats a whole `index` segment as the directory index", () => {
+    expect(normalizePathname("/reindex.html")).toBe("/reindex");
+  });
+
   it("strips a trailing slash", () => {
     expect(normalizePathname("/blog/2/")).toBe("/blog/2");
   });

--- a/packages/seo/src/pathname.ts
+++ b/packages/seo/src/pathname.ts
@@ -5,7 +5,7 @@
  * og:url tags contradicts the extensionless URLs the sitemap advertises.
  */
 export const normalizePathname = (pathname: string): string => {
-  const withoutHtml = pathname.replace(/(?:index)?\.html$/u, "");
+  const withoutHtml = pathname.replace(/\/index\.html$/u, "/").replace(/\.html$/u, "");
   const withoutTrailingSlash = withoutHtml.replace(/(?<=.)\/$/u, "");
   return withoutTrailingSlash === "" ? "/" : withoutTrailingSlash;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
       astro-expressive-code:
         specifier: 0.44.1
         version: 0.44.1(astro@7.2.9(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2))
+      astro-pagefind:
+        specifier: 2.0.1
+        version: 2.0.1(astro@7.2.9(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2))
       kiso.css:
         specifier: 'catalog:'
         version: 1.2.4
@@ -2194,6 +2197,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pagefind/component-ui@1.5.2':
+    resolution: {integrity: sha512-t8/aE0tan4JiKa6cyhhSt/5qrEVwAK/qlYBHFpnRoq+qaFFVrhmXFFMY+r6n4GJtVIFCN2A5nUpeLN68cYjEjw==}
+
+  '@pagefind/darwin-arm64@1.5.2':
+    resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pagefind/darwin-x64@1.5.2':
+    resolution: {integrity: sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pagefind/freebsd-x64@1.5.2':
+    resolution: {integrity: sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@pagefind/linux-arm64@1.5.2':
+    resolution: {integrity: sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pagefind/linux-x64@1.5.2':
+    resolution: {integrity: sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pagefind/windows-arm64@1.5.2':
+    resolution: {integrity: sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pagefind/windows-x64@1.5.2':
+    resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
+    cpu: [x64]
+    os: [win32]
+
   '@playform/compress@0.2.5':
     resolution: {integrity: sha512-yr3a47zMUAUXuJ2KjXr9/avDxNt+NIaofmeEtvpkblh1Z6ryozaQhJy9JtksOsCSdxLfhbLtN+tSwIC/1tDvMA==}
 
@@ -2204,6 +2245,9 @@ packages:
     resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
     engines: {node: '>=20'}
     hasBin: true
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
@@ -2664,6 +2708,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adequate-little-templates@1.0.2:
+    resolution: {integrity: sha512-d0tFFG538l3Y4CElRKtticzrMr/OGohs32/nf3Ewn8rbTMBYwkVNe8mPdXWrDnMlz+ZVUFQjsTmsBD5zCtU4wg==}
+    engines: {node: '>=14'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -2732,6 +2780,11 @@ packages:
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta || ^7.0.0
 
+  astro-pagefind@2.0.1:
+    resolution: {integrity: sha512-zhMTctuVuKrYH1C0Xl+p8mhexEuxVrqfT8paQOAbKZFtgUIWAMtR2nCeU11ti4Rfeit16LhiCxZFwjOqYoiaNQ==}
+    peerDependencies:
+      astro: ^2.0.4 || ^3 || ^4 || ^5 || ^6 || ^7
+
   astro@7.0.7:
     resolution: {integrity: sha512-swqrKDSI/B83GFroYPZYMFcxqbSe9+tkynu1WDBk3GLgBfV9++qVM4Z+2uFT6uu9A53Q0TROnxLketfMEENuqQ==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
@@ -2778,6 +2831,9 @@ packages:
 
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
+
+  bcp-47@2.1.1:
+    resolution: {integrity: sha512-KLw+H/gd2p4zly1X7Yh/qziuyae5/w/QFnvTng9eZL5fvszL7Whl3MBoWF8yxL7ksUjBfOD+OxkytiqbBpG+Fw==}
 
   bech32@2.0.0:
     resolution: {integrity: sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==}
@@ -4179,6 +4235,10 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  pagefind@1.5.2:
+    resolution: {integrity: sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==}
+    hasBin: true
+
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
 
@@ -4503,6 +4563,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -4635,6 +4699,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
@@ -6423,6 +6491,32 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.80.0':
     optional: true
 
+  '@pagefind/component-ui@1.5.2':
+    dependencies:
+      adequate-little-templates: 1.0.2
+      bcp-47: 2.1.1
+
+  '@pagefind/darwin-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/darwin-x64@1.5.2':
+    optional: true
+
+  '@pagefind/freebsd-x64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/linux-x64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-arm64@1.5.2':
+    optional: true
+
+  '@pagefind/windows-x64@1.5.2':
+    optional: true
+
   '@playform/compress@0.2.5(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)(@types/node@26.1.2)(yaml@2.8.2)':
     dependencies:
       '@playform/pipe': 0.1.6
@@ -6482,6 +6576,8 @@ snapshots:
   '@playwright/test@1.62.1':
     dependencies:
       playwright: 1.62.1
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
     dependencies:
@@ -6958,6 +7054,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adequate-little-templates@1.0.2: {}
+
   agent-base@7.1.4: {}
 
   ajv-draft-04@1.0.0(ajv@8.17.1):
@@ -7013,6 +7111,13 @@ snapshots:
       astro: 7.2.9(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
       rehype-expressive-code: 0.44.1
       url-extras: 0.1.0
+
+  astro-pagefind@2.0.1(astro@7.2.9(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)):
+    dependencies:
+      '@pagefind/component-ui': 1.5.2
+      astro: 7.2.9(@astrojs/markdown-remark@7.2.4(supports-color@10.2.2))(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2)
+      pagefind: 1.5.2
+      sirv: 3.0.2
 
   astro@7.0.7(@astrojs/markdown-remark@7.2.1)(@emnapi/core@2.0.0-alpha.4)(@emnapi/runtime@2.0.0-alpha.4)(@types/node@26.1.2)(terser@5.49.2)(yaml@2.8.2):
     dependencies:
@@ -7391,6 +7496,12 @@ snapshots:
   base64-js@1.5.1: {}
 
   bcp-47-match@2.0.3: {}
+
+  bcp-47@2.1.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
 
   bech32@2.0.0: {}
 
@@ -9203,6 +9314,16 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pagefind@1.5.2:
+    optionalDependencies:
+      '@pagefind/darwin-arm64': 1.5.2
+      '@pagefind/darwin-x64': 1.5.2
+      '@pagefind/freebsd-x64': 1.5.2
+      '@pagefind/linux-arm64': 1.5.2
+      '@pagefind/linux-x64': 1.5.2
+      '@pagefind/windows-arm64': 1.5.2
+      '@pagefind/windows-x64': 1.5.2
+
   pako@0.2.9: {}
 
   param-case@3.0.4:
@@ -9729,6 +9850,12 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   sitemap@9.0.1:
@@ -9862,6 +9989,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  totalist@3.0.1: {}
 
   tr46@0.0.3: {}
 


### PR DESCRIPTION
- Add astro-pagefind integration so the post index is built from dist after astro build
- Mark only the post title and body with data-pagefind-body, exposing category as a filter and emoji/date as metadata
- Add a native dialog search UI built on the pagefind.js API, opened from a fixed button, Cmd/Ctrl+K, or "/"
- Lock the page behind the modal against wheel/touch scrolling while the dialog is open
- Strip the .html suffix from result URLs left by the file-format build
- Document the search feature and local build requirement in apps/me/CLAUDE.md

https://claude.ai/code/session_01JeAX9cEwApjLeSibxtG4p7