### PR TITLE
[main] feat: rework the trends digest page for readability

### DIFF
--- a/apps/trends/CLAUDE.md
+++ b/apps/trends/CLAUDE.md
@@ -15,23 +15,26 @@ src/
   pages/api/favicon/          # Dev-only favicon endpoints via @kkhys/og (omitted from prod builds)
   layouts/base-layout.astro   # HTML shell wired to the @kkhys/seo primitives
   components/
-    site-header.astro         # Static header (brand → /, Archive / About links)
-    digest-view.astro         # One day's body: DateNav + hero + markets + generated-at footer
-    digest-hero.astro         # headline / lead / numbered highlights
-    market-section.astro      # グローバル / 日本 section (global first via sortMarketsGlobalFirst in digest-view; the run JSON stores japan first)
-    service-card.astro        # Per-service section (brand-color dot, total + fresh counts, error note, 該当なし / すべて既出 states)
-    source-toc.astro          # Always-visible source TOC (markets → services), ≥1280px only
-    item-row.astro            # rank → title → summary → meta row (score, stars, chip, host, engagement)
+    site-header.astro         # Header (brand → /, Archive / About links with aria-current)
+    digest-view.astro         # One day's body: DateNav + main(hero + toolbar + markets) + bottom DateNav + generated-at footer
+    digest-hero.astro         # headline / lead / numbered highlights; service chips jump to the item row
+    digest-toolbar.astro      # Sticky bar: date permalink, item count (total / fresh), SeenFilter
+    market-section.astro      # グローバル / 日本 group label (global first via sortMarketsGlobalFirst in digest-view; the run JSON stores japan first)
+    service-card.astro        # Per-service section (sticky header with brand-color dot, total + fresh counts, error note, 該当なし / すべて既出 states)
+    source-toc.astro          # Always-visible source TOC (markets → services, per-service counts), ≥1280px only
+    item-row.astro            # rank → title → summary → fold → meta row (facts left: chips / host / engagement / comments link; signal right: score bar + stars)
     seen-filter.astro         # すべて / 既出を除く toggle; flips html[data-seen-filter], persisted in localStorage
-    date-nav.astro            # ← 前日 / current date (plain text) / 翌日 →
+    date-nav.astro            # ← 前日 / current date (permalink) / 翌日 →, rendered at top and bottom
   utils/runs.ts               # sortRunsByDateDesc, adjacentRuns, date formatters (pure, unit-tested)
   utils/host.ts               # formatHost — hostname without www. for the meta row
   utils/markets.ts            # sortMarketsGlobalFirst — display order of the markets (pure, unit-tested)
   utils/paragraphs.ts         # splitParagraphs — blank-line split for the summary folds (pure, unit-tested)
   utils/score.ts              # scoreLevel: 80+/60+ thresholds → hi/mid/lo score emphasis
   utils/seen.ts               # countSeen — 既出 item count for the seen filter (pure, unit-tested)
+  utils/highlights.ts         # itemAnchorId / highlightAnchors — hero highlight → item row anchors (pure, unit-tested)
+  utils/stars.ts              # interestStars — ★ counts; level 1 renders nothing (pure, unit-tested)
   utils/service-colors.ts     # Upstream brand colors, shared by service-card and source-toc
