### PR TITLE
[main] fix: restore memo styles lost when adopting the shared ui

### DIFF
--- a/apps/memo/src/__tests__/components/memo-images.test.ts
+++ b/apps/memo/src/__tests__/components/memo-images.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// memo-images.astro sizes the gallery through :global() selectors that reach
+// into BlurImage's markup. Those rules die silently when the package renames a
+// class (it once shipped .blur-load-wrapper), so pin every reached class to
+// one BlurImage actually emits.
+const memoImages = readFileSync(
+  path.resolve(__dirname, "../../components/memo-images.astro"),
+  "utf8",
+);
+const blurImage = readFileSync(
+  path.resolve(__dirname, "../../../node_modules/@kkhys/ui/src/blur-image.astro"),
+  "utf8",
+);
+
+const globalClasses = [...memoImages.matchAll(/:global\(\.([\w-]+)/gu)].map((m) => m[1]);
+const emittedClasses = new Set(
+  [...blurImage.matchAll(/class(?::list)?=(?:"([^"]*)"|\{\[\s*"([^"]*)")/gu)].flatMap((m) =>
+    (m[1] ?? m[2] ?? "").split(/\s+/u).filter(Boolean),
+  ),
+);
+
+describe("memo-images gallery selectors", () => {
+  it("reaches into BlurImage", () => {
+    expect(globalClasses.length).toBeGreaterThan(0);
+  });
+
+  it.each([...new Set(globalClasses)])("targets a class BlurImage emits: .%s", (className) => {
+    expect(emittedClasses).toContain(className);
+  });
+});

--- a/apps/memo/src/components/memo-images.astro
+++ b/apps/memo/src/components/memo-images.astro
@@ -37,7 +37,7 @@ const { images, alts } = Astro.props;
         display: grid;
     }
 
-    .memo-images:has(> :only-child) :global(.blur-load-wrapper) {
+    .memo-images:has(> :only-child) :global(.blur-image) {
         max-height: 430px;
     }
 
@@ -52,7 +52,7 @@ const { images, alts } = Astro.props;
         padding-bottom: var(--space-2);
     }
 
-    .memo-images:not(:has(> :only-child)) :global(.blur-load-wrapper) {
+    .memo-images:not(:has(> :only-child)) :global(.blur-image) {
         flex: 0 0 auto;
         height: min(260px, 50vw);
         aspect-ratio: unset !important;

--- a/packages/ui/src/link-card.astro
+++ b/packages/ui/src/link-card.astro
@@ -141,10 +141,13 @@ if (imageSrc) {
     padding: var(--space-2) var(--space-4);
   }
 
+  /* Explicit so the card renders the same in every host: me's .prose is
+     already --fs-sm, but memo mounts it under the 1rem body. */
   .link-card-title {
     display: block;
     max-height: 3rem;
     overflow-wrap: break-word;
+    font-size: var(--fs-sm);
     font-weight: var(--fw-medium);
     line-height: 1.625;
   }


### PR DESCRIPTION
- Pin the link card title to --fs-sm so memo renders it at the same size as me instead of inheriting its 1rem body
- Retarget memo-images gallery rules from the old .blur-load-wrapper to @kkhys/ui BlurImage's .blur-image wrapper
- Add a memo-images test that asserts every class the gallery styles reach for is one BlurImage actually emits