### PR TITLE
[main] docs: comment out the diagram and packages notes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A pnpm monorepo for kkhys's personal sites, built with [Astro](https://astro.bui
   <img alt="System architecture of the kkhys monorepo: content submodules feed the Astro apps in the pnpm workspace, which deploy to Cloudflare Pages via GitHub Actions (memo) or a developer machine (the rest)" src="./docs/architecture/architecture-light.svg">
 </picture>
 
-The diagram is generated with [Archify](https://github.com/tt-a1i/archify) from [`docs/architecture/kkhys-monorepo.architecture.json`](./docs/architecture/kkhys-monorepo.architecture.json). To update it, edit the JSON, run `archify deliver architecture <json> <html> --quality showcase`, and re-export the light and dark SVGs from the viewer's Export menu.
+<!-- The diagram is generated with [Archify](https://github.com/tt-a1i/archify) from [`docs/architecture/kkhys-monorepo.architecture.json`](./docs/architecture/kkhys-monorepo.architecture.json). To update it, edit the JSON, run `archify deliver architecture <json> <html> --quality showcase`, and re-export the light and dark SVGs from the viewer's Export menu. -->
 
 ## Workspace
 
@@ -37,7 +37,7 @@ The diagram is generated with [Archify](https://github.com/tt-a1i/archify) from 
 | `@kkhys/analytics` | Self-hosted Umami tracker component                |
 | `@kkhys/release`   | Date-based release tagging                         |
 
-Shared packages are consumed as source (no build step); each app applies its own config via thin wrappers. Dependency versions are centralized in the `catalog:` of `pnpm-workspace.yaml`.
+<!-- Shared packages are consumed as source (no build step); each app applies its own config via thin wrappers. Dependency versions are centralized in the `catalog:` of `pnpm-workspace.yaml`. -->
 
 ## Tech Stack
 


### PR DESCRIPTION
- Comment out the Archify regeneration instructions under the architecture diagram
- Comment out the shared-packages consumption note below the packages table
- Keep both notes in the README source so they can be restored later