-  styles/global.css           # Imports @kkhys/styles (uchu + tokens + base); app-local --c-star / --c-faint
+  styles/global.css           # Imports @kkhys/styles (uchu + tokens + base); app-local --c-faint and the sticky chrome heights
   __tests__/                  # Vitest unit tests
 public/                       # robots.txt, manifest, static favicons (generated from dev routes)
 ```
@@ -67,7 +70,9 @@ Consumed as source (no build step).
 - The 既出 filter is CSS-driven: rows carry an `is-seen` class, per-service counts are prerendered for both modes (`service-card.astro` renders the total and the fresh count and swaps them with CSS), and `html[data-seen-filter="hide"]` switches everything. JS only flips that attribute and persists the choice (`trends:seen-filter`); without JS the toggle stays hidden and the site behaves as before.
 - `service-card.astro` has two empty states: 該当なし when a service returned no items with `status: "ok"`, and すべて既出 (shown only in hide mode) when every item is 既出, so a fully-filtered service keeps more than a bare header.
 - The source TOC descends from apps/me's `toc.astro` but stays visible instead of expanding on hover; the observer keeps one entry highlighted while scrolling. Anchor ids are `{market.id}` on h2 and `{market.id}-{service.id}` on h3.
-- `about.astro` is the visitor-facing spec of the score (engagement percentile 75% + freshness decay 25%, hi/mid/lo at 80 / 60), the ★1-3 interest stars, and the 既出 / summary fold terms. Keep it in step with the skill's scoring when that changes.
+- `about.astro` is the visitor-facing spec of the score (engagement percentile 75% + freshness decay 25%, hi/mid/lo at 80 / 60 shown as the fill of a small bar), the interest stars (★★★ / ★★☆; level 1 renders no stars), and the 既出 / summary fold terms. Keep it in step with the skill's scoring when that changes.
+- Sticky chrome: `digest-toolbar` sticks at the top of `main`, each `service-card` header sticks below it, and every anchor target (h2 / h3 / item row) offsets its `scroll-margin-top` by `--toolbar-height` / `--service-header-height` from `global.css`. The toolbar's hairline appears only while stuck, via a `scroll-state()` container query.
+- Hero highlights link to their own row: `highlightAnchors` (`utils/highlights.ts`) resolves each highlight URL to an item anchor (`{market}-{service}-{rank}`), matching the service label first because the same URL can appear in several services; the matched rows show a ハイライト chip.
 - Service dot colors are upstream brand colors, intentionally not mapped to the uchu palette.
 - `runs/**` JSON is excluded from oxlint/oxfmt via root `ignorePatterns` — data, not code.
 

--- a/apps/trends/src/__tests__/utils/highlights.test.ts
+++ b/apps/trends/src/__tests__/utils/highlights.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { highlightAnchors, itemAnchorId } from "#/utils/highlights";
+
+const markets = [
+  {
+    id: "global",
+    services: [
+      {
+        id: "hackernews",
+        label: "Hacker News",
+        items: [{ url: "https://a" }, { url: "https://b" }],
+      },
+      { id: "lobsters", label: "Lobsters", items: [{ url: "https://a" }] },
+    ],
+  },
+  {
+    id: "japan",
+    services: [{ id: "zenn", label: "Zenn", items: [{ url: "https://c" }] }],
+  },
+];
+
+describe("itemAnchorId", () => {
+  it("joins market, service and rank", () => {
+    expect(itemAnchorId("global", "hackernews", 3)).toBe("global-hackernews-3");
+  });
+});
+
+describe("highlightAnchors", () => {
+  it("resolves to the row in the highlight's own service", () => {
+    const anchors = highlightAnchors(markets, [{ url: "https://a", service_label: "Lobsters" }]);
+
+    expect(anchors.get("https://a")).toBe("global-lobsters-1");
+  });
+
+  it("falls back to the first row with the same URL when the label does not match", () => {
+    const anchors = highlightAnchors(markets, [{ url: "https://a", service_label: "Techmeme" }]);
+
+    expect(anchors.get("https://a")).toBe("global-hackernews-1");
+  });
+
+  it("uses 1-based ranks", () => {
+    const anchors = highlightAnchors(markets, [{ url: "https://b", service_label: "Hacker News" }]);
+
+    expect(anchors.get("https://b")).toBe("global-hackernews-2");
+  });
+
+  it("skips highlights that have no row", () => {
+    const anchors = highlightAnchors(markets, [{ url: "https://x", service_label: "Zenn" }]);
+
+    expect(anchors.size).toBe(0);
+  });
+});

--- a/apps/trends/src/__tests__/utils/stars.test.ts
+++ b/apps/trends/src/__tests__/utils/stars.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { interestStars } from "#/utils/stars";
+
+describe("interestStars", () => {
+  it("fills all three at level 3", () => {
+    expect(interestStars(3)).toEqual({ filled: 3, empty: 0 });
+  });
+
+  it("leaves one empty at level 2", () => {
+    expect(interestStars(2)).toEqual({ filled: 2, empty: 1 });
+  });
+
+  it("renders nothing at level 1", () => {
+    expect(interestStars(1)).toBeUndefined();
+  });
+});

--- a/apps/trends/src/components/date-nav.astro
+++ b/apps/trends/src/components/date-nav.astro
@@ -5,14 +5,20 @@ interface Props {
   current: string;
   prev: string | undefined;
   next: string | undefined;
+  /* "bottom" repeats the nav after the last section so a reader who has
+     scrolled the whole day can move on without going back up. */
+  position?: "top" | "bottom" | undefined;
 }
 
-const { current, prev, next } = Astro.props;
+const { current, prev, next, position = "top" } = Astro.props;
+const label = position === "top" ? "日付ナビゲーション" : "日付ナビゲーション（末尾）";
 ---
 
-<nav class="date-nav" aria-label="日付ナビゲーション">
+<nav class:list={["date-nav", position]} aria-label={label}>
   <span class="slot">{prev && <a href={`/${prev}`}>← 前日</a>}</span>
-  <span class="current">{formatRunDate(current)}</span>
+  <a class="current" href={`/${current}`} title="この日の固定 URL">
+    <time datetime={current}>{formatRunDate(current)}</time>
+  </a>
   <span class="slot end">{next && <a href={`/${next}`}>翌日 →</a>}</span>
 </nav>
 
@@ -25,6 +31,10 @@ const { current, prev, next } = Astro.props;
     margin-top: var(--space-6);
     font-size: var(--fs-xs);
     color: var(--c-sub);
