### PR TITLE
[main] docs: sync READMEs and CLAUDE.md files with the code

### DIFF
--- a/.claude/rules/design-system.md
+++ b/.claude/rules/design-system.md
@@ -1,0 +1,45 @@
+---
+paths:
+  - "apps/*/src/**/*.astro"
+  - "apps/*/src/**/*.css"
+  - "apps/*/src/**/*.tsx"
+  - "apps/*/src/**/*.html"
+  - "packages/ui/**"
+  - "packages/styles/**"
+---
+
+# Design system
+
+Every UI change follows the kkhys design system: `apps/design`
+(design.kkhys.me). The site renders the real sources at build time, so
+those sources are the reference — read them, not the rendered pages.
+
+| Question                                                       | Read                                                                    |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Color, type scale, spacing, radius, shadow, focus ring         | `packages/styles/tokens.css` (`--c-*`, `--fs-*`, `--space-*`, `--ring`) |
+| A component or class that may already exist                    | `packages/ui/CLAUDE.md`, `packages/styles/components.css` (`.btn`)      |
+| How the apps do motion, links, images, focus, dark mode, head  | `apps/design/src/data/conventions.ts` (rule / values / evidence)        |
+| Contrast, focus, landmarks, alt text, the new-screen checklist | `apps/design/src/data/accessibility.ts`                                 |
+| An icon                                                        | `packages/ui/src/icons/*.svg` (Lucide; `@kkhys/ui/icons/<name>.svg`)    |
+
+Principles (`apps/design/src/pages/index.astro`): hairline `--c-border`
+and whitespace instead of cards and shadows; uchu only through the
+semantic `--c-*` tokens; theming through `light-dark()` in the token, never
+a media-query branch; body column `--content-width` (42rem); plain CSS in
+cascade layers; small, dense type (`--fs-sm` body, `--fs-xs` notes).
+
+Before editing:
+
+1. Read the rows above that the change touches. A value in the diff is
+   either a token from `tokens.css`, an app-local token declared in that
+   app's `tokens` layer, or a documented deviation in `conventions.ts`.
+2. Reach for `@kkhys/ui` and `components.css` before writing a new
+   component; a new shared one goes into `packages/ui` with a demo on
+   `apps/design/src/components/demo.astro`.
+3. A new cross-app pattern, or an app departing from one, lands in
+   `conventions.ts` (evidence as `path:line`, `deviation` when departing)
+   or `accessibility.ts`. Run `pnpm --filter @kkhys/design test:vrt:update`
+   after an intended visual change to the shared packages.
+
+Done when every new value and component in the diff traces to one of the
+files above, and the design site still builds (`pnpm build:design`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-pnpm monorepo for kkhys's personal sites: four Astro static sites on Cloudflare Pages plus shared packages. TypeScript strictest mode throughout. Dev tools are managed by a Nix Flake (`flake.nix`) — run `direnv allow` to autoload Node.js, pnpm, and Bun.
+pnpm monorepo for kkhys's personal sites: eight apps (seven Astro static sites deployed on Cloudflare Pages, plus studio, which is local-only) and shared packages. TypeScript strictest mode throughout. Dev tools are managed by a Nix Flake (`flake.nix`) — run `direnv allow` to autoload Node.js, pnpm, and Bun.
 
 ## Workspace
 
@@ -17,12 +17,12 @@ Apps:
 
 Packages:
 
-- `packages/styles` — `@kkhys/styles`, uchu.css OKLCH palette + shared semantic tokens (`tokens.css`), base styles (`base.css`), and Satori hex mirrors (`colors`).
+- `packages/styles` — `@kkhys/styles`, uchu.css OKLCH palette + shared semantic tokens (`tokens.css`), base styles (`base.css`), component classes (`components.css`: `.btn` and its modifiers), and Satori hex mirrors (`colors`).
 - `packages/seo` — `@kkhys/seo`, BaseSEO / OpenGraph / TwitterCard Astro primitives.
 - `packages/og` — `@kkhys/og`, Satori OG image + favicon generators.
-- `packages/ui` — `@kkhys/ui`, shared Astro components (spinner, BudouX wrapper) + the cached BudouX parser.
+- `packages/ui` — `@kkhys/ui`, shared Astro components: site header / footer chrome, head meta, skip link, blur-up images, link card, infinite scroll + paginated guard, TOC scrollspy, link-metadata fetcher, Lucide icons, and the BudouX wrapper + cached parser.
 - `packages/analytics` — `@kkhys/analytics`, self-hosted Umami tracker component.
-- `packages/search` — `@kkhys/search`, the Pagefind search dialog shell, setup script, runner, and helpers shared by me and memo.
+- `packages/search` — `@kkhys/search`, the Pagefind search dialog shell, setup script, runner, and helpers shared by me, memo, and design.
 - `packages/release` — `@kkhys/release`, date-based release tagging used by `scripts/release.ts`.
 
 Shared packages are consumed as source (no build step); each app supplies its own config via thin wrappers. Dependency versions are centralized in the `catalog:` of `pnpm-workspace.yaml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,3 +48,4 @@ Run from the repo root:
 - `exactOptionalPropertyTypes: true` — optional props need `| undefined`, not just `?:`
 - `.astro` files can't be imported from `.ts` (tsc doesn't resolve them)
 - Per-app specifics (content schemas, blog/memo conventions) live in each app's `CLAUDE.md` — read those first when working inside an app.
+- UI changes (`.astro` / `.css` / `.tsx` under `apps/*/src`, `packages/ui`, `packages/styles`) follow the design system in `apps/design` (design.kkhys.me). `.claude/rules/design-system.md` loads for those files and names the sources to read — consult it first when a task is UI work, even before opening a file.

--- a/README.md
+++ b/README.md
@@ -28,14 +28,15 @@ A pnpm monorepo for kkhys's personal sites, built with [Astro](https://astro.bui
 
 ### Packages
 
-| Package            | Description                                        |
-| ------------------ | -------------------------------------------------- |
-| `@kkhys/styles`    | uchu.css OKLCH color palette                       |
-| `@kkhys/seo`       | BaseSEO / OpenGraph / TwitterCard Astro primitives |
-| `@kkhys/og`        | Satori OG image + favicon generators               |
-| `@kkhys/ui`        | Shared Astro components + cached BudouX parser     |
-| `@kkhys/analytics` | Self-hosted Umami tracker component                |
-| `@kkhys/release`   | Date-based release tagging                         |
+| Package            | Description                                                                                                                                            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@kkhys/styles`    | uchu.css OKLCH palette + semantic tokens (`tokens.css`), base styles (`base.css`), component classes (`components.css`), Satori hex mirrors (`colors`) |
+| `@kkhys/seo`       | BaseSEO / OpenGraph / TwitterCard Astro primitives                                                                                                     |
+| `@kkhys/og`        | Satori OG image + favicon generators                                                                                                                   |
+| `@kkhys/ui`        | Shared Astro components + cached BudouX parser                                                                                                         |
+| `@kkhys/analytics` | Self-hosted Umami tracker component                                                                                                                    |
+| `@kkhys/search`    | Pagefind search dialog shell, runner, and helpers (used by me / memo / design)                                                                         |
+| `@kkhys/release`   | Date-based release tagging                                                                                                                             |
 
 <!-- Shared packages are consumed as source (no build step); each app applies its own config via thin wrappers. Dependency versions are centralized in the `catalog:` of `pnpm-workspace.yaml`. -->
 
@@ -79,13 +80,13 @@ Run from the repo root:
 | `pnpm --filter @kkhys/memo <script>`               | Target a single app                                                    |
 | `pnpm release`                                     | Tag a repo-wide release                                                |
 
-Per-app commands are documented in each app's README ([me](./apps/me/README.md), [memo](./apps/memo/README.md), [lgtm](./apps/lgtm/README.md), [diary](./apps/diary/README.md), [trends](./apps/trends/README.md), [art](./apps/art/README.md)).
+Per-app commands are documented in each app's README ([me](./apps/me/README.md), [memo](./apps/memo/README.md), [lgtm](./apps/lgtm/README.md), [diary](./apps/diary/README.md), [trends](./apps/trends/README.md), [art](./apps/art/README.md), [design](./apps/design/README.md), [studio](./apps/studio/README.md)).
 
 ## CI / Deploy
 
 - `.github/workflows/ci.yml` — runs on pull requests and the merge queue: lint, test, type check, and build across the workspace against fixtures.
 - `.github/workflows/deploy-memo.yml` — deploys memo to Cloudflare Pages on pushes to main that touch memo or shared packages.
-- me, lgtm, diary, trends, and design are built and deployed locally via `pnpm deploy:me` / `pnpm deploy:lgtm` / `pnpm deploy:diary` / `pnpm deploy:trends` / `pnpm deploy:design`. trends is normally published end-to-end by the `creating-trend-digest` Claude Code skill (data commit → deploy → push).
+- me, lgtm, diary, trends, design, and art are built and deployed locally via `pnpm deploy:me` / `pnpm deploy:lgtm` / `pnpm deploy:diary` / `pnpm deploy:trends` / `pnpm deploy:design` / `pnpm deploy:art`. trends is normally published end-to-end by the `creating-trend-digest` Claude Code skill (data commit → deploy → push).
 
 ## License
 

--- a/apps/art/CLAUDE.md
+++ b/apps/art/CLAUDE.md
@@ -22,6 +22,7 @@ src/
   components/pager.astro                # prev / back / next links on detail pages
   content.config.ts                     # `works` / `fashion` collections (file loader over YAML)
   config/content-path.ts                # USE_FIXTURE_DATA switch between art-content and __fixtures__
+  config/site.ts                        # SITE_NAME / SITE_DESCRIPTION (base-layout, site-header, detail page titles)
   utils/caption.ts                      # Caption schema/types, sortByOrder, pairCaptionsWithImages, ContentMismatchError
   utils/works.ts                        # buildWorks: captions + images → ordered works
   utils/fashion.ts                      # buildFashionSeries + flattenFashionSheets
@@ -47,7 +48,7 @@ Consumed as source (no build step).
 - `@kkhys/styles` — uchu.css palette + shared `tokens.css` / `base.css`, imported in `src/styles/global.css`. Tokens resolve to their light values (no dark scheme opt-in).
 - `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard in `base-layout.astro`. The OG image is the page's work (the first work on the index), a variable-height JPEG built by `lib/og-image.ts` and passed via the `imageType`/`imageWidth`/`imageHeight` props; `twitter:card` switches to "summary" when no work exists.
 - `@kkhys/analytics` — the Umami tracker in `base-layout.astro` (production only).
-- `@kkhys/ui` — `blurLoadHandlers` (inline load/error reveal) and `BlurLoadNoscript`.
+- `@kkhys/ui` — `BlurImage` in `gallery-thumb` / `work-figure` / `fashion-figure` (the `<Picture>`, blurred 20px placeholder, `transitionName`, and `framed` frame live in `packages/ui/src/blur-image.astro`; `blurLoadHandlers` is applied inside it, art does not import it directly), plus `BlurLoadNoscript` and `HeadMeta` in `base-layout.astro`.
 - `@kkhys/og` — favicon routes (`src/pages/api/favicon/[file].ts`, bound to the pink→red→indigo gradient). Static icons in `public/` are generated from those routes.
 
 ## Key Design Decisions

--- a/apps/art/README.md
+++ b/apps/art/README.md
@@ -36,22 +36,23 @@ New images are added through the submodule's `pnpm ingest` script, which resizes
 
 Run from this directory, or prefix with `pnpm --filter @kkhys/art`:
 
-| Command                       | Description                          |
-| ----------------------------- | ------------------------------------ |
-| `pnpm dev`                    | Start development server             |
-| `pnpm build`                  | Production build (static)            |
-| `pnpm preview`                | Preview production build locally     |
-| `pnpm check`                  | Astro check + `tsc --noEmit`         |
-| `pnpm test`                   | Run unit tests                       |
-| `pnpm lint` / `pnpm lint:fix` | Check / auto-fix with oxlint + oxfmt |
-| `pnpm deploy`                 | Build and deploy to Cloudflare Pages |
+| Command                       | Description                                |
+| ----------------------------- | ------------------------------------------ |
+| `pnpm dev`                    | Start development server                   |
+| `pnpm build`                  | Production build (static)                  |
+| `pnpm preview`                | Preview production build locally           |
+| `pnpm check`                  | Astro check + `tsc --noEmit`               |
+| `pnpm test` / `pnpm coverage` | Run unit tests / with coverage             |
+| `pnpm lint` / `pnpm lint:fix` | Check / auto-fix with oxlint + oxfmt       |
+| `pnpm all`                    | build + check + lint:fix + test + coverage |
+| `pnpm deploy`                 | Build and deploy to Cloudflare Pages       |
 
 ## Project Structure
 
 ```
 apps/art/
 ├── src/
-│   ├── components/   # art-picture (<Picture> + blur-up), gallery-thumb, work/fashion figures, header, pager
+│   ├── components/   # gallery-thumb, work-figure, fashion-figure (around @kkhys/ui/blur-image.astro), site-header, pager
 │   ├── config/       # content-path.ts (fixture switch), site.ts
 │   ├── layouts/      # base-layout.astro (HTML shell + SEO/OGP meta, view-transition opt-in)
 │   ├── lib/          # gallery.ts (collections + globbed images), og-image.ts, images/ (the two image trees)

--- a/apps/design/CLAUDE.md
+++ b/apps/design/CLAUDE.md
@@ -4,7 +4,10 @@ Design system documentation site (design.kkhys.me), the `@kkhys/design` app
 of the kkhys monorepo. Astro 7 static site on Cloudflare Pages. Documents
 the shared tokens (`@kkhys/styles`) and components (`@kkhys/ui`) by parsing
 the actual CSS sources at build time — token pages can never drift from the
-real values. TypeScript strictest mode. Path alias: `#/*` → `./src/*`.
+real values. Also consumes `@kkhys/seo` (BaseSEO in `base-layout.astro`) and
+`@kkhys/search` (the dialog shell in `components/search-dialog.astro`, the
+query helpers in `utils/search.ts`). TypeScript strictest mode. Path alias:
+`#/*` → `./src/*`.
 
 ## Project Map
 
@@ -20,7 +23,7 @@ src/
   pages/accessibility.astro   # Build-time WCAG contrast table + a11y rules / known gaps / checklist
   pages/preview/[kind].astro  # Standalone demo documents for the phone-width iframe (noindex)
   pages/preview/infinite-scroll/[page].astro  # Pages 2..N of the InfiniteScroll demo feed (fetch targets)
-  layouts/base-layout.astro   # Sidebar + main shell; runs enhanceProse over the rendered page; data-pagefind-body on <main>
+  layouts/base-layout.astro   # Sidebar + main shell: HeadMeta icons={false}, ThemeInit, BaseSEO, SkipLink label="本文へ移動", SiteFooter; runs enhanceProse over the rendered page; data-pagefind-body on <main>
   layouts/preview-layout.astro  # Shell of the /preview documents (no sidebar, noindex, not indexed)
   components/site-sidebar.astro  # Sticky page nav + current page's h2 sections + theme toggle
   components/site-footer.astro
@@ -37,9 +40,10 @@ src/
   utils/tokens.ts             # parseCustomProperties / splitLightDark / filterByPrefix (unit-tested)
   utils/color.ts              # OKLCH → sRGB, WCAG contrast + grading, token color resolver (unit-tested)
   utils/prose.ts              # enhanceProse: BudouX over prose blocks + h2[id] section index (unit-tested)
-  utils/demos.ts              # DEMO_KINDS / previewPath
+  utils/demos.ts              # DEMO_KINDS / DemoKind / isDemoKind / previewPath
   utils/feed-demo.ts          # FEED_DEMO paging constants + feedDemoPage (unit-tested)
   utils/search.ts             # searchConfig, pickSubResult, toSectionHref (unit-tested)
+  utils/source-refs.ts        # splitSourceRefs / SourceRefPart — `path:line` refs in prose (unit-tested)
   utils/pagefind-index.ts     # Index coverage check helpers (unit-tested)
   integrations/verify-pagefind-index.ts  # Fails the build unless the index covers every doc page
   utils/icons.ts              # parseSvgAttributes / iconNameFromPath / iconImportName (unit-tested)
@@ -48,6 +52,10 @@ src/
   data/icons.ts               # Per-glyph role + usedBy annotations for the Icons page (hand-curated)
   styles/global.css           # Imports @kkhys/styles (uchu + tokens + base) + site shell
   __tests__/                  # Vitest unit tests
+public/
+  favicon.svg                 # The only icon; linked by hand since HeadMeta runs with icons={false}
+  preview/og.svg              # imageSrc of the LinkCard demo (no network at build time)
+  robots.txt
 vrt/
   pages.spec.ts               # Playwright full-page screenshots of all eight pages
   serve.mjs                   # Foreground static server for dist/ (astro preview daemonizes)

--- a/apps/design/README.md
+++ b/apps/design/README.md
@@ -1,0 +1,93 @@
+# design
+
+Source code for [design.kkhys.me](https://design.kkhys.me) — the design system docs for kkhys.me and its sibling sites, built with Astro. Token pages are rendered by parsing the `@kkhys/styles` CSS at build time, and the component pages show live `@kkhys/ui` instances, so the docs cannot drift from the shared packages. The `@kkhys/design` app of the [kkhys monorepo](../../README.md).
+
+## Tech Stack
+
+- [Astro](https://astro.build/) — Static site generator
+- [astro-pagefind](https://github.com/shishkin/astro-pagefind) — Full-text search, with a build-time check that the index covers every doc page
+- [Vanilla CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) — [kiso.css](https://github.com/build-trust/kiso.css) reset + [uchu.css](https://github.com/kkhys/uchu.css) palette (`@kkhys/styles`)
+- [TypeScript](https://www.typescriptlang.org/) — Strictest mode type safety
+- [Playwright](https://playwright.dev/) — Visual regression tests (local only)
+- [oxlint](https://oxc.rs/docs/guide/usage/linter.html) + [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) — Linting and formatting
+- [Cloudflare Pages](https://pages.cloudflare.com/) — Hosting and deployment
+
+## Getting Started
+
+From the monorepo root:
+
+```bash
+direnv allow      # Loads Node.js, pnpm, Bun via Nix Flake
+pnpm install
+pnpm build:design # Search is served from dist/pagefind on the dev server
+pnpm dev:design   # or: pnpm --filter @kkhys/design dev
+```
+
+Open [http://localhost:4321](http://localhost:4321) to view the site. There is no content submodule; everything is documented from the shared packages in this repo.
+
+## Pages
+
+| URL               | Content                                                        |
+| ----------------- | -------------------------------------------------------------- |
+| `/`               | Principles, usage, page index                                  |
+| `/colors`         | Semantic color tokens + uchu palette                           |
+| `/typography`     | Font size / weight / line-height tokens with live samples      |
+| `/layout`         | Spacing, radius, content width, shadow                         |
+| `/icons`          | `@kkhys/ui/icons` inventory                                    |
+| `/components`     | Live `@kkhys/ui` demos with usage guidance                     |
+| `/conventions`    | Cross-app UI/UX conventions with source references             |
+| `/accessibility`  | Build-time WCAG contrast table, a11y rules, checklist          |
+| `/preview/<kind>` | Standalone demo documents for the phone-width iframe (noindex) |
+
+## Scripts
+
+Run from this directory, or prefix with `pnpm --filter @kkhys/design`:
+
+| Command                       | Description                                        |
+| ----------------------------- | -------------------------------------------------- |
+| `pnpm dev`                    | Start development server                           |
+| `pnpm build`                  | Production build (static) + search index           |
+| `pnpm preview`                | Preview production build locally                   |
+| `pnpm check`                  | Astro check + `tsc --noEmit`                       |
+| `pnpm test`                   | Run unit tests                                     |
+| `pnpm test:vrt`               | Playwright screenshots against committed baselines |
+| `pnpm test:vrt:update`        | Re-record the screenshot baselines                 |
+| `pnpm coverage`               | Unit tests with coverage                           |
+| `pnpm lint` / `pnpm lint:fix` | Check / auto-fix with oxlint + oxfmt               |
+| `pnpm all`                    | build → check → lint:fix → test → coverage         |
+| `pnpm deploy`                 | Build and deploy to Cloudflare Pages               |
+
+VRT runs locally only (the baselines use macOS system fonts) and needs the Playwright browser once: `pnpm exec playwright install chromium`.
+
+## Project Structure
+
+```
+apps/design/
+├── src/
+│   ├── components/   # sidebar, stage + demo bodies, search dialog, code block, swatches, rule lists
+│   ├── data/         # conventions, accessibility rules, icon annotations (hand-curated)
+│   ├── integrations/ # verify-pagefind-index (fails the build on index gaps)
+│   ├── layouts/      # base-layout.astro (sidebar shell), preview-layout.astro (iframe documents)
+│   ├── pages/        # the eight doc pages + preview/
+│   ├── styles/       # global.css (tokens + site shell)
+│   ├── utils/        # token / color / prose / search / icon helpers
+│   └── __tests__/    # Vitest unit tests
+├── vrt/              # Playwright spec, static server, committed screenshots
+└── public/           # favicon.svg, robots.txt, preview/og.svg
+```
+
+For detailed architecture, see [CLAUDE.md](./CLAUDE.md).
+
+## Deployment
+
+Built and deployed locally via wrangler:
+
+```bash
+pnpm deploy   # wrangler pages deploy dist --project-name=design
+```
+
+design is not deployed from CI. No analytics yet.
+
+## License
+
+Code is licensed under [MIT](../../LICENSE.md).

--- a/apps/diary/CLAUDE.md
+++ b/apps/diary/CLAUDE.md
@@ -8,12 +8,13 @@ Photo diary site (diary.kkhys.me), the `@kkhys/diary` app of the kkhys monorepo.
 src/
   pages/index.astro           # The gallery: globs diary-content photos, builds entries + OG image
   pages/api/favicon/          # Dev-only favicon endpoints via @kkhys/og (omitted from prod builds)
-  layouts/base-layout.astro   # HTML shell wired to the @kkhys/seo primitives
-  components/diary-image.astro # <Picture> with AVIF/WebP variants + blur-up placeholder
+  layouts/base-layout.astro   # HTML shell: HeadMeta, @kkhys/seo primitives, Umami, BlurLoadNoscript
+  components/diary-image.astro # Thin wrapper: entry frame + date/number meta around @kkhys/ui BlurImage
   utils/entries.ts            # buildEntries: glob paths → dated, numbered entries (newest first)
   styles/global.css           # Imports @kkhys/styles (uchu + tokens + base) + app-local base styles
   __tests__/                  # Vitest unit tests
-public/robots.txt
+astro.config.ts               # site, @astrojs/sitemap, image service switch (see below)
+public/                       # robots.txt + the favicon set and manifest.webmanifest that HeadMeta links
 diary-content/                # Git submodule (private) — photos at diary/<YYYY-MM-DD>/<n>.jpg, not checked out in CI
 ```
 
@@ -23,7 +24,9 @@ Consumed as source (no build step).
 
 - `@kkhys/styles` — uchu.css palette + shared `tokens.css` / `base.css`, imported in `src/styles/global.css`. Tokens resolve to their light values (no dark scheme opt-in).
 - `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard in `base-layout.astro`. diary's OG image is the newest photo (variable-height JPEG), passed via the `imageType`/`imageWidth`/`imageHeight` props; `twitter:card` switches to "summary" when no photo exists.
-- `@kkhys/og` — favicon routes (`src/pages/api/favicon/[file].ts`, bound to the grayscale gradient). The OG image stays app-local (a photo, not a Satori card).
+- `@kkhys/ui` — `BlurImage` in `components/diary-image.astro` (the `<Picture>` with AVIF/WebP variants and the 20px blurred placeholder live in `packages/ui/src/blur-image.astro`; diary only passes `widths` / `sizes` / `priority`), plus `BlurLoadNoscript` and `HeadMeta` (`colorScheme="light"`; links the favicon set, manifest, and the sitemap that `@astrojs/sitemap` emits) in `base-layout.astro`.
+- `@kkhys/analytics` — the Umami tracker in `base-layout.astro`.
+- `@kkhys/og` — favicon routes (`src/pages/api/favicon/[file].ts`, bound to the grayscale gradient). Static icons in `public/` are generated from those routes. The OG image stays app-local (a photo, not a Satori card).
 
 ## Key Design Decisions
 

--- a/apps/diary/README.md
+++ b/apps/diary/README.md
@@ -34,26 +34,30 @@ git submodule update --init apps/diary/diary-content
 
 Run from this directory, or prefix with `pnpm --filter @kkhys/diary`:
 
-| Command                       | Description                          |
-| ----------------------------- | ------------------------------------ |
-| `pnpm dev`                    | Start development server             |
-| `pnpm build`                  | Production build (static)            |
-| `pnpm preview`                | Preview production build locally     |
-| `pnpm check`                  | Astro check + `tsc --noEmit`         |
-| `pnpm lint` / `pnpm lint:fix` | Check / auto-fix with oxlint + oxfmt |
-| `pnpm deploy`                 | Build and deploy to Cloudflare Pages |
+| Command                       | Description                                |
+| ----------------------------- | ------------------------------------------ |
+| `pnpm dev`                    | Start development server                   |
+| `pnpm build`                  | Production build (static)                  |
+| `pnpm preview`                | Preview production build locally           |
+| `pnpm check`                  | Astro check + `tsc --noEmit`               |
+| `pnpm test` / `pnpm coverage` | Run unit tests / with coverage             |
+| `pnpm lint` / `pnpm lint:fix` | Check / auto-fix with oxlint + oxfmt       |
+| `pnpm all`                    | build + check + lint:fix + test + coverage |
+| `pnpm deploy`                 | Build and deploy to Cloudflare Pages       |
 
 ## Project Structure
 
 ```
 apps/diary/
 ├── src/
-│   ├── components/   # diary-image.astro (<Picture> + blur-up placeholder)
+│   ├── components/   # diary-image.astro (entry frame around the shared <Picture> in @kkhys/ui/blur-image.astro)
 │   ├── layouts/      # base-layout.astro (HTML shell + SEO/OGP meta)
 │   ├── pages/        # index.astro (the gallery)
-│   └── styles/       # global.css (tokens + base styles)
+│   ├── styles/       # global.css (tokens + base styles)
+│   ├── utils/        # entries.ts (photo paths → dated entries)
+│   └── __tests__/    # Vitest unit tests
 ├── diary-content/    # Photos (Git submodule, private)
-└── public/           # Static assets (robots.txt)
+└── public/           # Static assets (icons, manifest, robots.txt)
 ```
 
 For detailed architecture, see [CLAUDE.md](./CLAUDE.md).

--- a/apps/lgtm/CLAUDE.md
+++ b/apps/lgtm/CLAUDE.md
@@ -8,16 +8,26 @@ LGTM image generator (lgtm.kkhys.me), the `@kkhys/lgtm` app of the kkhys monorep
 src/
   components/lgtm-image.tsx       # Core image pipeline (Satori + Sharp). Exports formatForEntry + LgtmImage
   content.config.ts               # Collections: lgtm, privacy, copyright. lgtm schema = { image, animated, description }
+  content/{privacy,copyright}/    # Legal pages as markdown, {en,ja}.md each (title, description, lang, lastUpdated)
   loaders/lgtm-dir-loader.ts      # Custom loader: one entry per ULID dir, image = first media file + description.txt. Probes animation via sharp
-  config/constants.ts             # TITLE, TWITTER_ACCOUNT_NAME, IMAGES_PER_PAGE
-  layouts/layout.astro            # Base layout (Header, Main, Footer)
+  config/constants.ts             # TITLE, TWITTER_ACCOUNT_NAME, IMAGES_PER_PAGE, SITE_URL (canonical origin for embed snippets)
+  config/content-path.ts          # resolveLgtmBasePath: lgtm-content vs __fixtures__ (USE_FIXTURE_DATA)
+  layouts/layout.astro            # Base layout (HeadMeta, Umami, SkipLink, SiteHeader, main, SiteFooter)
   assets/BBHBartle-Regular.ttf    # Font for the LGTM text overlay
   components/seo/                 # SEO adapters + OG card (see Shared Packages)
+  components/legal-layout.astro   # en/ja toggle + prose styles for the legal pages
+  components/legal-page.astro     # Renders a privacy/copyright entry with SEO, hreflang alternates, last-updated
+  utils/alt.ts                    # lgtmAlt: "LGTM over <description>"
+  utils/date.ts                   # formatDate (UTC getters; legal-page lastUpdated)
+  utils/embed.ts                  # buildEmbedCode: the <a><img></a> snippet the copy buttons put on the clipboard
+  utils/shuffle.ts                # Fisher-Yates for the gallery order
   pages/
-    [...page].astro               # Gallery with pagination + infinite scroll
-    [id].astro                    # Detail page with format selector
+    [...page].astro               # Gallery with pagination + infinite scroll; copy button per item
+    [id].astro                    # Detail page: the entry's image + "Copy embed code" button (format is fixed per entry, no selector)
     [id].[format].ts              # Image API (800px default)
     [id]-[size].[format].ts       # Sized image API (400/1000/1200px)
+    privacy/[...lang].astro       # /privacy (en) and /privacy/ja
+    copyright/[...lang].astro     # /copyright (en) and /copyright/ja
     api/ids.json.ts               # JSON listing of all image IDs
     api/og/                       # OG images: default.png (shared handler) + [id].png (per-image, app-local)
     api/favicon/                  # Dev-only favicon endpoints (omitted from prod builds)
@@ -33,9 +43,9 @@ Consumed as source (no build step); this app supplies its own config via thin wr
 
 - `@kkhys/styles` — uchu.css palette + shared `tokens.css` / `base.css`, imported in `src/styles/global.css`. Dark mode via `light-dark()`. Only lgtm-specific tokens (`--c-bg-gray`, `--c-text-emphasis`) stay app-local.
 - `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard primitives, wrapped by thin adapters in `src/components/seo/`; `JsonLd` comes from `@kkhys/seo/json-ld.astro`.
-- `@kkhys/ui` — `HeadMeta` (charset / viewport / color-scheme / favicon set / sitemap), `SiteHeader` / `SiteFooter`, `InfiniteScroll` + `PaginatedGuard` for the gallery pages, `BlurLoadNoscript`, and the Lucide icons under `@kkhys/ui/icons/*.svg`.
+- `@kkhys/ui` — in `layouts/layout.astro`: `HeadMeta` (charset / viewport / color-scheme / favicon set / sitemap), `SkipLink`, `SiteHeader` / `SiteFooter`, `BlurLoadNoscript`. In `pages/[...page].astro`: `InfiniteScroll` (which brings its own spinner) + `PaginatedGuard`, and `blurLoadHandlers` from `@kkhys/ui/blur-load` on the gallery images (the detail page inlines its own `onload`). Icons (`arrow-left`, `check`, `copy`) come from `@kkhys/ui/icons/*.svg`.
 - `@kkhys/og` — favicon routes (`src/pages/api/favicon/[file].ts`, bound to the green gradient) + OG route handlers. The default OG card (`opengraph-image.tsx`) and the per-id OG (`pages/api/og/[id].png.ts`) stay app-local (bespoke layouts).
-- `@kkhys/ui` — shared Astro components; lgtm uses `spinner.astro` in the gallery's infinite scroll.
+- `@kkhys/analytics` — the Umami tracker in `layouts/layout.astro`.
 
 ## Key Design Decisions
 
@@ -61,6 +71,6 @@ Consumed as source (no build step); this app supplies its own config via thin wr
 - `lgtm-content/` is a private Git submodule — initialize it before local builds or deploy
 - `BBHBartle-Regular.ttf` must exist in `src/assets/`
 - ULIDs must be lowercase
-- A new entry needs both the media file and `description.txt` — the dev server logs the missing file and keeps the previous entries, the build stops
+- A new entry needs both the media file and `description.txt` — the dev server logs the missing file and keeps the previous entries, the build stops. `description.txt` has been required since ff4f61721, but the content repo's `scripts/create-lgtm.ts` (`pnpm lgtm` in `lgtm-content/`) still only creates the ULID directory — write the file by hand for every new entry
 - Non-first gallery pages (`/2`, `/3`, …) redirect to `/` when accessed directly — they exist only for the infinite-scroll fetch
 - Favicon endpoints (`api/favicon/*`) are dev-only (their `getStaticPaths` emits no paths in prod builds); production serves favicons as static assets

--- a/apps/lgtm/README.md
+++ b/apps/lgtm/README.md
@@ -2,285 +2,142 @@
 
 <a href="https://lgtm.kkhys.me/01kdg0h1dnmjgpqw8rxwmbakeh"><img src="https://lgtm.kkhys.me/01kdg0h1dnmjgpqw8rxwmbakeh.avif" alt="LGTM!!" width="400" /></a>
 
-A curated collection of LGTM images for GitHub Pull Requests. High-performance image delivery with multiple formats, progressive loading, and infinite scroll pagination.
-
-**Live**: [lgtm.kkhys.me](https://lgtm.kkhys.me)
-
-## Overview
-
-LGTM generates and serves optimized review approval images with dynamic text overlay rendering. Built on Astro with server-side image processing, delivering AVIF/WebP/PNG formats with aggressive caching strategies.
-
-## Browser Extension
-
-**[LGTM Chrome Extension](https://github.com/kkhys/lgtm-chrome-extension)** – One-click LGTM image insertion for GitHub code reviews.
-
-Simply click the extension icon while browsing GitHub, and a random LGTM image is automatically copied to your clipboard as ready-to-paste HTML. The extension activates exclusively on GitHub domains with visual feedback (checkmark badge) and requires minimal permissions for privacy.
-
-**Key Features:**
-
-- One-click operation with GitHub-only activation
-- Random image selection from the full gallery
-- Instant clipboard copy with AVIF format
-- Privacy-focused with minimal required permissions
-- Lightweight design (< 50KB total)
-
-**Get it:** [Chrome Web Store](https://chromewebstore.google.com/detail/lgtm-chrome-extension/pekflahhcpfnbllbphcjnjngkhlabohh) | [GitHub Repository](https://github.com/kkhys/lgtm-chrome-extension)
+Source code for [lgtm.kkhys.me](https://lgtm.kkhys.me) — a curated collection of LGTM images for GitHub Pull Requests, built with Astro. The `@kkhys/lgtm` app of the [kkhys monorepo](../../README.md).
 
 ## Features
 
-- **Dynamic Image Generation** – Server-rendered text overlays using Satori + Sharp
-- **Multi-Format Delivery** – AVIF, WebP, PNG with automatic format negotiation
-- **Progressive Loading** – Low-res WebP placeholder blur with smooth transitions
-- **Infinite Scroll** – Paginated gallery with IntersectionObserver-based loading
-- **Responsive Images** – Multiple size variants (400/1000/1200px) with 2x density support
-- **One-Click Markdown** – Copy-to-clipboard with format selection (AVIF/WebP/PNG)
-- **SEO Optimized** – Complete Open Graph, Twitter Card, JSON-LD, PWA manifest
-- **Edge Cached** – Immutable responses with max-age 1 year
+- "LGTM" text rendered by Satori and composited onto each source image by sharp at build time
+- Still sources ship as AVIF, animated sources as animated WebP — one format per image
+- Three sizes per image (400 / 1000 / 1200px) plus an 800px default endpoint
+- Paginated gallery (20 per page, shuffled at build) with infinite scroll over pre-built pages
+- Blur-up placeholders, one-click "Copy embed code" (HTML `<a><img></a>` snippet)
+- Per-image Open Graph cards, JSON-LD, sitemap, PWA manifest
+- Privacy policy and copyright pages in English and Japanese
+- Light/dark mode via `light-dark()`
+
+## Browser Extension
+
+[LGTM Chrome Extension](https://github.com/kkhys/lgtm-chrome-extension) copies a random image from this gallery to the clipboard while browsing GitHub. Get it from the [Chrome Web Store](https://chromewebstore.google.com/detail/lgtm-chrome-extension/pekflahhcpfnbllbphcjnjngkhlabohh).
 
 ## Tech Stack
 
-**Core**
+- [Astro](https://astro.build/) — Static site generator (Content Collections + pagination)
+- [Satori](https://github.com/vercel/satori) + [sharp](https://sharp.pixelplumbing.com/) — Text overlay rendering and image compositing
+- [React](https://react.dev/) — Server-side only, as Satori's JSX runtime
+- [Vanilla CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) — [kiso.css](https://github.com/build-trust/kiso.css) reset + [uchu.css](https://github.com/kkhys/uchu.css) palette (`@kkhys/styles`)
+- [TypeScript](https://www.typescriptlang.org/) — Strictest mode type safety
+- [Vitest](https://vitest.dev/) — Unit testing
+- [oxlint](https://oxc.rs/docs/guide/usage/linter.html) + [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) — Linting and formatting
+- [Cloudflare Pages](https://pages.cloudflare.com/) — Hosting and deployment
 
-- Astro 5.16 – Static site generation with Content Collections and pagination
-- TypeScript 5.9 – Strictest compiler mode
-- React 19 – Image generation components (JSX for Satori)
+Dependency versions are pinned in the `catalog:` of [`pnpm-workspace.yaml`](../../pnpm-workspace.yaml); Node.js, pnpm, Bun, and ffmpeg come from the Nix Flake at the repo root.
 
-**Image Processing**
+## Getting Started
 
-- Satori 0.18 – SVG/text rendering with custom fonts (BBHBartle-Regular)
-- Sharp 0.34 – High-performance image manipulation (libvips)
+From the monorepo root:
 
-**Styling**
-
-- kiso.css 1.2 – Minimal CSS framework
-- Custom design system with light/dark mode
-
-**Infrastructure**
-
-- Cloudflare Pages – Static hosting
-- pnpm 10.26 – Workspace monorepo
-- oxlint + oxfmt – Linting + formatting
-
-**Testing**
-
-- Vitest 4.0 – Unit testing framework
-- Coverage: 100% statements, 88% branch, 100% functions
-
-## Architecture
-
-### Image Generation Pipeline
-
-```
-1. Load source image from lgtm-content submodule
-2. Resize to target width (Sharp)
-3. Render "LGTM" text as SVG (Satori, 2x resolution)
-4. Composite text overlay with 85% opacity (blend mode: over)
-5. Convert to AVIF/WebP/PNG
-6. Serve with immutable cache headers
+```bash
+git clone --recurse-submodules https://github.com/kkhys/me.git
+cd me
+direnv allow   # Loads Node.js, pnpm, Bun, ffmpeg via Nix Flake
+pnpm install
+pnpm dev:lgtm  # or: pnpm --filter @kkhys/lgtm dev
 ```
 
-**Implementation**: `src/components/lgtm-image.tsx`
+Open [http://localhost:4321](http://localhost:4321) to view the site.
 
-### URL Structure
+### Content
 
-```
-/                        → Gallery (paginated, 20 images per page)
-/{page}                  → Gallery page N (infinite scroll target)
-/{id}                    → Detail page with format selector
-/{id}.{format}           → 800px image (default endpoint)
-/{id}-{size}.{format}    → Custom size (400|1000|1200)
-/api/og/default.png      → Default Open Graph image
-/api/og/{id}.png         → Per-image Open Graph image
-/api/favicon/*           → Dynamic favicon generation
+Images live in the private `lgtm-content` Git submodule. Without it, set `USE_FIXTURE_DATA=true` to build against the sample entries in `src/__fixtures__/lgtm-sample` (CI does this automatically). A production build needs the submodule:
+
+```bash
+git submodule update --init apps/lgtm/lgtm-content
 ```
 
-### Content Collections
-
-Astro Content Collections with environment-based loader:
-
-```typescript
-// src/content.config.ts
-const lgtmBasePath = GITHUB_ACTIONS ? "./src/__fixtures__/lgtm-sample" : "./lgtm-content/lgtm";
-
-const lgtm = defineCollection({
-  loader: glob({ pattern: "**/index.md", base: lgtmBasePath }),
-  schema: z.object({
-    color: z.enum(["white", "black"]), // Text color
-    image: z.string(), // Source image filename
-    isDraft: z.boolean().default(false), // Publishing control
-  }),
-});
-```
-
-### Private Content Submodule
-
-Images stored in private Git submodule with ULID-based identifiers:
+Each entry is a directory named by a lowercase ULID:
 
 ```
 lgtm-content/lgtm/{ulid}/
