### PR TITLE
[main] feat: link satellite sites from the blog

### DIFF
--- a/apps/me/src/__tests__/config/sites.test.ts
+++ b/apps/me/src/__tests__/config/sites.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { navItems } from "#/config/navigation";
+import { sites } from "#/config/sites";
+
+describe("sites", () => {
+  it("uses unique https kkhys.me subdomains", () => {
+    const hrefs = sites.map((site) => site.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+    expect(hrefs.map((href) => new URL(href).protocol)).toEqual(hrefs.map(() => "https:"));
+    expect(hrefs.every((href) => new URL(href).host.endsWith(".kkhys.me"))).toBe(true);
+    expect(hrefs.map((href) => new URL(href).pathname)).toEqual(hrefs.map(() => "/"));
+  });
+
+  it("has a unique label and a description for every site", () => {
+    const labels = sites.map((site) => site.label);
+    expect(new Set(labels).size).toBe(labels.length);
+    expect(sites.every((site) => site.description.length > 0)).toBe(true);
+  });
+
+  it("covers every kkhys.me subdomain linked from the navigation", () => {
+    const siteHosts = sites.map((site) => new URL(site.href).host);
+    const navHosts = navItems
+      .map((item) => new URL(item.href, "https://kkhys.me").host)
+      .filter((host) => host.endsWith(".kkhys.me"));
+    expect(navHosts.length).toBeGreaterThan(0);
+    expect(siteHosts).toEqual(expect.arrayContaining(navHosts));
+  });
+});

--- a/apps/me/src/config/navigation.ts
+++ b/apps/me/src/config/navigation.ts
@@ -30,6 +30,11 @@ export const navItems = [
     isExternal: true,
   },
   {
+    label: "Art",
+    href: me.art,
+    isExternal: true,
+  },
+  {
     label: "GitHub",
     href: me.github.url,
     isExternal: true,

--- a/apps/me/src/config/site.ts
+++ b/apps/me/src/config/site.ts
@@ -26,6 +26,9 @@ export const me = {
   twitter: "@kkhys_",
   memo: "https://memo.kkhys.me",
   diary: "https://diary.kkhys.me",
+  art: "https://art.kkhys.me",
+  lgtm: "https://lgtm.kkhys.me",
+  trends: "https://trends.kkhys.me",
   zenn: {
     url: "https://zenn.dev/kkhys",
     feed: "https://zenn.dev/kkhys/feed",

--- a/apps/me/src/config/sites.ts
+++ b/apps/me/src/config/sites.ts
@@ -1,0 +1,37 @@
+import { me } from "#/config/site";
+
+export type SatelliteSite = {
+  label: string;
+  href: string;
+  description: string;
+};
+
+// Display order for /about and llms.txt: personal/creative sites first,
+// tooling last.
+export const sites = [
+  {
+    label: "Memo",
+    href: me.memo,
+    description: "日々のつぶやきを残す短文のメモ",
+  },
+  {
+    label: "Diary",
+    href: me.diary,
+    description: "日付を添えた写真の記録",
+  },
+  {
+    label: "Art",
+    href: me.art,
+    description: "描いた絵とファッションデザインの作品集",
+  },
+  {
+    label: "Trends",
+    href: me.trends,
+    description: "国内外で話題になった技術記事を1日1回まとめるダイジェスト",
+  },
+  {
+    label: "LGTM",
+    href: me.lgtm,
+    description: "GitHubのPRレビューで使うLGTM画像",
+  },
+] as const satisfies SatelliteSite[];

--- a/apps/me/src/content/pages/about.mdx
+++ b/apps/me/src/content/pages/about.mdx
@@ -3,6 +3,8 @@ title: About
 description: Keisuke Hayashiについて
 ---
 
+import SiteList from "#/features/pages/components/site-list.astro";
+
 私は1995年生まれのソフトウェアエンジニアです。
 
 コードに限らず、手を動かしてものを作ることが好きです。無駄を削ぎ落として本質だけを残す、という考え方がすべてに通底しています。
@@ -10,6 +12,12 @@ description: Keisuke Hayashiについて
 このサイトでは[プログラミング](/blog/categories/tech)から[日々のこと](/blog/categories/life)、[手に馴染む道具](/blog/categories/object)の話などを書いています。SNSはやっていませんが、日々のつぶやきは自作の[メモサイト](https://memo.kkhys.me/)に残しています。
 
 MBTIは[INTJ-A](https://www.16personalities.com/ja/%E7%B5%90%E6%9E%9C/intj-a/x/tge9ig8t3)です。
+
+## Sites
+
+このブログのほかに、次のサイトを運用しています。
+
+<SiteList />
 
 ## Identities
 

--- a/apps/me/src/content/pages/about.mdx
+++ b/apps/me/src/content/pages/about.mdx
@@ -19,6 +19,17 @@ MBTIは[INTJ-A](https://www.16personalities.com/ja/%E7%B5%90%E6%9E%9C/intj-a/x/t
 
 <SiteList />
 
+## Open Source
+
+| Project                                                                     |                                                                             |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [gh-labeler](https://github.com/kkhys/gh-labeler)                           | GitHubのラベルをJSON/YAMLで宣言し、差分だけを同期するCLI                    |
+| [gh-labeler-actions](https://github.com/kkhys/gh-labeler-actions)           | gh-labelerをGitHub Actionsから実行するアクション                            |
+| [scrub-exif](https://github.com/kkhys/scrub-exif)                           | JPEG/PNGからExifやGPSなどのメタデータを無劣化で取り除く依存ゼロのライブラリ |
+| [mcp-off](https://github.com/kkhys/mcp-off)                                 | Claude CodeのMCPサーバーをプロジェクト単位で一括無効化するCLI               |
+| [lgtm-chrome-extension](https://github.com/kkhys/lgtm-chrome-extension)     | ワンクリックでLGTM画像をクリップボードにコピーするChrome拡張                |
+| [claude-code-marketplace](https://github.com/kkhys/claude-code-marketplace) | 自分の開発ワークフロー向けのClaude Codeプラグインマーケットプレイス         |
+
 ## Identities
 
 | Service | Link                               |                                                         |

--- a/apps/me/src/features/pages/components/site-list.astro
+++ b/apps/me/src/features/pages/components/site-list.astro
@@ -1,0 +1,25 @@
+---
+import LinkHandler from "#/features/blog/components/link-handler.astro";
+import { sites } from "#/config/sites";
+
+const hostOf = (href: string) => new URL(href).host;
+---
+
+<table>
+  <thead>
+    <tr>
+      <th>Site</th>
+      <th>Link</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {sites.map(({ label, href, description }) => (
+      <tr>
+        <td>{label}</td>
+        <td><LinkHandler href={href}>{hostOf(href)}</LinkHandler></td>
+        <td>{description}</td>
+      </tr>
+    ))}
+  </tbody>
+</table>

--- a/apps/me/src/lib/json-ld.ts
+++ b/apps/me/src/lib/json-ld.ts
@@ -12,7 +12,7 @@ const personSchema: WithContext<Person> = {
   name: me.name,
   url: BASE_URL,
   image: `${BASE_URL}/images/avatar.jpg`,
-  sameAs: [me.memo],
+  sameAs: [me.github.url, me.memo, me.diary, me.art],
   jobTitle: "Software engineer",
   worksFor: {
     "@type": "Organization",

--- a/apps/me/src/pages/humans.txt.ts
+++ b/apps/me/src/pages/humans.txt.ts
@@ -28,7 +28,9 @@ const getHumansTxt = () => `# TXT for Human Beings
   Location:  Tokyo, Japan
   GitHub:    ${me.github.url}
   Memo:      ${me.memo}
-  
+  Diary:     ${me.diary}
+  Art:       ${me.art}
+
 ## SITE
 
   Last update: ${lastUpdate}

--- a/apps/me/src/pages/index.astro
+++ b/apps/me/src/pages/index.astro
@@ -4,6 +4,7 @@ import MoveUpRightIcon from "#/components/icons/move-up-right.svg";
 import JsonLd from "#/components/seo/json-ld.astro";
 import SEO from "#/components/seo/seo.astro";
 import { defaultOgImage } from "#/config/constant";
+import { me } from "#/config/site";
 import BaseLayout from "#/layouts/base-layout.astro";
 import { websiteSchema } from "#/lib/json-ld";
 ---
@@ -18,7 +19,7 @@ import { websiteSchema } from "#/lib/json-ld";
     <Budoux>
       <div class="home-body prose">
         <p><a href="/about" class="home-link">コードを書いて暮らしています</a>。色々なものを作ることが好きです。プログラミングのことから手縫いの服づくりまで、日々のことや手に馴染む道具の話をブログに残しています。</p>
-        <p>コードを書いていないときは、珈琲を淹れたりボクシングジムで汗を流したりしています。日々考えたことは<a href="https://memo.kkhys.me" target="_blank" rel="noreferrer" class="home-link external-link">メモ<MoveUpRightIcon class="external-icon" /></a>に書き留めて、いつかやりたいことは<a href="/bucket-list" class="home-link">バケットリスト</a>にまとめています。</p>
+        <p>コードを書いていないときは、珈琲を淹れたりボクシングジムで汗を流したりしています。日々考えたことは<a href={me.memo} target="_blank" rel="noreferrer" class="home-link external-link">メモ<MoveUpRightIcon class="external-icon" /></a>に書き留めて、いつかやりたいことは<a href="/bucket-list" class="home-link">バケットリスト</a>にまとめています。</p>
         <p>私の好きな文章には次のようなものがあります。</p>
         <ul class="home-list">
           <li><a href="/blog/posts/b1e2lej" class="home-link">2026年8月時点の開発環境スナップショット</a></li>
@@ -27,7 +28,7 @@ import { websiteSchema } from "#/lib/json-ld";
           <li><a href="/blog/posts/b1x478m" class="home-link">夏の北海道2泊3日の旅行記</a></li>
           <li><a href="/blog/posts/b17ruev" class="home-link">7日間のマレーシア放浪記</a></li>
         </ul>
-        <p><a href="/blog" class="home-link">私の文章</a>を読んだり<a href="https://github.com/kkhys" target="_blank" rel="noreferrer" class="home-link external-link">GitHub<MoveUpRightIcon class="external-icon" /></a>でコードを見ることができます。何かあれば<a href="mailto:hi@kkhys.me" class="home-link">ご連絡ください</a>。</p>
+        <p><a href="/blog" class="home-link">私の文章</a>を読んだり<a href={me.github.url} target="_blank" rel="noreferrer" class="home-link external-link">GitHub<MoveUpRightIcon class="external-icon" /></a>でコードを見ることができます。何かあれば<a href="mailto:hi@kkhys.me" class="home-link">ご連絡ください</a>。</p>
       </div>
     </Budoux>
   </div>

--- a/apps/me/src/pages/llms.txt.ts
+++ b/apps/me/src/pages/llms.txt.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 import { me, siteConfig } from "#/config/site";
+import { sites } from "#/config/sites";
 import { getPublicBlogEntries } from "#/features/blog/utils/entry";
 import { BASE_URL } from "#/utils/base-url";
 
@@ -14,6 +15,11 @@ ${blogEntries.map((entry) => `- [${entry.data.title}](${BASE_URL}/blog/posts/${e
 ## Other
 
 - [About me](${BASE_URL}/about)
+- [Bucket list](${BASE_URL}/bucket-list)
+
+## Sites
+
+${sites.map(({ label, href, description }) => `- [${label}](${href}): ${description}`).join("\n")}
 
 ## Contact & Social
 


### PR DESCRIPTION
- Add a shared satellite site list (`config/sites.ts`) with Memo, Diary, Art, Trends, and LGTM entries
- Add a Sites section to the about page rendered by a new `SiteList` component
- Add Art to the site navigation
- Expose satellite sites in llms.txt, humans.txt, and the Person JSON-LD `sameAs`
- Add an Open Source section to the about page listing gh-labeler, gh-labeler-actions, scrub-exif, mcp-off, lgtm-chrome-extension, and claude-code-marketplace
- Read home page Memo and GitHub URLs from the site config instead of hardcoding them