+  }
+
+  .date-nav.bottom {
+    margin-top: var(--space-8);
   }
 
   a {

--- a/apps/trends/src/components/digest-hero.astro
+++ b/apps/trends/src/components/digest-hero.astro
@@ -5,9 +5,11 @@ import Budoux from "@kkhys/ui/budoux.astro";
 
 interface Props {
   digest: CollectionEntry<"runs">["data"]["digest"];
+  /* Highlight URL → anchor of its row in the list below (see highlightAnchors). */
+  anchors: ReadonlyMap<string, string>;
 }
 
-const { digest } = Astro.props;
+const { digest, anchors } = Astro.props;
 ---
 
 <section class="hero">
@@ -19,25 +21,36 @@ const { digest } = Astro.props;
   </Budoux>
   <ol class="highlights">
     {
-      digest.highlights.map((highlight, i) => (
-        <li>
-          <span class="hl-rank">{i + 1}</span>
-          <div class="hl-body">
-            <Budoux>
-              <span class="hl-title palt">
-                <a href={highlight.url} target="_blank" rel="noreferrer">
-                  {highlight.title_ja || highlight.title}
-                </a>
-                <span class="hl-service">{highlight.service_label}</span>
-              </span>
-            </Budoux>
-            {highlight.title_ja && <span class="hl-original">{highlight.title}</span>}
-            <Budoux>
-              <span class="hl-reason">{highlight.reason}</span>
-            </Budoux>
-          </div>
-        </li>
-      ))
+      digest.highlights.map((highlight, i) => {
+        const anchor = anchors.get(highlight.url);
+
+        return (
+          <li>
+            <span class="hl-rank">{i + 1}</span>
+            <div class="hl-body">
+              <Budoux>
+                <span class="hl-title palt">
+                  <a href={highlight.url} target="_blank" rel="noreferrer">
+                    {highlight.title_ja || highlight.title}
+                    <span class="sr-only">(新しいタブで開く)</span>
+                  </a>
+                  {anchor ? (
+                    <a class="hl-service is-link" href={`#${anchor}`} title="一覧の該当記事へ移動">
+                      {highlight.service_label}
+                    </a>
+                  ) : (
+                    <span class="hl-service">{highlight.service_label}</span>
+                  )}
+                </span>
+              </Budoux>
+              {highlight.title_ja && <span class="hl-original">{highlight.title}</span>}
+              <Budoux>
+                <span class="hl-reason">{highlight.reason}</span>
+              </Budoux>
+            </div>
+          </li>
+        );
+      })
     }
   </ol>
 </section>
@@ -106,6 +119,15 @@ const { digest } = Astro.props;
     line-height: 1.6;
   }
 
+  .hl-original {
+    display: block;
+    margin-top: 0.15rem;
+    color: var(--c-sub);
+    font-size: var(--fs-xs);
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+  }
+
   .hl-service {
     font-size: var(--fs-2xs);
     font-weight: var(--fw-normal);
@@ -117,13 +139,14 @@ const { digest } = Astro.props;
     white-space: nowrap;
   }
 