-  ├── index.md           # Frontmatter: color, image, isDraft
-  └── {filename}.jpg     # Source image
+  ├── 01.jpg             # Source image (jpg / png / webp / gif / avif; the first media file by name is used)
+  └── description.txt    # One line describing the picture — required, the build fails without it
 ```
 
-### Pagination & Infinite Scroll
+The loader probes each file with sharp: a multi-frame source is served as animated WebP, everything else as AVIF. The description becomes the image alt (`LGTM over <description>`).
 
-- Gallery shows 20 images per page (IMAGES_PER_PAGE constant)
-- Fisher-Yates shuffle on build for randomized display order
-- IntersectionObserver triggers next page load 200px before scroll end
-- Minimum 500ms loading indicator for better UX
-- Non-first pages redirect to home if accessed directly
+Inside `lgtm-content/`, `pnpm lgtm` creates a new ULID directory (drop the image and write `description.txt` by hand), `pnpm strip-exif` scrubs EXIF from all images, and a lefthook pre-commit hook scrubs staged images automatically. `.mov` sources are converted to animated WebP with `pnpm convert-videos` from this directory (Bun + ffmpeg).
 
-## Development
+## Routes
 
-### Prerequisites
-
-- Node.js 24.12 (via Volta)
-- pnpm 10.26
-- Bun (for utility scripts in lgtm-content/)
-
-### Setup
-
-```bash
-# Clone with submodules
-git clone --recursive https://github.com/kkhys/lgtm.git
-
-# Install dependencies
-pnpm install
+```
+/                         → Gallery (paginated)
+/{page}                   → Gallery page N — infinite-scroll fetch target; direct visits redirect to /
+/{id}                     → Detail page with the image and a "Copy embed code" button
+/{id}.{avif|webp}         → 800px image (the embed URL)
+/{id}-{size}.{avif|webp}  → 400 / 1000 / 1200px image
+/privacy, /privacy/ja     → Privacy policy (en / ja)
+/copyright, /copyright/ja → Copyright (en / ja)
+/api/ids.json             → All image IDs with their format
+/api/og/default.png       → Default Open Graph image
+/api/og/{id}.png          → Per-image Open Graph image
+/api/favicon/*            → Favicon generation (dev only; production serves static files from public/)
 ```
 