-  .hl-original {
-    display: block;
-    margin-top: 0.15rem;
-    color: var(--c-faint);
-    font-size: var(--fs-xs);
-    line-height: 1.5;
-    overflow-wrap: anywhere;
+  .hl-service.is-link::after {
+    content: " ↓";
+  }
+
+  .hl-service.is-link:hover {
+    color: var(--c-text);
+    text-decoration: none;
+    border-color: var(--c-sub);
   }
 
   .hl-reason {

--- a/apps/trends/src/components/digest-toolbar.astro
+++ b/apps/trends/src/components/digest-toolbar.astro
@@ -1,0 +1,79 @@
+---
+/**
+ * Sticky context bar above the sections: the day, how many items it holds,
+ * and the 既出 filter. Stays in reach through the whole scroll, where the
+ * top-of-page nav and the filter would otherwise be gone after one screen.
+ */
+import SeenFilter from "#/components/seen-filter.astro";
+import { formatRunDate } from "#/utils/runs";
+
+interface Props {
+  date: string;
+  total: number;
+  seen: number;
+}
+
+const { date, total, seen } = Astro.props;
+---
+
+<div class:list={["toolbar", { "has-seen": seen > 0 }]}>
+  <a class="date" href={`/${date}`} title="この日の固定 URL">
+    <time datetime={date}>{formatRunDate(date)}</time>
+  </a>
+  <span class="count total">{total}件</span>
+  {seen > 0 && <span class="count fresh">{total - seen}件</span>}
+  {seen > 0 && <SeenFilter />}
+</div>
+
+<style>
+  .toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    min-height: var(--toolbar-height);
+    margin-top: var(--space-8);
+    background: var(--c-bg);
+    color: var(--c-sub);
+    font-size: var(--fs-xs);
+    font-variant-numeric: tabular-nums;
+    container-type: scroll-state;
+  }
+
+  /* Hairline only while stuck; at rest the bar sits in the flow with the
+     hero above and needs no separator. Browsers without scroll-state
+     queries simply never draw it. */
+  .toolbar::after {
+    content: "";
+    position: absolute;
+    inset: auto 0 0;
+    height: 1px;
+    background: transparent;
+  }
+
+  @container scroll-state(stuck: top) {
+    .toolbar::after {
+      background: var(--c-border);
+    }
+  }
+
+  .date {
+    color: var(--c-text);
+    font-weight: var(--fw-medium);
+  }
+
+  /* Both counts are prerendered; the 既出 filter swaps them with CSS only. */
+  .count.fresh {
+    display: none;
+  }
+
+  :global(html[data-seen-filter="hide"]) .toolbar.has-seen .count.total {
+    display: none;
+  }
+
+  :global(html[data-seen-filter="hide"]) .toolbar.has-seen .count.fresh {
+    display: inline;
+  }
+</style>

--- a/apps/trends/src/components/digest-view.astro
+++ b/apps/trends/src/components/digest-view.astro
@@ -3,9 +3,10 @@ import type { CollectionEntry } from "astro:content";
 
 import DateNav from "#/components/date-nav.astro";
 import DigestHero from "#/components/digest-hero.astro";
+import DigestToolbar from "#/components/digest-toolbar.astro";
 import MarketSection from "#/components/market-section.astro";
-import SeenFilter from "#/components/seen-filter.astro";
 import SourceToc from "#/components/source-toc.astro";
+import { highlightAnchors } from "#/utils/highlights";
 import { sortMarketsGlobalFirst } from "#/utils/markets";
 import { formatGeneratedAt } from "#/utils/runs";
 import { countSeen } from "#/utils/seen";
@@ -19,10 +20,16 @@ interface Props {
 const { entry, prev, next } = Astro.props;
 const { date, digest, generated_at } = entry.data;
 const markets = sortMarketsGlobalFirst(entry.data.markets);
+const itemTotal = markets.reduce(
+  (total, market) => total + market.services.reduce((n, s) => n + s.items.length, 0),
+  0,
+);
 const seenTotal = markets.reduce(
   (total, market) => total + market.services.reduce((n, s) => n + countSeen(s.items), 0),
   0,
 );
+const anchors = highlightAnchors(markets, digest.highlights);
+const highlightedAnchors = new Set(anchors.values());
 ---
 
 <aside class="sidebar">
@@ -30,11 +37,16 @@ const seenTotal = markets.reduce(
 </aside>
 <div class="wrap">
   <DateNav current={date} prev={prev} next={next} />
-  <DigestHero digest={digest} />
-  {seenTotal > 0 && <SeenFilter />}
   <main id="main">
-    {markets.map((market) => <MarketSection market={market} />)}
+    <DigestHero digest={digest} anchors={anchors} />
+    <DigestToolbar date={date} total={itemTotal} seen={seenTotal} />
+    {
+      markets.map((market) => (
+        <MarketSection market={market} highlightedAnchors={highlightedAnchors} />
+      ))
+    }
   </main>
+  <DateNav current={date} prev={prev} next={next} position="bottom" />
   <footer class="site">生成: {formatGeneratedAt(generated_at)}</footer>
 </div>
 
@@ -65,7 +77,7 @@ const seenTotal = markets.reduce(
   }
 
   footer.site {
-    margin-top: var(--space-12);
+    margin-top: var(--space-6);
     padding-top: 0.875rem;
     border-top: 1px solid var(--c-border);
     color: var(--c-sub);

--- a/apps/trends/src/components/item-row.astro
+++ b/apps/trends/src/components/item-row.astro
@@ -5,6 +5,7 @@ import Budoux from "@kkhys/ui/budoux.astro";
 import { formatHost } from "#/utils/host";
 import { splitParagraphs } from "#/utils/paragraphs";
 import { scoreLevel } from "#/utils/score";
+import { interestStars } from "#/utils/stars";
 
 type Item =
   CollectionEntry<"runs">["data"]["markets"][number]["services"][number]["items"][number];
@@ -12,9 +13,12 @@ type Item =
 interface Props {
   item: Item;
   rank: number;
+  /* Row id; the hero's service chips jump here. */
+  anchorId: string;
+  highlighted: boolean;
 }
 
-const { item, rank } = Astro.props;
+const { item, rank, anchorId, highlighted } = Astro.props;
 
 const host = formatHost(item.url);
 const hasDiscussionLink = item.comments_url !== "" && item.comments_url !== item.url;
@@ -24,9 +28,13 @@ const discussionParagraphs = splitParagraphs(item.discussion_summary);
 const foldParagraphs =
   discussionParagraphs.length > 0 ? discussionParagraphs : splitParagraphs(item.article_summary);
 const foldLabel = discussionParagraphs.length > 0 ? "コメントの要約" : "記事の要約";
+const stars = interestStars(item.interest);
 ---
 
-<article class:list={["item", { "is-seen": item.seen_before }]}>
+<article
+  class:list={["item", { "is-seen": item.seen_before, "is-highlight": highlighted }]}
+  id={anchorId}
+>
   <span class="rank">{rank}</span>
   <div class="body">
     <Budoux>
@@ -48,33 +56,49 @@ const foldLabel = discussionParagraphs.length > 0 ? "コメントの要約" : "�
       foldParagraphs.length > 0 && (
         <details class="discussion">
           <summary>{foldLabel}</summary>
-          <Budoux>
-            {foldParagraphs.map((paragraph) => (
-              <p>{paragraph}</p>
-            ))}
-          </Budoux>
+          <div class="fold-body">
+            <Budoux>
+              {foldParagraphs.map((paragraph) => (
+                <p>{paragraph}</p>
+              ))}
+            </Budoux>
+          </div>
         </details>
       )
     }
     <div class="meta">
-      <span class:list={["score", scoreLevel(item.score)]} title="スコア">
-        <span class="sr-only">スコア </span>{item.score}
+      <span class="facts">
+        {highlighted && <span class="chip highlight">ハイライト</span>}
+        {item.category && <span class="chip">{item.category}</span>}
+        {host && <span>{host}</span>}
+        {item.engagement_label && <span>{item.engagement_label}</span>}
+        {item.seen_before && <span class="seen">既出</span>}
+        {
+          hasDiscussionLink && (
+            <a class="comments" href={item.comments_url} target="_blank" rel="noreferrer">
+              コメントを見る<span class="sr-only">(新しいタブで開く)</span>
+            </a>
+          )
+        }
       </span>
-      <span class="stars" title="興味マッチ度">
-        <span class="sr-only">興味マッチ度 {item.interest}</span>
-        <span aria-hidden="true">{"★".repeat(item.interest)}</span>
+      <span class="signal">
+        <span
+          class:list={["score", scoreLevel(item.score)]}
+          title="スコア: ソース内の相対的な盛り上がり (0-100)"
+        >
+          <span class="sr-only">スコア </span>
+          <span class="score-bar" aria-hidden="true" style={`--score:${item.score}`}></span>
+          {item.score}
+        </span>
+        {
+          stars && (
+            <span class="stars" title="興味マッチ度">
+              <span class="sr-only">興味マッチ度 {item.interest}</span>
+              <span aria-hidden="true">{"★".repeat(stars.filled) + "☆".repeat(stars.empty)}</span>
+            </span>
+          )
+        }
       </span>
-      {item.category && <span class="chip">{item.category}</span>}
-      {host && <span>{host}</span>}
-      {item.engagement_label && <span>{item.engagement_label}</span>}
-      {item.seen_before && <span class="seen">既出</span>}
-      {
-        hasDiscussionLink && (
-          <a class="comments" href={item.comments_url} target="_blank" rel="noreferrer">
-            コメントを見る<span class="sr-only">(新しいタブで開く)</span>
-          </a>
-        )
-      }
     </div>
   </div>
 </article>
@@ -85,6 +109,8 @@ const foldLabel = discussionParagraphs.length > 0 ? "コメントの要約" : "�
     gap: var(--space-3);
     padding: var(--space-4) var(--space-1);
     border-bottom: 1px solid var(--c-border);
+    /* Lands below the two sticky bars when jumped to from the hero. */
+    scroll-margin-top: calc(var(--toolbar-height) + var(--service-header-height) + var(--space-2));
   }
 
   :global(html[data-seen-filter="hide"]) .item.is-seen {
@@ -101,8 +127,20 @@ const foldLabel = discussionParagraphs.length > 0 ? "コメントの要約" : "�
     padding-top: var(--space-1);
   }
 
+  /* Give the gutter back to the text on phones. */
+  @media (width < 640px) {
+    .item {
+      gap: var(--space-2);
+    }
+
+    .rank {
+      width: 1rem;
+    }
+  }
+
   .body {
     min-width: 0;
+    flex: 1;
   }
 
   .title {
@@ -113,7 +151,7 @@ const foldLabel = discussionParagraphs.length > 0 ? "コメントの要約" : "�
 
   .original-title {
     margin: 0.15rem 0 0;
-    color: var(--c-faint);
+    color: var(--c-sub);
     font-size: var(--fs-xs);
     line-height: 1.5;
     overflow-wrap: anywhere;
@@ -133,6 +171,7 @@ const foldLabel = discussionParagraphs.length > 0 ? "コメントの要約" : "�
   }
 
   .discussion summary {
+    position: relative;
     cursor: pointer;
     width: fit-content;
   }
@@ -145,12 +184,27 @@ const foldLabel = discussionParagraphs.length > 0 ? "コメントの要約" : "�
     content: "▾ ";
   }
 
+  /* 12px text is an 18px target; extend it to the 24px minimum without
+     changing the visual. */
+  .discussion summary::after {
+    content: "";
+    position: absolute;
+    inset: -0.25rem 0;
+  }
+
   .discussion summary:hover {
     color: var(--c-text);
   }
 
+  /* A hairline marks where the fold ends and the meta row begins. */
+  .fold-body {
+    margin-top: var(--space-2);
+    padding-left: var(--space-3);
+    border-left: 1px solid var(--c-border);
+  }
+
   .discussion p {
-    margin: 0.3rem 0 0;
+    margin: 0;
     font-size: 0.8125rem;
     line-height: 1.7;
   }
@@ -159,36 +213,71 @@ const foldLabel = discussionParagraphs.length > 0 ? "コメントの要約" : "�
     margin-top: 0.6rem;
   }
 
+  /* Facts about the article on the left, this site's judgement on the right. */
   .meta {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-1) 0.875rem;
     align-items: center;
+    gap: var(--space-1) 0.875rem;
+    margin-top: var(--space-2);
     color: var(--c-sub);
     font-size: var(--fs-xs);
-    margin-top: var(--space-2);
+  }
+
+  /* Facts wrap as individual flex items so the signal can share their last
+     line when there is room, instead of always dropping below them. */
+  .facts {
+    display: contents;
+  }
+
+  .signal {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-left: auto;
   }
 
   .score {
-    font-weight: var(--fw-medium);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
     font-variant-numeric: tabular-nums;
   }
 
+  .score-bar {
+    position: relative;
+    width: 2.5rem;
+    height: 3px;
+    border-radius: var(--radius-full);
+    background: var(--c-border);
+    overflow: hidden;
+  }
+
+  .score-bar::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    width: calc(var(--score) * 1%);
+    border-radius: inherit;
+    background: var(--bar);
+  }
+
   .score.hi {
-    color: var(--c-text);
+    --bar: var(--c-text);
   }
 
   .score.mid {
-    color: var(--c-sub);
+    --bar: var(--c-sub);
   }
 
   .score.lo {
-    color: var(--c-faint);
+    --bar: var(--c-faint);
   }
 
+  /* Filled vs outline glyphs carry the level; lightness alone was under
+     2:1 between the two states. */
   .stars {
-    color: var(--c-star);
-    letter-spacing: 1px;
+    color: var(--c-sub);
   }
 
   .chip {
@@ -197,6 +286,11 @@ const foldLabel = discussionParagraphs.length > 0 ? "コメントの要約" : "�
     padding: 0 var(--space-2);
     font-size: var(--fs-2xs);
     line-height: 1.1rem;
+  }
+
+  .chip.highlight {
+    border-color: var(--c-sub);
+    color: var(--c-text);
   }
 
   .seen {

--- a/apps/trends/src/components/market-section.astro
+++ b/apps/trends/src/components/market-section.astro
@@ -7,14 +7,23 @@ type Market = CollectionEntry<"runs">["data"]["markets"][number];
 
 interface Props {
   market: Market;
+  highlightedAnchors: ReadonlySet<string>;
 }
 
-const { market } = Astro.props;
+const { market, highlightedAnchors } = Astro.props;
 ---
 
 <section class="market">
   <h2 id={market.id}>{market.label}</h2>
-  {market.services.map((service) => <ServiceCard service={service} marketId={market.id} />)}
+  {
+    market.services.map((service) => (
+      <ServiceCard
+        service={service}
+        marketId={market.id}
+        highlightedAnchors={highlightedAnchors}
+      />
+    ))
+  }
 </section>
 
 <style>
@@ -26,7 +35,7 @@ const { market } = Astro.props;
     margin: 0 0 1.25rem;
     font-size: 1rem;
     font-weight: var(--fw-medium);
-    /* Breathing room above anchor-jump targets. */
-    scroll-margin-top: 1.25rem;
+    /* Lands below the sticky toolbar when jumped to. */
+    scroll-margin-top: calc(var(--toolbar-height) + var(--space-4));
   }
 </style>