-### Commands
+The format of an image is fixed by its source: `.avif` for still images, `.webp` for animated ones. There is no format negotiation.
 
-```bash
-pnpm dev          # Start dev server (localhost:4321)
-pnpm build        # Production build to ./dist
-pnpm preview      # Preview production build
-pnpm check        # Type checking (Astro + tsc)
-pnpm lint         # oxlint + oxfmt check
-pnpm lint:fix     # Auto-fix issues
-pnpm test         # Run unit tests (Vitest)
-pnpm coverage     # Test coverage report
-pnpm all          # Full validation (build + check + lint:fix + test + coverage)
-```
+## Scripts
 
-### Utility Scripts
+Run from this directory, or prefix with `pnpm --filter @kkhys/lgtm`:
 
-```bash
-# Generate lowercase ULID for new images
-cd lgtm-content
-pnpm id
+| Command                       | Description                                               |
+| ----------------------------- | --------------------------------------------------------- |
+| `pnpm dev`                    | Start development server                                  |
+| `pnpm build`                  | Production build (static)                                 |
+| `pnpm preview`                | Preview production build locally                          |
+| `pnpm check`                  | Astro check + `tsc --noEmit`                              |
+| `pnpm test` / `pnpm coverage` | Run unit tests / with coverage                            |
+| `pnpm lint` / `pnpm lint:fix` | Check / auto-fix with oxlint + oxfmt                      |
+| `pnpm all`                    | build + check + lint:fix + test + coverage                |
+| `pnpm convert-videos`         | Convert `.mov` sources in `lgtm-content` to animated WebP |
+| `pnpm deploy`                 | Build and deploy to Cloudflare Pages                      |
 
-# Create timestamped memo
-pnpm memo
-
-# Create release tag (date-based versioning)
-pnpm release [--dry-run]
-```
-
-## Performance
-
-### Optimization Strategies
-
-1. **Progressive Enhancement**
-   - 20x13px WebP placeholder with CSS blur filter (36px)
-   - Full image fades in on load (300ms transition)
-   - `loading="eager"` on detail page, lazy on gallery
-
-2. **Format Priorities** (via `<Picture>` component)
-   - AVIF: Best compression (~50% smaller than WebP)
-   - WebP: Broad browser support
-   - PNG: Lossless fallback
-
-3. **Build-Time Processing**
-   - Static generation of all image variants at build time
-   - Pre-rendered text overlays with Satori
-   - HTML/CSS/JS compression via @playform/compress
-
-4. **Runtime Caching**
-   - `Cache-Control: public, max-age=31536000, immutable`
-   - Cloudflare CDN
-
-5. **Infinite Scroll**
-   - Fetch next page in background
-   - Pre-connect and load images on demand
-   - Smooth transition with loading states
-
-## Deployment
-
-### Cloudflare Pages
-
-Deployed locally via wrangler:
-
-```bash
-pnpm deploy   # Build and deploy to Cloudflare Pages
-```
-
-This runs `pnpm build` followed by `wrangler pages deploy dist`. The lgtm-content submodule must be available locally.
-
-### Environment Variables
-
-```bash
-NODE_ENV              # development | production (auto-set)
-GITHUB_ACTIONS        # CI detection (auto-set, switches to fixtures)
-```
-
-### CI/CD
-
-GitHub Actions uses fixture data (`src/__fixtures__/lgtm-sample/`) to avoid private submodule dependency in public CI.
+Releases are tagged for the whole repo with `pnpm release` from the monorepo root.
 
 ## Project Structure
 
 ```
-lgtm/
+apps/lgtm/
 ├── src/
-│   ├── assets/               # Static assets (fonts, images)
-│   ├── components/
-│   │   ├── icon/            # SVG icon components
-│   │   ├── seo/             # SEO meta components
-│   │   ├── lgtm-image.tsx   # Image generation logic
-│   │   └── *.astro          # UI components
-│   ├── config/              # Constants and configuration
-│   ├── layouts/             # Page layouts
-│   ├── pages/
-│   │   ├── [...page].astro  # Paginated gallery
-│   │   ├── [id].astro       # Detail page
-│   │   ├── [id].[format].ts # Default image API
-│   │   ├── [id]-[size].[format].ts # Sized image API
-│   │   └── api/             # OG images and favicons
-│   ├── styles/              # Global CSS
-│   ├── content.config.ts    # Content Collections config
-│   ├── __fixtures__/        # Test fixtures for CI
-│   └── __tests__/           # Unit tests (Vitest)
-│       ├── components/      # Component tests
-│       ├── pages/           # API route tests
-│       └── config/          # Configuration tests
-├── lgtm-content/         # Git submodule (private)
-├── scripts/                 # Build and release scripts
-├── vitest.config.ts         # Vitest configuration
-└── public/                  # Static public assets
+│   ├── assets/           # BBHBartle-Regular.ttf (the overlay font)
+│   ├── components/       # lgtm-image.tsx (Satori + sharp pipeline), seo/ adapters + OG card, legal-layout / legal-page
+│   ├── config/           # constants.ts, content-path.ts (fixture switch)
+│   ├── content/          # privacy/ and copyright/ pages ({en,ja}.md)
+│   ├── layouts/          # layout.astro (HTML shell: head meta, header, footer, Umami)
+│   ├── loaders/          # lgtm-dir-loader.ts (one entry per ULID directory)
+│   ├── pages/            # Gallery, detail, image endpoints, legal pages, api/
+│   ├── styles/           # global.css (@kkhys/styles + app-local tokens)
+│   ├── utils/            # alt, date, embed, shuffle
+│   ├── content.config.ts # lgtm / privacy / copyright collections
+│   ├── __fixtures__/     # Sample entries for CI builds
+│   └── __tests__/        # Vitest unit tests (components, pages, config, loaders, utils)
+├── scripts/              # convert-videos.ts (Bun + ffmpeg)
+├── lgtm-content/         # Images (Git submodule, private)
+└── public/               # Static assets (icons, manifest, robots.txt)
 ```
 