--- a/apps/trends/src/components/seen-filter.astro
+++ b/apps/trends/src/components/seen-filter.astro
@@ -2,7 +2,8 @@
 /**
  * すべて / 既出を除く toggle. Filtering itself is pure CSS keyed off
  * `html[data-seen-filter="hide"]`; this component only flips that attribute
- * and remembers the choice. Rendered only on days that have 既出 items.
+ * and remembers the choice. Rendered by digest-toolbar only on days that
+ * have 既出 items.
  */
 ---
 
@@ -56,10 +57,9 @@
 <style>
   .seen-filter {
     display: flex;
-    justify-content: flex-end;
     align-items: baseline;
     gap: 0.625rem;
-    margin-top: var(--space-6);
+    margin-left: auto;
     font-size: var(--fs-xs);
     color: var(--c-sub);
   }

--- a/apps/trends/src/components/service-card.astro
+++ b/apps/trends/src/components/service-card.astro
@@ -2,6 +2,7 @@
 import type { CollectionEntry } from "astro:content";
 
 import ItemRow from "#/components/item-row.astro";
+import { itemAnchorId } from "#/utils/highlights";
 import { countSeen } from "#/utils/seen";
 import { SERVICE_COLORS } from "#/utils/service-colors";
 
@@ -10,9 +11,10 @@ type Service = CollectionEntry<"runs">["data"]["markets"][number]["services"][nu
 interface Props {
   service: Service;
   marketId: string;
+  highlightedAnchors: ReadonlySet<string>;
 }
 
-const { service, marketId } = Astro.props;
+const { service, marketId, highlightedAnchors } = Astro.props;
 
 const dotColor = SERVICE_COLORS[service.id] ?? "var(--c-sub)";
 const seenCount = countSeen(service.items);
@@ -27,7 +29,20 @@ const freshCount = service.items.length - seenCount;
     {seenCount > 0 && <span class="count fresh">{freshCount}件</span>}
     {service.note && <span class="note">{service.note}</span>}
   </header>
-  {service.items.map((item, i) => <ItemRow item={item} rank={i + 1} />)}
+  {
+    service.items.map((item, i) => {
+      const anchorId = itemAnchorId(marketId, service.id, i + 1);
+
+      return (
+        <ItemRow
+          item={item}
+          rank={i + 1}
+          anchorId={anchorId}
+          highlighted={highlightedAnchors.has(anchorId)}
+        />
+      );
+    })
+  }
   {service.items.length === 0 && service.status === "ok" && <p class="empty">該当なし</p>}
   {service.items.length > 0 && freshCount === 0 && <p class="empty all-seen">すべて既出</p>}
 </section>
@@ -37,12 +52,20 @@ const freshCount = service.items.length - seenCount;
     margin-bottom: 2.5rem;
   }
 
+  /* Sticks under the toolbar while its own rows scroll, so the source is
+     always named on screen; the next section pushes it away. */
   header {
+    position: sticky;
+    top: var(--toolbar-height);
+    z-index: 1;
     display: flex;
     align-items: baseline;
     gap: var(--space-2);
+    min-height: var(--service-header-height);
+    padding-top: var(--space-3);
     padding-bottom: 0.625rem;
     border-bottom: 1px solid var(--c-border);
+    background: var(--c-bg);
   }
 
   .dot {
@@ -57,8 +80,8 @@ const freshCount = service.items.length - seenCount;
     margin: 0;
     font-size: var(--fs-sm);
     font-weight: var(--fw-medium);
-    /* Breathing room above anchor-jump targets. */
-    scroll-margin-top: 1.25rem;
+    /* Jump targets land exactly where the header sticks. */
+    scroll-margin-top: calc(var(--toolbar-height) + var(--space-3));
   }
 
   .count {

--- a/apps/trends/src/components/site-header.astro
+++ b/apps/trends/src/components/site-header.astro
@@ -1,11 +1,24 @@
+---
+const path = Astro.url.pathname.replace(/\/$/u, "") || "/";
+const links = [
+  { href: "/archive", label: "Archive" },
+  { href: "/about", label: "About" },
+];
+---
+
 <header>
   <div class="site-inner">
     <span class="brand">
       <a href="/">Trend Digest</a>
     </span>
     <nav class="menu" aria-label="サイト内リンク">
-      <a href="/archive">Archive</a>
-      <a href="/about">About</a>
+      {
+        links.map(({ href, label }) => (
+          <a href={href} aria-current={path === href ? "page" : undefined}>
+            {label}
+          </a>
+        ))
+      }
     </nav>
   </div>
 </header>
@@ -42,7 +55,12 @@
     color: var(--c-sub);
   }
 
-  .menu a:hover {
+  .menu a:hover,
+  .menu a[aria-current="page"] {
     color: var(--c-text);
+  }
+
+  .menu a[aria-current="page"] {
+    font-weight: var(--fw-medium);
   }
 </style>

--- a/apps/trends/src/components/source-toc.astro
+++ b/apps/trends/src/components/source-toc.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from "astro:content";
 
+import { countSeen } from "#/utils/seen";
 import { SERVICE_COLORS } from "#/utils/service-colors";
 
 type Market = CollectionEntry<"runs">["data"]["markets"][number];
@@ -16,19 +17,35 @@ interface TocEntry {
   id: string;
   label: string;
   color: string | undefined;
+  /* Item counts, so the reader can size a section before jumping. Both are
+     prerendered and swapped by the 既出 filter; fresh is undefined when the
+     service has nothing to hide. */
+  total: number | undefined;
+  fresh: number | undefined;
 }
 
 const entries: TocEntry[] = [];
 
 for (const market of markets) {
-  entries.push({ depth: 2, id: market.id, label: market.label, color: undefined });
+  entries.push({
+    depth: 2,
+    id: market.id,
+    label: market.label,
+    color: undefined,
+    total: undefined,
+    fresh: undefined,
+  });
 
   for (const service of market.services) {
+    const seen = countSeen(service.items);
+
     entries.push({
       depth: 3,
       id: `${market.id}-${service.id}`,
       label: service.label,
       color: SERVICE_COLORS[service.id] ?? "var(--c-sub)",
+      total: service.items.length,
+      fresh: seen > 0 ? service.items.length - seen : undefined,
     });
   }
 }
@@ -38,10 +55,18 @@ for (const market of markets) {
   <nav class="toc scroller-thin" aria-label="ソース一覧">
     <ul class="toc-list">
       {entries.map((entry) => (
-        <li class:list={["toc-item", `toc-item--depth-${entry.depth}`]}>
+        <li
+          class:list={[
+            "toc-item",
+            `toc-item--depth-${entry.depth}`,
+            { "toc-item--has-seen": entry.fresh !== undefined },
+          ]}
+        >
           <a href={`#${entry.id}`} class="toc-link">
             {entry.color && <span class="toc-dot" style={`background:${entry.color}`} />}
             <span class="toc-link-text palt">{entry.label}</span>
+            {entry.total !== undefined && <span class="toc-count total">{entry.total}</span>}
+            {entry.fresh !== undefined && <span class="toc-count fresh">{entry.fresh}</span>}
           </a>
         </li>
       ))}
@@ -126,6 +151,24 @@ for (const market of markets) {
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 1;
     overflow: hidden;
+  }
+
+  .toc-count {
+    color: var(--c-faint);
+    font-size: var(--fs-2xs);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .toc-count.fresh {
+    display: none;
+  }
+
+  :global(html[data-seen-filter="hide"]) .toc-item--has-seen .toc-count.total {
+    display: none;
+  }
+
+  :global(html[data-seen-filter="hide"]) .toc-item--has-seen .toc-count.fresh {
+    display: inline;
   }
 </style>
 

--- a/apps/trends/src/pages/about.astro
+++ b/apps/trends/src/pages/about.astro
@@ -21,10 +21,10 @@ const scoreItems = [
   },
 ];
 const scoreNote =
-  "単位の違うソースを絶対値で比べず、ソース内の相対評価に正規化しているため、サービス間でスコアを直接比較することはできません。表示の濃淡は 80以上 / 60以上 / それ未満の3段階です。";
+  "単位の違うソースを絶対値で比べず、ソース内の相対評価に正規化しているため、サービス間でスコアを直接比較することはできません。数字の横のバーの濃さは 80以上 / 60以上 / それ未満の3段階です。";
 
 const starsIntro =
-  "タイトルの下に付く星は、運営者の興味プロフィールと記事のテーマがどの程度合っているかを示す注釈です。";
+  "記事の右下に付く星は、運営者の興味プロフィールと記事のテーマがどの程度合っているかを示す注釈です。合致が弱い記事には星を付けていません。";
 const starsNote =
   "星は並び順に影響しません。一覧は世間のトレンドをそのまま映し、個人の興味は星の注釈と冒頭のハイライトの選定にだけ反映されます。なお、除外テーマに該当する記事は掲載されません。";
 
@@ -88,9 +88,9 @@ const glossary = [
       <dl class="legend">
         <dt><span class="stars">★★★</span></dt>
         <dd>関心の高いテーマに合致</dd>
-        <dt><span class="stars">★★</span></dt>
+        <dt><span class="stars">★★☆</span></dt>
         <dd>中程度のテーマに合致</dd>
-        <dt><span class="stars">★</span></dt>
+        <dt><span class="stars">なし</span></dt>
         <dd>合致が弱い、または該当なし</dd>
       </dl>
       <p>{starsNote}</p>
@@ -203,7 +203,6 @@ const glossary = [
   }
 
   .stars {
-    color: var(--c-star);
-    letter-spacing: 1px;
+    color: var(--c-sub);
   }
 </style>

--- a/apps/trends/src/styles/global.css
+++ b/apps/trends/src/styles/global.css
@@ -11,10 +11,14 @@
   :root {
     color-scheme: light dark;
 
-    --c-star: var(--uchu-orange-5);
-    /* Decorative only (rank numbers): 2.7:1 light / 3.7:1 dark. Text that
-       must be read uses --c-sub. */
+    /* Decorative only (rank numbers, empty stars): 2.7:1 light / 3.7:1 dark.
+       Text that must be read uses --c-sub. */
     --c-faint: light-dark(var(--uchu-gray-7), var(--uchu-yin-6));
+
+    /* Sticky chrome heights, shared by the toolbar, the service headers and
+       the scroll-margin of every anchor target beneath them. */
+    --toolbar-height: 2.5rem;
+    --service-header-height: 2.75rem;
   }
 }
 

--- a/apps/trends/src/styles/global.css
+++ b/apps/trends/src/styles/global.css
@@ -12,7 +12,9 @@
     color-scheme: light dark;
 
     --c-star: var(--uchu-orange-5);
-    --c-faint: light-dark(var(--uchu-gray-4), var(--uchu-yin-7));
+    /* Decorative only (rank numbers): 2.7:1 light / 3.7:1 dark. Text that
+       must be read uses --c-sub. */
+    --c-faint: light-dark(var(--uchu-gray-7), var(--uchu-yin-6));
   }
 }
 