-## Release Management
+Shared packages from the monorepo: `@kkhys/ui` (head meta, header / footer, infinite scroll, icons), `@kkhys/seo`, `@kkhys/og`, `@kkhys/styles`, `@kkhys/analytics`.
 
-Automated versioning with date-based tags:
+For detailed architecture, see [CLAUDE.md](./CLAUDE.md).
+
+## Deployment
+
+Built and deployed locally via wrangler:
 
 ```bash
-pnpm release
-# Creates tag: YYYY.MM.DD[-N]
-# Generates GitHub release with changelog comparison
+pnpm deploy:lgtm   # from the repo root; runs pnpm build then wrangler pages deploy dist --project-name=lgtm
 ```
 
-**Process**:
-
-1. Generate version from current date
-2. Check for existing tags, increment suffix if needed
-3. Create and force-push Git tag
-4. Generate GitHub Release via API
-5. Return to original branch
+The `lgtm-content` submodule must be initialized first. lgtm is not deployed from CI; CI only verifies the build against fixtures.
 
 ## License
 
-MIT © [Keisuke Hayashi](https://github.com/kkhys)
-
----
-
-Built with precision. Served with speed.
+Code is licensed under [MIT](../../LICENSE.md). Image usage terms are on the [copyright page](https://lgtm.kkhys.me/copyright).

--- a/apps/me/CLAUDE.md
+++ b/apps/me/CLAUDE.md
@@ -5,8 +5,9 @@ Personal blog (kkhys.me), the `@kkhys/me` app of the kkhys monorepo. Astro 7 sta
 ## Project Map
 
 - `src/features/` — Self-contained feature modules (blog, pages, search)
-- `src/lib/` — remark/rehype plugins, API wrappers (`api/`), utilities
-- `src/utils/` — Pure helpers (date, hash, font-loader, base-url, extract-description)
+- `src/lib/` — remark/rehype plugins, API wrappers (`api/`), content loaders (`loaders/zenn.ts`), JSON-LD builders (`json-ld.ts`), Expressive Code options (`expressive-code.ts`)
+- `src/utils/` — Pure helpers (date, hash, font-loader, base-url, extract-description, image-alt)
+- `src/content/` — Repo-side content: `pages/*.mdx` and `external-posts/data.yaml` (not part of the submodule)
 - `src/styles/` — Global CSS with light-dark() theme switching
 - `src/__tests__/` — Vitest unit tests mirroring source structure
 - `me-content/` — Blog MDX and bucket-list YAML (Git submodule)
@@ -18,11 +19,17 @@ Consumed as source (no build step); this app supplies its own config via thin wr
 - `@kkhys/styles` — uchu.css OKLCH palette + shared semantic tokens / base styles; me keeps only prose- and code-specific tokens local
 - `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard primitives, wrapped in `src/components/seo/`
 - `@kkhys/og` — Satori OG image + favicon generators, wired in `src/pages/api/`
-- `@kkhys/ui` — shared Astro components and the helpers behind them; me uses the cached BudouX parser (`src/lib/rehype-budoux.ts`, OG image titles)
+- `@kkhys/ui` — shared Astro components and the helpers behind them; me uses head-meta, skip-link, blur-load / blur-load-noscript, link-card + link-metadata, favicon, toc-observer (`src/features/blog/components/ui/toc.astro`), the SVG icons under `@kkhys/ui/icons/` (9 in use), and the cached BudouX parser (`src/lib/rehype-budoux.ts`, OG image titles)
+- `@kkhys/search` — Pagefind dialog shell, runner, and query helpers, wrapped in `src/features/search/` (see Search below)
+- `@kkhys/analytics` — Umami tracker, mounted in `src/layouts/base-layout.astro`
 
 ## Content System
 
-4 collections in `src/content.config.ts`: blog (MDX in `me-content/blog/`), pages (MDX), bucketList (YAML in `me-content/`), externalPost (YAML). Blog frontmatter requires `title`, `emoji`, `category`, `publishedAt`. Slugs are Bech32m hashed (7 chars) via `src/utils/hash.ts`.
+5 collections in `src/content.config.ts`: blog (MDX in `me-content/blog/`), pages (MDX in `src/content/pages/`), bucketList (YAML in `me-content/`), externalPost (YAML in `src/content/external-posts/`), zennPost (auto-imported at build time from the Zenn RSS feed `me.zenn.feed` in `src/config/site.ts` by `src/lib/loaders/zenn.ts`). Blog frontmatter requires `title`, `emoji`, `category`, `publishedAt`. Slugs are Bech32m hashed (7 chars) via `src/utils/hash.ts`.
+
+zennPost entries carry no category or tags, so `siteName` is fixed to Zenn and `category` to Tech; to override one article, add a manual externalPost with the same URL (it takes precedence in `getPublicListEntries`). The loader keeps the previous `Last-Modified` in the loader meta store for conditional requests, and a fetch/parse failure logs and keeps the previously loaded entries instead of failing the build.
+
+`USE_FIXTURE_DATA=true` points blog and bucketList at `src/__fixtures__/content` instead of `me-content`. It is the only switch CI uses; plain `pnpm dev` without the submodule reads an empty `me-content`. The Zenn loader has no fixture mode and still fetches the feed.
 
 4 categories (Tech, Life, Object, DIY) in `src/features/blog/config/category.ts`. Tags scoped per category in `src/features/blog/config/tag.ts`, validated via `z.enum`.
 
@@ -30,7 +37,7 @@ Consumed as source (no build step); this app supplies its own config via thin wr
 
 - Dev tools are managed by the Nix Flake at the repo root (`flake.nix`). Run `direnv allow` once.
 - Run scripts from this directory, or from the repo root via `pnpm --filter @kkhys/me <script>`.
-- CI: lint → test → type check → build, against fixtures. Add the `skip-ci` label to PRs to skip.
+- CI: lint → test → type check → build, against fixtures (`USE_FIXTURE_DATA=true`). Add the `skip-ci` label to PRs to skip.
 - Deploy: built and shipped locally via `pnpm deploy`; me is not deployed from CI.
 - Lint/format: runs automatically via Stop hook (oxlint + oxfmt auto-fix). Fix remaining errors before completing.
 - Search: `astro-pagefind` indexes `dist` after `astro build`; only elements marked `data-pagefind-body` (blog post title + body in `src/layouts/blog-layout.astro`) are indexed. The dev server serves `/pagefind/` from `dist`, so run `pnpm build` once before `pnpm dev` to try search locally. The dialog lives in `src/features/search/` as a thin wrapper over `@kkhys/search` (shell, runner, keyboard handling); only the category filter, the result-row template, and the Pagefind meta keys are app-local. No CSP is configured today; adding one needs `script-src` for the dynamic `import()` of `/pagefind/pagefind.js`, `wasm-unsafe-eval` for the Pagefind WASM, and `connect-src 'self'` for fragment fetches.

--- a/apps/me/README.md
+++ b/apps/me/README.md
@@ -8,6 +8,7 @@ Source code for [kkhys.me](https://kkhys.me) — a personal website and blog bui
 - [React](https://react.dev/) — Server-side OG image generation (via Satori, `@kkhys/og`)
 - [Vanilla CSS](https://developer.mozilla.org/en-US/docs/Web/CSS) — [kiso.css](https://github.com/build-trust/kiso.css) reset + [uchu.css](https://github.com/kkhys/uchu.css) palette (`@kkhys/styles`)
 - [TypeScript](https://www.typescriptlang.org/) — Strictest mode type safety
+- [Pagefind](https://pagefind.app/) — Full-text search over blog posts (`astro-pagefind`, indexed after `astro build`)
 - [Vitest](https://vitest.dev/) — Unit testing
 - [oxlint](https://oxc.rs/docs/guide/usage/linter.html) + [oxfmt](https://oxc.rs/docs/guide/usage/formatter.html) — Linting and formatting
 - [Cloudflare Pages](https://pages.cloudflare.com/) — Hosting and deployment
@@ -26,7 +27,7 @@ Open [http://localhost:4321](http://localhost:4321) to view the site.
 
 ### Content
 
-Blog content lives in the `me-content` Git submodule. Development works without it (fixtures). A production build needs the submodule:
+Blog content lives in the `me-content` Git submodule. Without it, set `USE_FIXTURE_DATA=true` to read the fixtures in `src/__fixtures__/content` (CI does this automatically); plain `pnpm dev` without the submodule sees an empty `me-content`. A production build needs the submodule:
 
 ```bash
 git submodule update --init apps/me/me-content
@@ -36,17 +37,20 @@ git submodule update --init apps/me/me-content
 
 Run from this directory, or prefix with `pnpm --filter @kkhys/me`:
 
-| Command                       | Description                              |
-| ----------------------------- | ---------------------------------------- |
-| `pnpm dev`                    | Start development server                 |
-| `pnpm build`                  | Production build (static)                |
-| `pnpm preview`                | Preview production build locally         |
-| `pnpm check`                  | Astro check + `tsc --noEmit`             |
-| `pnpm lint` / `pnpm lint:fix` | Check / auto-fix with oxlint + oxfmt     |
-| `pnpm test` / `pnpm coverage` | Run unit tests / with coverage           |
-| `pnpm render:mermaid`         | Pre-render Mermaid diagrams to SVG cache |
-| `pnpm create:entry`           | Scaffold a new blog post                 |
-| `pnpm deploy`                 | Build and deploy to Cloudflare Pages     |
+| Command                       | Description                                |
+| ----------------------------- | ------------------------------------------ |
+| `pnpm dev`                    | Start development server                   |
+| `pnpm build`                  | Production build (static)                  |
+| `pnpm preview`                | Preview production build locally           |
+| `pnpm check`                  | Astro check + `tsc --noEmit`               |
+| `pnpm lint` / `pnpm lint:fix` | Check / auto-fix with oxlint + oxfmt       |
+| `pnpm test` / `pnpm coverage` | Run unit tests / with coverage             |
+| `pnpm all`                    | build + check + lint:fix + test + coverage |
+| `pnpm astro`                  | Run the Astro CLI directly                 |
+| `pnpm playwright-install`     | Install Chromium for Mermaid rendering     |
+| `pnpm render:mermaid`         | Pre-render Mermaid diagrams to SVG cache   |
+| `pnpm create:entry`           | Scaffold a new blog post                   |
+| `pnpm deploy`                 | Build and deploy to Cloudflare Pages       |
 
 ## Project Structure
 
@@ -55,9 +59,10 @@ apps/me/
 ├── src/
 │   ├── components/       # Shared UI components + SEO wrappers
 │   ├── config/           # Site configuration
-│   ├── features/         # Feature modules (blog, pages)
+│   ├── content/          # Repo-side content: pages/*.mdx, external-posts/data.yaml
+│   ├── features/         # Feature modules (blog, pages, search)
 │   ├── layouts/          # Page layouts
-│   ├── lib/              # Custom remark/rehype plugins, API wrappers
+│   ├── lib/              # remark/rehype plugins, API wrappers, loaders/zenn.ts, json-ld.ts, expressive-code.ts
 │   ├── pages/            # File-based routing
 │   ├── styles/           # Global styles (global.css, prose.css)
 │   ├── utils/            # Pure helper functions

--- a/apps/me/src/config/site.ts
+++ b/apps/me/src/config/site.ts
@@ -29,6 +29,7 @@ export const me = {
   art: "https://art.kkhys.me",
   lgtm: "https://lgtm.kkhys.me",
   trends: "https://trends.kkhys.me",
+  design: "https://design.kkhys.me",
   zenn: {
     url: "https://zenn.dev/kkhys",
     feed: "https://zenn.dev/kkhys/feed",

--- a/apps/me/src/config/sites.ts
+++ b/apps/me/src/config/sites.ts
@@ -34,4 +34,9 @@ export const sites = [
     href: me.lgtm,
     description: "GitHubのPRレビューで使うLGTM画像",
   },
+  {
+    label: "Design",
+    href: me.design,
+    description: "各サイトを支えるデザイントークンと共有コンポーネントのドキュメント",
+  },
 ] as const satisfies SatelliteSite[];

--- a/apps/memo/CLAUDE.md
+++ b/apps/memo/CLAUDE.md
@@ -7,17 +7,32 @@ Astro-based memo posting site. Short memos (max 500 chars) in a threaded social 
 ```
 src/
 ├── pages/
-│   ├── [...page].astro        # Paginated feed with infinite scroll
+│   ├── [...page].astro        # Paginated feed with infinite scroll (pinned memos first)
 │   ├── posts/[id].astro       # Single memo detail
-│   └── tag/[tag].astro        # Tag-filtered feed
-├── components/                 # Astro components
+│   ├── tag/[tag]/[...page].astro  # Tag-filtered feed, paginated
+│   ├── @[slug]/[...page].astro    # Author profile feed: pinned + paginated
+│   └── api/
+│       ├── posts/[id].json.ts # Public JSON per memo (consumed by apps/me)
+│       ├── og/default.png.ts  # Default OG image via @kkhys/og
+│       └── favicon/[file].ts  # Favicon set via @kkhys/og
+├── components/                 # Astro components; seo/ wraps @kkhys/seo primitives
+├── layouts/                    # layout.astro: head meta, skip link, header/footer, Umami
 ├── features/
-│   └── search/                # Pagefind dialog; pure logic in utils/ (unit-tested)
+│   └── search/                # Pagefind dialog; pure logic in utils/ (unit-tested); verify-index.ts build check
+├── loaders/
+│   ├── memo-loader.ts         # Content Layer loader: memo dirs + bot feed entries
+│   ├── feed-cache.ts          # On-disk feed cache with TTL + conditional revalidation
+│   └── rss-parser.ts          # Minimal RSS parsing for the bot feeds
 ├── utils/
-│   ├── memo.ts                # Filtering, sorting, comment threading
-│   └── image.ts               # Dynamic image imports from submodule
-├── lib/                        # Remark plugins (word limit, link extraction, etc.)
-├── styles/                     # CSS variables, theme (uchu.css, kiso.css)
+│   ├── memo.ts                # Filtering, sorting, pinning, comment threading
+│   ├── user.ts                # users collection lookup + avatar/cover resolution
+│   ├── date.ts                # UTC date formatting
+│   ├── image.ts               # Dynamic image imports from submodule
+│   └── image-alt.ts           # images[].alt lookup with numbered fallback
+├── lib/                        # Remark plugins (word limit, link extraction, etc.) + metadata.ts (link-card fetcher)
+├── config/                     # constants.ts: site-level personal config
+├── assets/                     # Avatars, covers, bot icons, OG font
+├── styles/                     # global.css: @kkhys/styles (uchu/tokens/base) + kiso.css imports, app tokens
 ├── __fixtures__/               # Test fixtures and sample data
 └── __tests__/                  # Vitest tests
 
@@ -28,13 +43,28 @@ memo-content/                   # Git submodule — all production content/perso
 
 ## Content System
 
-Each memo is a directory in `memo-content/memo/` containing `index.md` and optional images (max 4, JPG/PNG). Schema: `id` (ULID), `createdAt`, `tag?`, `images?` (`{ file, alt }[]` — alt text keyed by file name; the files themselves are discovered from the directory by `utils/image.ts`), `comment?` (parent ULID for threaded replies), `isDraft`, `author`, `hideLinkCard`. Images without an `images[].alt` entry render with a numbered placeholder alt; new memos get their alt from the studio composer.
+Each memo is a directory in `memo-content/memo/` containing `index.md` and optional images (max 4, JPG/PNG). Schema: `id` (ULID), `createdAt`, `tag?`, `images?` (`{ file, alt }[]` — alt text keyed by file name; the files themselves are discovered from the directory by `utils/image.ts`), `comment?` (parent ULID for threaded replies), `quote?` (quoted ULID), `isDraft`, `author`, `hideLinkCard`, `isBot`, `isPinned` (listed first in the main and author feeds), `hideComments` (feeds collapse the replies to a count; the detail page still shows them). Images without an `images[].alt` entry render with a numbered placeholder alt; new memos get their alt from the studio composer.
 
 Personal data (user profiles, OSS project list) lives in `memo-content/data/` to keep it out of the public repo. Avatar/cover images stay in `src/assets`. Site-level personal config (author name, site URL, blog RSS URL) is centralized in `src/config/constants.ts`.
 
 Bot feeds: the memo loader injects entries from external RSS feeds as bot authors — `blog-feed` (`rss-` id prefix) and `zenn-feed` (`zenn-` id prefix), each with a distinct prefix so per-feed stale cleanup stays isolated. Feed XML is cached under `node_modules/.cache/memo-feeds/` with a TTL (default 10 min, override via `FEED_CACHE_TTL_MINUTES`); past the TTL the loader revalidates with conditional requests (ETag/Last-Modified) instead of re-downloading. OSS projects (`oss-` prefix) come from a local JSON file, not a feed.
 
 `USE_FIXTURE_DATA=true` switches to `src/__fixtures__/memo-sample` (memos) and `src/__fixtures__/users.yaml` (sample profiles) for CI/development without the submodule. RSS/Zenn fetches and OSS entries are skipped in fixture mode.
+
+## Shared Packages
+
+Consumed as source (no build step); memo supplies its own config via thin wrappers.
+
+- `@kkhys/ui` — site-header (`src/components/header.astro`), site-footer / skip-link / head-meta / blur-load-noscript (`src/layouts/layout.astro`), blur-image (`memo-images.astro`), link-card + link-metadata + favicon (`link-card.astro`, `lib/metadata.ts`), infinite-scroll + paginated-guard (`paginated-feed.astro`), search icon
+- `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard wrapped in `src/components/seo/`; `@kkhys/seo/json-ld.astro` used directly by the pages
+- `@kkhys/og` — OG image + favicon generators behind `src/pages/api/og/` and `src/pages/api/favicon/`
+- `@kkhys/styles` — uchu.css palette, semantic tokens, base styles imported by `src/styles/global.css`
+- `@kkhys/analytics` — Umami tracker in `src/layouts/layout.astro`
+- `@kkhys/search` — Pagefind dialog shell, runner, query helpers (see Search)
+
+## Public JSON API
+
+`src/pages/api/posts/[id].json.ts` statically emits one JSON per published memo: `id`, `body` (raw markdown), `createdAt`, `author` (name / username / absolute avatar URL), `tag`, and `images` (absolute `src`, `width`, `height`, `alt` via `utils/image-alt.ts`). `public/_headers` sets `Access-Control-Allow-Origin: https://kkhys.me` (GET only) on `/api/*`; the consumer is `apps/me/src/lib/api/memo.ts`, which embeds memos in blog posts. Changing the shape breaks me.
 
 ## Search
 

--- a/apps/memo/README.md
+++ b/apps/memo/README.md
@@ -8,25 +8,33 @@ social media layout, part of the [kkhys monorepo](../../README.md).
 ## Features
 
 - Short memo posts with threaded replies and quotes
-- Up to 4 images per post (JPG/PNG)
+- Up to 4 images per post (JPG/PNG) with alt text
+- Full-text search over posts (Pagefind)
+- Per-author feed at `/@slug`, with pinned posts (`isPinned`) shown first
+- Replies collapsed to a count in feeds per post (`hideComments`)
 - Bot feeds: blog RSS, Zenn RSS, and OSS projects injected as entries
+- Public JSON per post at `/api/posts/<id>.json` (CORS opened to `https://kkhys.me`, consumed by the blog)
 - Light/dark mode via `light-dark()`
 - Fully static build with infinite scroll over pre-built pages
 
 ## Tech Stack
 
 Astro 7 static site, TypeScript (strictest), vanilla CSS (kiso.css +
-uchu.css via `@kkhys/styles`), Vitest, oxlint + oxfmt. Deployed to
-Cloudflare Pages by GitHub Actions (`.github/workflows/deploy-memo.yml`)
-on pushes to main.
+uchu.css via `@kkhys/styles`), Vitest, oxlint + oxfmt. Shared monorepo
+packages: `@kkhys/ui` (components), `@kkhys/seo`, `@kkhys/og` (OG image +
+favicons), `@kkhys/search` (Pagefind dialog), `@kkhys/analytics` (Umami),
+`@kkhys/styles`. Deployed to Cloudflare Pages by GitHub Actions
+(`.github/workflows/deploy-memo.yml`) on pushes to main.
 
 ## Content
 
 Each memo is a directory in the private `memo-content/` submodule
 (`memo/<YYYYMMDD_HHMMSS>/index.md` + numbered images). Frontmatter:
 `id` (lowercase ULID), `createdAt`, optional `tag`, `comment` (parent
-ULID), `quote`, `isDraft`, `hideLinkCard`, `isPinned`, `hideComments`,
-`isBot`, and `author` (user slug).
+ULID), `quote`, `images` (`{ file, alt }[]` — `file` matches
+`/^\d{2}\.(jpg|png)$/`, `alt` is the image's alt text), `isDraft`,
+`hideLinkCard`, `isPinned`, `hideComments`, `isBot`, and `author` (user
+slug).
 
 Memos are composed locally with [`@kkhys/studio`](../studio). Without the
 submodule, set `USE_FIXTURE_DATA=true` to build against

--- a/apps/studio/CLAUDE.md
+++ b/apps/studio/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Local-only browser app for composing memos into `apps/memo/memo-content`. Never deployed — it runs on the developer's machine (`pnpm dev:studio`, binds to 127.0.0.1:5757) and writes directly to the memo-content submodule.
+Local-only browser app for composing memos into `apps/memo/memo-content`. Never deployed — it runs on the developer's machine (`pnpm dev:studio`, binds to 127.0.0.1:5757; the port follows the `PORT` env var, and the allowed Host list in `server.ts` follows it) and writes directly to the memo-content submodule.
 
 ## Codebase Map
 
@@ -8,6 +8,7 @@ Local-only browser app for composing memos into `apps/memo/memo-content`. Never 
 src/
 ├── server.ts        # Bun.serve: serves the UI (HTML import) + JSON API, git status/sync
 ├── memo-store.ts    # Pure Node module: list/create memos, frontmatter, validation
+├── memo-format.ts   # Shared by memo-store.ts and client.ts: MAX_BODY_LENGTH (500), MAX_IMAGES (4), countMemoChars, toCreatedAt, MemoSummary; fs/DOM-free
 ├── memo-filter.ts   # Pure Node module: free-text feed filtering (AND terms)
 ├── request-guard.ts # Pure Node module: Host/Origin validation for all API routes
 ├── index.html       # Single-page UI (bundled by Bun with client.ts / styles.css)
@@ -28,6 +29,6 @@ All API routes are guarded by a Host/Origin check (`request-guard.ts`) against D
 
 ## Constraints
 
-- Writes must follow memo conventions: dir `YYYYMMDD_HHMMSS`, ULID lowercased and derived from `createdAt`, images numbered `01.jpg`… each described by `images[].alt` in the frontmatter; body ≤500 chars counted like remark-word-limit (rendered text, not raw markdown)
+- Writes must follow memo conventions: dir `YYYYMMDD_HHMMSS`, ULID lowercased and derived from `createdAt`, images numbered `01.jpg`… each described by `images[].alt` in the frontmatter; body ≤500 chars counted like remark-word-limit (rendered text, not raw markdown — `countMemoChars` in `memo-format.ts`, tested in `__tests__/memo-format.test.ts`)
 - `memo-store.ts` stays Bun-free so CI (Node + vitest) can test it; Bun APIs live in `server.ts` only
 - EXIF stripping is handled by memo-content's lefthook pre-commit hook, not here

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -10,10 +10,11 @@ the content submodule.
 pnpm dev:studio   # from the repo root; binds to 127.0.0.1:5757
 ```
 
-The UI provides a compose form (body, tag, reply/quote, draft flag,
-images), a searchable feed of existing memos, and a sync button that
-commits and pushes memo-content (optionally triggering the deploy
-workflow).
+The UI provides a compose form (body, created-at datetime, tag,
+reply/quote, draft flag, "No link card" toggle, images with a required
+alt text input per image), a searchable feed of existing memos, and a
+sync button that commits and pushes memo-content (optionally triggering
+the deploy workflow).
 
 Body length is validated like the memo app (rendered text ≤ 500 chars),
 and all API routes are guarded against DNS rebinding / cross-origin

--- a/apps/trends/CLAUDE.md
+++ b/apps/trends/CLAUDE.md
@@ -18,14 +18,16 @@ src/
     site-header.astro         # Static header (brand → /, Archive / About links)
     digest-view.astro         # One day's body: DateNav + hero + markets + generated-at footer
     digest-hero.astro         # headline / lead / numbered highlights
-    market-section.astro      # 日本 / グローバル section
-    service-card.astro        # Per-service section (brand-color dot, count, error note)
+    market-section.astro      # グローバル / 日本 section (global first via sortMarketsGlobalFirst in digest-view; the run JSON stores japan first)
+    service-card.astro        # Per-service section (brand-color dot, total + fresh counts, error note, 該当なし / すべて既出 states)
     source-toc.astro          # Always-visible source TOC (markets → services), ≥1280px only
     item-row.astro            # rank → title → summary → meta row (score, stars, chip, host, engagement)
     seen-filter.astro         # すべて / 既出を除く toggle; flips html[data-seen-filter], persisted in localStorage
     date-nav.astro            # ← 前日 / current date (plain text) / 翌日 →
   utils/runs.ts               # sortRunsByDateDesc, adjacentRuns, date formatters (pure, unit-tested)
   utils/host.ts               # formatHost — hostname without www. for the meta row
+  utils/markets.ts            # sortMarketsGlobalFirst — display order of the markets (pure, unit-tested)
+  utils/paragraphs.ts         # splitParagraphs — blank-line split for the summary folds (pure, unit-tested)
   utils/score.ts              # scoreLevel: 80+/60+ thresholds → hi/mid/lo score emphasis
   utils/seen.ts               # countSeen — 既出 item count for the seen filter (pure, unit-tested)
   utils/service-colors.ts     # Upstream brand colors, shared by service-card and source-toc
@@ -33,6 +35,16 @@ src/
   __tests__/                  # Vitest unit tests
 public/                       # robots.txt, manifest, static favicons (generated from dev routes)
 ```
+
+## Shared Packages
+
+Consumed as source (no build step).
+
+- `@kkhys/styles` — uchu.css palette + shared `tokens.css` / `base.css`, imported in `src/styles/global.css`; light/dark via `light-dark()`.
+- `@kkhys/ui` — `Budoux` wraps the Japanese copy in `item-row.astro`, `digest-hero.astro`, and `pages/archive.astro`; `HeadMeta` / `SkipLink` in `base-layout.astro`; `observeActiveHeading` from `@kkhys/ui/toc-observer` drives the scrollspy in `source-toc.astro`.
+- `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard in `base-layout.astro` (`twitter:card` is "summary"; no OG image).
+- `@kkhys/analytics` — Umami tracker in `base-layout.astro`.
+- `@kkhys/og` — favicon routes (`src/pages/api/favicon/[file].ts`, bound to the blue radial gradient).
 
 ## Data Contract
 
@@ -42,7 +54,7 @@ public/                       # robots.txt, manifest, static favicons (generated
 - When changing the schema, update in the same change: `content.config.ts`, the JSON example in the skill's SKILL.md, and every existing file in `src/content/runs/`.
 - File name must equal the `date` field; `[date].astro`'s getStaticPaths throws on mismatch.
 - All string fields are required with `""` for absent values (no nulls) — keeps `exactOptionalPropertyTypes` out of the data path.
-- `discussion_summary` is non-empty only for the top items of comment-capable sources (HN / Lobsters / Reddit / はてなブックマーク, `comments_top_n` in the skill's config, default 10 = every displayed item). It is 2-3 short paragraphs separated by blank lines (`\n\n`); `item-row.astro` splits on blank lines and renders one `<p>` per paragraph inside a `<details>` fold, so older single-paragraph runs render unchanged.
+- `discussion_summary` is non-empty only for the top items of comment-capable sources (HN / Lobsters / Reddit / はてなブックマーク, `comments_top_n` in the skill's config, default 10 = every displayed item). It is 2-3 short paragraphs separated by blank lines (`\n\n`); `item-row.astro` splits it with `splitParagraphs` (`utils/paragraphs.ts`) and renders one `<p>` per paragraph inside a `<details>` fold, so older single-paragraph runs render unchanged.
 - `article_summary` is the same multi-paragraph format for the sources without a comment fetcher (GitHub Trending / dev.to / Zenn / Qiita / Hugging Face Daily Papers, `articles_top_n` in the skill's config), summarizing the article body the fetch script attaches. Mutually exclusive with `discussion_summary`; the fold label switches (コメントの要約 / 記事の要約). Techmeme items carry neither summary — the headline is already the condensed story. Older runs predate the field and rely on the zod default.
 - `title_ja` (on items and digest highlights) is a Japanese translation of an originally non-Japanese title, `""` when the title is already Japanese. When present it becomes the linked title and the original renders beneath it. Older runs predate the field and rely on the zod default.
 
@@ -50,9 +62,12 @@ public/                       # robots.txt, manifest, static favicons (generated
 
 - The UI follows the kkhys.me design language (see apps/me): plain `--uchu-yang`/`--uchu-yin` background, hairline separators instead of cards, a `--content-width` content column, `2026.08.10` date format, and the shared `--c-*` / `--fs-*` / `--radius-*` tokens from `@kkhys/styles`.
 - `/` renders the latest run in full (duplicate of its `/[date]` page, accepted); `/[date]` is the permanent URL.
-- Client JS is minimal and colocated: the scrollspy in `source-toc.astro` and the 既出 filter toggle in `seen-filter.astro`. Navigation between sources is the TOC's job — the header stays a plain brand link.
-- The 既出 filter is CSS-driven: rows carry an `is-seen` class, per-service counts are prerendered for both modes, and `html[data-seen-filter="hide"]` switches everything. JS only flips that attribute and persists the choice (`trends:seen-filter`); without JS the toggle stays hidden and the site behaves as before.
-- The source TOC descends from apps/me's `toc.astro` but stays visible instead of expanding on hover; `pickActiveId` keeps one entry highlighted while scrolling. Anchor ids are `{market.id}` on h2 and `{market.id}-{service.id}` on h3.
+- Markets display global first: `digest-view.astro` applies `sortMarketsGlobalFirst` before rendering the sections and the TOC, while the run JSON keeps japan first. Reorder there, not in the data.
+- Client JS is minimal: `source-toc.astro` only wires `observeActiveHeading` from `@kkhys/ui/toc-observer` (the `pickActiveId` selection logic lives in `packages/ui/src/toc-active.ts`), and the 既出 filter toggle stays colocated in `seen-filter.astro`. Navigation between sources is the TOC's job — the header stays a plain brand link.
+- The 既出 filter is CSS-driven: rows carry an `is-seen` class, per-service counts are prerendered for both modes (`service-card.astro` renders the total and the fresh count and swaps them with CSS), and `html[data-seen-filter="hide"]` switches everything. JS only flips that attribute and persists the choice (`trends:seen-filter`); without JS the toggle stays hidden and the site behaves as before.
+- `service-card.astro` has two empty states: 該当なし when a service returned no items with `status: "ok"`, and すべて既出 (shown only in hide mode) when every item is 既出, so a fully-filtered service keeps more than a bare header.
+- The source TOC descends from apps/me's `toc.astro` but stays visible instead of expanding on hover; the observer keeps one entry highlighted while scrolling. Anchor ids are `{market.id}` on h2 and `{market.id}-{service.id}` on h3.
+- `about.astro` is the visitor-facing spec of the score (engagement percentile 75% + freshness decay 25%, hi/mid/lo at 80 / 60), the ★1-3 interest stars, and the 既出 / summary fold terms. Keep it in step with the skill's scoring when that changes.
 - Service dot colors are upstream brand colors, intentionally not mapped to the uchu palette.
 - `runs/**` JSON is excluded from oxlint/oxfmt via root `ignorePatterns` — data, not code.
 

--- a/apps/trends/README.md
+++ b/apps/trends/README.md
@@ -6,20 +6,25 @@ One JSON file per day lives in `src/content/runs/`, validated by the zod schema 
 
 ## Pages
 
-| URL        | Content                                   |
-| ---------- | ----------------------------------------- |
-| `/`        | Latest digest                             |
-| `/<date>`  | Permanent per-day page with prev/next nav |
-| `/archive` | All runs, newest first                    |
+| URL        | Content                                     |
+| ---------- | ------------------------------------------- |
+| `/`        | Latest digest                               |
+| `/<date>`  | Permanent per-day page with prev/next nav   |
+| `/archive` | All runs, newest first                      |
+| `/about`   | How the site works, score and star criteria |
 
 ## Scripts
 
-| Command       | Description                                     |
-| ------------- | ----------------------------------------------- |
-| `pnpm dev`    | Start the dev server                            |
-| `pnpm build`  | Build to `dist/` (validates all run JSON)       |
-| `pnpm check`  | `astro check` + `tsc --noEmit`                  |
-| `pnpm test`   | Vitest unit tests                               |
-| `pnpm deploy` | Build and deploy to Cloudflare Pages (`trends`) |
+| Command                       | Description                                     |
+| ----------------------------- | ----------------------------------------------- |
+| `pnpm dev`                    | Start the dev server                            |
+| `pnpm build`                  | Build to `dist/` (validates all run JSON)       |
+| `pnpm preview`                | Preview the production build locally            |
+| `pnpm check`                  | `astro check` + `tsc --noEmit`                  |
+| `pnpm test`                   | Vitest unit tests                               |
+| `pnpm coverage`               | Vitest with coverage                            |
+| `pnpm lint` / `pnpm lint:fix` | Check / auto-fix with oxlint + oxfmt            |
+| `pnpm all`                    | build → check → lint:fix → test → coverage      |
+| `pnpm deploy`                 | Build and deploy to Cloudflare Pages (`trends`) |
 
 From the repo root: `pnpm dev:trends` / `pnpm build:trends` / `pnpm deploy:trends`.

--- a/packages/analytics/CLAUDE.md
+++ b/packages/analytics/CLAUDE.md
@@ -1,7 +1,8 @@
 # CLAUDE.md
 
 `@kkhys/analytics` — Umami tracker script component, consumed as source by
-the five published apps (me, memo, lgtm, diary, trends).
+six published apps (me, memo, lgtm, diary, trends, art); design does not
+render it.
 
 ## API notes
 
@@ -12,6 +13,8 @@ the five published apps (me, memo, lgtm, diary, trends).
 - The tracker only renders in production builds (`import.meta.env.PROD`),
   so dev servers never send events; `data-domains` additionally guards
   non-production hostnames (e.g. `*.pages.dev` previews).
+  `data-exclude-search="true"` strips query strings from tracked URLs, so
+  a search dialog's `?q=` never reaches the dashboard.
 - Website IDs are public (they ship in the served HTML), so apps hardcode
   them at the call site in their root layout.
 

--- a/packages/og/CLAUDE.md
+++ b/packages/og/CLAUDE.md
@@ -1,7 +1,8 @@
 # CLAUDE.md
 
 `@kkhys/og` — Satori-based OG image and favicon generation, consumed as
-source by me, memo, lgtm, and diary.
+source by me, memo, lgtm, and diary in full; art and trends use only the
+favicon route (`src/pages/api/favicon/[file].ts`).
 
 ## Exports
 

--- a/packages/release/CLAUDE.md
+++ b/packages/release/CLAUDE.md
@@ -7,9 +7,12 @@
 
 - Versions are `YYYY.MM.DD`, suffixed `-2`, `-3`, … for same-day
   re-releases (`version.ts`, anchored matching — tested).
-- `release()` fetches origin tags first, refuses to tag a stale or
-  diverged main (`pull --ff-only`), force-pushes the tag, and creates a
-  GitHub Release; any failure sets a non-zero exit code.
+- `release({ repoName, repoOwner?, dryRun? })` (`src/index.ts`) targets
+  `repoOwner/repoName` on GitHub (`repoOwner` defaults to `kkhys`;
+  `scripts/release.ts` passes `repoName: "me"`). It fetches origin tags
+  first, refuses to tag a stale or diverged main (`pull --ff-only`),
+  force-pushes the tag, and creates a GitHub Release; any failure sets a
+  non-zero exit code.
 - `dryRun: true` (CLI: `--dry-run`) previews without git/API mutations
   and needs no `GITHUB_ACCESS_TOKEN`.
 

--- a/packages/search/CLAUDE.md
+++ b/packages/search/CLAUDE.md
@@ -1,27 +1,43 @@
 # CLAUDE.md
 
-`@kkhys/search` — the Pagefind search dialog shared by me and memo,
-consumed as source (no build step).
+`@kkhys/search` — the Pagefind search dialog shared by me, memo, and
+design, consumed as source (no build step). Workspace deps: `@kkhys/seo`
+(`normalizePathname` in `src/query.ts`) and `@kkhys/ui` (the search icon in
+`src/dialog.astro`).
 
 - `dialog.astro` — the command-palette shell: field, close button, status
   line, results list, and the shared CSS (open/close transitions, light
-  dismiss look). Props: `id`, `label`, `placeholder`. Slots: `filters`
+  dismiss look). Props: `id`, `label`, `placeholder` — nothing else is
+  configurable; the field / close button / results aria labels are
+  hardcoded Japanese (検索キーワード / 閉じる / 検索結果). Slots: `filters`
   (optional chips under the field) and `template` (the app's
   `<template class="search-result-template">` for one result row).
-- `dialog-setup` (`src/dialog-setup.ts`) — `mountSearchDialog(id, options)`
-  wires Pagefind loading and warm-up, the runner, keyboard handling (⌘K /
-  Ctrl+K, arrows, Escape, IME composition), invoker and light-dismiss
-  fallbacks. The app supplies `renderResult(fragment, template)` and,
-  optionally, `searchOptions()` for filters; it gets back `{ input,
-runSearch, openDialog }`. `requireElement` / `isHTMLElement` /
-  `renderExcerpt` are exported for renderers.
+- `dialog-setup` (`src/dialog-setup.ts`) —
+  `setupSearchDialog(dialog, options)` wires Pagefind loading and warm-up,
+  the runner, keyboard handling (⌘K / Ctrl+K, arrows, Escape, IME
+  composition), invoker and light-dismiss fallbacks on a `<dialog>` element
+  you already hold;
+  `mountSearchDialog(id, options)` looks the dialog up by id and calls it
+  (logs and returns `undefined` on a miss). The app supplies
+  `renderResult(fragment, template)` and, optionally, `searchOptions()`
+  for filters; it gets back `{ input, runSearch, openDialog }`.
+  `requireElement` / `isHTMLElement` / `renderExcerpt` are exported for
+  renderers. All three apps use `mountSearchDialog`.
 - `runner` — `createSearchRunner(deps, { maxResults, debounceMs, noun })`:
   stale-request discarding, partial fragment failures, and the status
   strings (`noun` is 記事 / メモ).
 - `keyboard`, `excerpt`, `query`, `types` — the pure helpers and the
   hand-written Pagefind browser types.
 
-App-local pieces stay in each app's `src/features/search/`: `config.ts`
-(dialog id, bundle path, meta keys), `meta.ts` (data-pagefind-* attribute
-builders), me's `buildSearchOptions` (category filter), and the result-row
-markup + CSS. `vitest run` covers runner / keyboard / excerpt / query.
+App-local pieces: me and memo keep them in `src/features/search/` —
+`config.ts` (dialog id, bundle path, meta keys), `utils/meta.ts`
+(data-pagefind-* attribute builders), me's `buildSearchOptions` (category
+filter), the result-row markup + CSS, and memo's `verify-index.ts` (the
+Astro integration that fails the build when the Pagefind index does not
+cover every post). design has no `features/` dir: the dialog is
+`src/components/search-dialog.astro`, config + result ranking live in
+`src/utils/search.ts`, and the index check is split into
+`src/utils/pagefind-index.ts` + `src/integrations/verify-pagefind-index.ts`.
+That check is a near-duplicate of memo's `verify-index.ts` — a known
+candidate to fold into this package. `vitest run` covers runner / keyboard
+/ excerpt / query.

--- a/packages/seo/CLAUDE.md
+++ b/packages/seo/CLAUDE.md
@@ -1,8 +1,10 @@
 # CLAUDE.md
 
 `@kkhys/seo` — BaseSEO / OpenGraph / TwitterCard Astro primitives,
-consumed as source by me, memo, lgtm (via thin app-local adapters in
-`src/components/seo/`) and diary (directly in its layout).
+consumed as source by all seven apps: me, memo, lgtm (via thin app-local
+adapters in `src/components/seo/`), diary, art, trends (directly in their
+layouts), and design (BaseSEO only). `@kkhys/search` also imports
+`normalizePathname` for result hrefs.
 
 ## API notes
 
@@ -31,5 +33,5 @@ consumed as source by me, memo, lgtm (via thin app-local adapters in
   `Astro.url.pathname` reintroduces the `.html` suffix.
 - `check` runs tsc over the `.ts` sources only; the `.astro` components
   are type-checked by each consuming app's `astro check`.
-- API changes ripple into four apps — grep consumers before changing
-  props.
+- API changes ripple into seven apps and `@kkhys/search` — grep consumers
+  before changing props.

--- a/packages/styles/CLAUDE.md
+++ b/packages/styles/CLAUDE.md
@@ -7,8 +7,13 @@ by every app.
 - `tokens.css` — shared semantic tokens: `--c-*` colors (via `light-dark()`),
   `--fs-*` / `--fw-*` / `--lh-*` / `--radius-*` / `--space-*` scales,
   `--font-mono`, `--shadow-sm`, `--content-width`, focus-ring tokens.
-- `base.css` — shared base rules built on the tokens (focus ring, html
-  defaults, scrollbars, `::selection`, `.budoux` / `.palt`).
+- `base.css` — shared base rules built on the tokens: `* { border-color }`,
+  the `:focus-visible` ring, html defaults, page scrollbars, heading
+  `palt` + `text-wrap: balance`, `.budoux` / `.palt`, `.sr-only`,
+  `.scroller-thin` (3px thumb for inner scrollers; never on `:root`),
+  `::selection`, and a `prefers-reduced-motion` block that collapses
+  transitions and smooth scrolling (animations are left alone on
+  purpose).
 - `components.css` — shared component classes (`.btn` and its
   `--outline` / `--ghost` / `--size-*` modifiers), used by me / studio /
   design.
@@ -17,7 +22,7 @@ by every app.
 
 Apps import css files into their cascade layers
 (`@import "@kkhys/styles/tokens.css" layer(tokens);` etc.). Each app declares
-its own `color-scheme` (diary pins light) and may override any token in its
+its own `color-scheme` (diary and art pin light) and may override any token in its
 local tokens layer; app-specific tokens (me's prose/code colors, trends'
 `--c-star`) stay app-local.
 

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -3,32 +3,41 @@
 `@kkhys/ui` — shared Astro UI components, consumed as source (no build
 step).
 
-- `spinner.astro` — loading spinner (memo / lgtm infinite scroll). Colors
-  via the shared `--c-*` tokens from `@kkhys/styles`. `role="status"` with
-  a `label` prop (default "Loading"; memo passes 読み込み中).
+- `spinner.astro` — loading spinner. Rendered inside `infinite-scroll.astro`
+  (memo / lgtm never import it directly); the design demo imports it on
+  its own. Colors via the shared `--c-*` tokens from `@kkhys/styles`.
+  `role="status"` with a `label` prop (default "Loading"; memo passes
+  読み込み中 through `loadingLabel`).
 - `budoux.astro` — wraps its slot and inserts `<wbr>` at Japanese phrase
-  boundaries (me / trends).
+  boundaries (me / trends / design demo).
 - `budoux` (`src/budoux.ts`) — cached BudouX HTML parser behind the
-  component; also used directly for OG image titles.
+  component; also used directly for OG image titles, me's rehype plugin,
+  and design's prose helper.
 - `site-header.astro` / `site-footer.astro` — the centered small-site
-  chrome (header: memo / lgtm / art / trends / design; footer: memo / lgtm /
-  design / me). Both expect the consumer's body grid to define the
-  `[top]` / `[main-start]` / `[main-end]` / `[bottom]` row names. The
-  header's `actions` slot pins controls to the right edge (memo's search
-  button).
-  `heading` renders the header title as the page's `<h1>` (lgtm, memo
-  feed / thread / tag); `backLabel` / `navLabel` name the back button and
-  the footer nav in the page's language.
+  chrome. Header: memo (`components/header.astro`) and lgtm
+  (`layouts/layout.astro`); design renders it only in its component demo.
+  Footer: memo / lgtm, plus the design demo. me, art, trends, and the
+  design shell keep their own header / footer. Both expect the consumer's
+  body grid to define the `[top]` / `[main-start]` / `[main-end]` /
+  `[bottom]` row names. Header props: `title` (required), `href` (renders
+  the title as a link — lgtm), `showBack` + `backLabel` (memo subpages),
+  `heading` (renders the title as the page's `<h1>` — lgtm, memo feed /
+  thread / tag), and the `actions` slot that pins controls to the right
+  edge (memo's search button). Footer props: `author` (required),
+  `authorUrl`, `links`, and `navLabel` (names the footer nav in the page's
+  language).
 - `skip-link.astro` — the "skip to content" link placed first in `<body>`;
   hidden until keyboard focus, targets `#main` (every layout gives its
-  `<main>` that id). `label` is required, in the page's language.
+  `<main>` that id). `label` is required, in the page's language. Rendered
+  by me / memo / lgtm / trends / design; art and diary do not render it.
 - `blur-load-noscript.astro` — the no-JS fallback for blur-up images;
   `selector` prop defaults to `.blur-load` (memo passes
   `[data-blur-load], .blur-load`).
-- `link-card.astro` — display-only OG link card (me / memo). Metadata
-  fetching stays in each app's data layer; this takes `title` /
-  `description` / `imageSrc` / `favicon` / `external` as props and does
-  the blur-up + responsive image work.
+- `link-card.astro` — display-only OG link card (me / memo / design demo).
+  Metadata fetching stays in each app's data layer. Props extend
+  `HTMLAttributes<"a">`: `href` required, `title` / `description` /
+  `imageSrc` / `favicon` / `external` optional; it does the blur-up +
+  responsive image work.
 - `favicon` (`src/favicon.ts`) — resolves a declared icon URL into the
   card's `favicon` prop at build time (raster → Astro image pipeline,
   ICO/SVG → data URI, anything dubious → the globe fallback), cached per
@@ -37,14 +46,19 @@ step).
   behind that validation; me's metadata layer uses it for og:image too,
   because content-type headers lie.
 - `blur-load` (`src/blur-load.ts`) — inline load/error handlers that
-  clear a blur-up placeholder (also used by me's content images).
-- `blur-image.astro` — the blur-up `<Picture>` itself (memo / diary / art):
-  20px placeholder behind a `blur(36px)`, aspect ratio reserved, `radius`
-  / `framed` / `transitionName` / `priority` props. me's `image.astro` keeps
-  its own wrapper (figure, wide breakout).
+  clear a blur-up placeholder; used by me's content images (`image.astro`,
+  `memo-card.astro`) and lgtm's feed (`pages/[...page].astro`).
+- `blur-image.astro` — the blur-up `<Picture>` itself (memo / diary / art /
+  design demo): 20px placeholder behind a `blur(36px)`, aspect ratio
+  reserved. Required: `src` (ImageMetadata) / `alt` / `widths` / `sizes`;
+  optional: `width` / `formats` / `quality` / `priority` /
+  `transitionName` / `framed` / `radius` / `class`. me's `image.astro`
+  keeps its own wrapper (figure, wide breakout).
 - `head-meta.astro` — charset, viewport, the color-scheme meta (must come
-  before any stylesheet), the @kkhys/og favicon set, and the sitemap link.
-  `colorScheme="light"` for art / diary, `icons={false}` for design.
+  before any stylesheet), the @kkhys/og favicon set, and the sitemap link;
+  rendered first in `<head>` by all seven apps. `colorScheme="light"` for
+  art / diary, `icons={false}` for design, `sitemap={false}` for an app
+  without `@astrojs/sitemap` (none passes it today).
 - `infinite-scroll.astro` / `paginated-guard.astro` — append-next-page
   scrolling for memo / lgtm feeds (container carries `data-current-page`
   / `data-total-pages` / `data-base-path`) and the redirect that bounces
@@ -61,12 +75,20 @@ step).
   `fetch-site-metadata` plus the repairs link cards have needed (garbled
   legacy charsets, SVG / undecodable og:images, http-only image hosts),
   memoized per URL. me / memo wrap it with their own production check.
-- `icons/*.svg` — the Lucide glyphs shared by the apps (search, arrow-left,
-  check, copy, link, move-up-right, …); import as
-  `@kkhys/ui/icons/<name>.svg` and pass `width` / `height` / `class`.
-  Brand icons stay in the app that uses them.
+- `icons/*.svg` — the 13 Lucide glyphs shared by the apps: `arrow-left`,
+  `check`, `copy`, `ellipsis`, `globe`, `info`, `lightbulb`, `link`,
+  `message-square-warning`, `move-up-right`, `octagon-alert`, `search`,
+  `triangle-alert`. Import as `@kkhys/ui/icons/<name>.svg` and pass
+  `width` / `height` / `class`. `globe` is only used by `link-card.astro`;
+  `ellipsis` has no consumer in the apps today. Brand icons stay in the
+  app that uses them.
 
 `.astro` exports can only be imported from `.astro` files (tsc doesn't
 resolve them); `./budoux` is the plain-TS entry for `.ts` / `.tsx`
-consumers. `vitest run` covers the parser, the blur-load handlers, and the
-favicon resolver.
+consumers. `vitest run` covers `src/__tests__/`: `blur-load` (selector
+targeting, reveal on error), `budoux` (cached parser, `<wbr>` insertion,
+tags preserved), `favicon` (data-URI inlining, rejections, per-URL cache),
+`infinite-scroll` (trigger margin, page append, spinner minimum, end /
+error announcements, re-init on replaced markup), `link-metadata`
+(disabled placeholder, caching, failure retry, SVG og:image dropped), and
+`toc-active` (`pickActiveId`).


### PR DESCRIPTION
- Update every README and CLAUDE.md to match the code after the shared-package extraction (search, ui, seo, og) and recent features (Pagefind search, image alt text, description.txt, zennPost, memo JSON API)
- Rewrite apps/lgtm/README.md, which still predated the monorepo, and add the missing apps/design/README.md
- Add a path-scoped .claude/rules/design-system.md that names the design system sources for UI changes and point to it from the root CLAUDE.md
- Add design.kkhys.me to the satellite site list so it appears on /about and in llms.txt

https://claude.ai/code/session_015Q4o4zjzb8qEhv6iNAhNkk