--- a/apps/trends/src/utils/highlights.ts
+++ b/apps/trends/src/utils/highlights.ts
@@ -1,0 +1,56 @@
+interface ItemRef {
+  url: string;
+}
+
+interface ServiceRef {
+  id: string;
+  label: string;
+  items: readonly ItemRef[];
+}
+
+interface MarketRef {
+  id: string;
+  services: readonly ServiceRef[];
+}
+
+interface HighlightRef {
+  url: string;
+  service_label: string;
+}
+
+/* Anchor id of one item row: market → service → 1-based rank. */
+export const itemAnchorId = (marketId: string, serviceId: string, rank: number): string =>
+  `${marketId}-${serviceId}-${rank}`;
+
+/* Maps each highlight URL to the anchor of the row it came from. The digest
+   stores only the service label, so the label is matched first; the same
+   story can sit in several services on one day, so a URL-only match is the
+   fallback. Highlights with no matching row are left out. */
+export const highlightAnchors = (
+  markets: readonly MarketRef[],
+  highlights: readonly HighlightRef[],
+): Map<string, string> => {
+  const rows = markets.flatMap((market) =>
+    market.services.flatMap((service) =>
+      service.items.map((item, i) => ({
+        url: item.url,
+        label: service.label,
+        anchor: itemAnchorId(market.id, service.id, i + 1),
+      })),
+    ),
+  );
+
+  const anchors = new Map<string, string>();
+
+  for (const highlight of highlights) {
+    const row =
+      rows.find((r) => r.url === highlight.url && r.label === highlight.service_label) ??
+      rows.find((r) => r.url === highlight.url);
+
+    if (row) {
+      anchors.set(highlight.url, row.anchor);
+    }
+  }
+
+  return anchors;
+};

--- a/apps/trends/src/utils/stars.ts
+++ b/apps/trends/src/utils/stars.ts
@@ -1,0 +1,9 @@
+export interface StarCounts {
+  filled: number;
+  empty: number;
+}
+
+/* ★ counts for the interest level out of 3. Level 1 means "weak or no
+   match", which is no signal to the reader, so it renders nothing. */
+export const interestStars = (interest: number): StarCounts | undefined =>
+  interest >= 2 ? { filled: interest, empty: 3 - interest } : undefined;


### PR DESCRIPTION
- Add a sticky toolbar (date, item count, 既出 filter) and sticky service headers to the digest page, with matching scroll-margin on anchor targets
- Link each hero highlight's service chip to its row in the list and mark that row with a ハイライト chip
- Split the item meta row into article facts and site judgement, rendering the score as a bar fill and interest as ★ stars via new interestStars / highlightAnchors helpers
- Repeat prev / next nav at the bottom, link the date to its permanent URL, and list per-service counts in the TOC
- Mark the current page in the header nav with aria-current and raise --c-faint contrast to the 3:1 floor

https://claude.ai/code/session_01Mx2ovmdiSk3S7iMYWUjaad